### PR TITLE
Add project min. metadata and standard files (#2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,22 @@
 .idea/*
 __pycache__/*
+
+# Distribution/packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# uqtestfuns
+
+A Python3 library of test functions from the uncertainty quantification community with a common interface for benchmarking purpose.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,15 @@
+[metadata]
+name = uqtestfuns
+version = 0.1.0
+url = https://github.com/damar-wicaksono/uqtestfuns
+author = Damar Wicaksono
+author_email = damar.wicaksono@outlook.com
+description = A Python3 library of test functions from the uncertainty quantification community with a common interface for benchmarking purpose.
+long_description = file: README.md
+long_description_content_type = text/markdown
+platform = ANY
+license = MIT
+license_files = LICENSE
+classifiers = 
+   LICENSE :: OSI Approved :: MIT License
+


### PR DESCRIPTION
- 'build'and 'setuptools' are used to build the package.
- `setup.cfg` metadata section has been filled.
- Update .gitignore to exclude build files.