### PR TITLE
fix #12: Remove import statement of non-existent module

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -59,5 +59,7 @@ deps =
    pytest
    pytest-cov
    pytest-randomly
+   numpy>=1.13.3
+   scipy>=1.9.0
 commands = pytest {posargs}
 

--- a/src/uqtestfuns/core/__init__.py
+++ b/src/uqtestfuns/core/__init__.py
@@ -4,8 +4,8 @@ The core subpackage of uqtestfuns.
 
 __all__ = []
 
-from .uqtestfun_abc import UQTestFun
+#from .uqtestfun_abc import UQTestFun
 from .prob_input import UnivariateInput
 
-__all__ += uqtestfun_abc.__all__
+#__all__ += uqtestfun_abc.__all__
 __all__ += prob_input.__all__


### PR DESCRIPTION
- Update the dependency requirements for the tox test environments
  in `setup.cfg`.