### PR TITLE
Feat #14 - Add pretty print of MultivariateInput

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ include_package_data = True
 python_requires = >=3.7
 install_requires =
    numpy>=1.13.3
-   scipy>=1.9.0
+   scipy>=1.7.3
 
 [options.packages.find]
 where = src

--- a/src/uqtestfuns/__init__.py
+++ b/src/uqtestfuns/__init__.py
@@ -3,3 +3,4 @@ This is the package init for uqtestfuns.
 
 """
 from . import core
+from .test_functions import WingWeight

--- a/src/uqtestfuns/core/__init__.py
+++ b/src/uqtestfuns/core/__init__.py
@@ -4,8 +4,8 @@ The core subpackage of uqtestfuns.
 
 __all__ = []
 
-#from .uqtestfun_abc import UQTestFun
-from .prob_input import UnivariateInput
+from .uqtestfun_abc import UQTestFun
+from .prob_input import UnivariateInput, MultivariateInput
 
-#__all__ += uqtestfun_abc.__all__
+__all__ += uqtestfun_abc.__all__
 __all__ += prob_input.__all__

--- a/src/uqtestfuns/core/prob_input/multivariate_input.py
+++ b/src/uqtestfuns/core/prob_input/multivariate_input.py
@@ -73,13 +73,13 @@ class MultivariateInput:
             name="X", distribution="uniform", parameters=[0, 1]
         )
 
-        xx = np.empty((sample_size, self.spatial_dimension))
+        xx = np.random.rand(sample_size, self.spatial_dimension)
         # Transform the sample in [0, 1] to the domain of the distribution
         if self.copulas is None:
             # Independent inputs generate sample marginal by marginal
             for idx_dim, marginal in enumerate(self.marginals):
                 xx[:, idx_dim] = univ_input.transform_sample(
-                    marginal, univ_input.get_sample(sample_size)
+                    marginal, xx[:, idx_dim]
                 )
         else:
             raise ValueError("Copulas are not currently supported!")

--- a/src/uqtestfuns/core/prob_input/multivariate_input.py
+++ b/src/uqtestfuns/core/prob_input/multivariate_input.py
@@ -6,8 +6,9 @@ Each multivariate input has a set of marginals defined by an instance of
 the UnivariateInput class.
 """
 import numpy as np
-from dataclasses import dataclass, InitVar, field
+from tabulate import tabulate
 from typing import List, Dict, Any
+from dataclasses import dataclass, InitVar, field, fields
 
 from .univariate_input import UnivariateInput
 
@@ -109,3 +110,58 @@ class MultivariateInput:
             raise ValueError("Copulas are not currently supported!")
 
         return yy
+
+    def __str__(self):
+
+        # Get the header names
+        header_names = get_repr_names(self.marginals[0])
+        header_names = [name.capitalize() for name in header_names]
+        header_names.insert(0, "No.")
+
+        # Get the values for each field as a list
+        list_values = get_values_as_list(self.marginals)
+
+        return tabulate(
+            list_values,
+            headers=header_names,
+            stralign="center"
+        )
+
+    def _repr_html_(self):
+        # Get the header names
+        header_names = get_repr_names(self.marginals[0])
+        header_names = [name.capitalize() for name in header_names]
+        header_names.insert(0, "No.")
+
+        # Get the values for each field as a list
+        list_values = get_values_as_list(self.marginals)
+
+        return tabulate(
+            list_values,
+            headers=header_names,
+            stralign="center",
+            tablefmt="html"
+        )
+
+
+def get_repr_names(univariate_input: UnivariateInput):
+    """Get the field names of UnivariateInput w/ repr attribute set to True."""
+    repr_names = []
+    for univariate_field in fields(univariate_input):
+        if univariate_field.repr:
+            repr_names.append(univariate_field.name)
+
+    return repr_names
+
+
+def get_values_as_list(univariate_inputs: list):
+    """"""
+    list_values = []
+    for i, marginal in enumerate(univariate_inputs):
+        values = [i+1]
+        for marginal_field in fields(marginal):
+            if marginal_field.repr:
+                values.append(getattr(marginal, marginal_field.name))
+        list_values.append(values)
+
+    return list_values

--- a/src/uqtestfuns/core/prob_input/univariate_input.py
+++ b/src/uqtestfuns/core/prob_input/univariate_input.py
@@ -36,6 +36,7 @@ class UnivariateInput:
     name: str
     distribution: str
     parameters: Union[List, np.ndarray]
+    description: str = None
     lower: float = field(init=False, repr=False)
     upper: float = field(init=False, repr=False)
 

--- a/src/uqtestfuns/core/uqtestfun_abc.py
+++ b/src/uqtestfuns/core/uqtestfun_abc.py
@@ -1,0 +1,88 @@
+"""
+uqtestfun_abc.py
+
+This module contains the abstract base class for the UQ test functions.
+"""
+import abc
+import numpy as np
+
+from .utils import create_canonical_uniform_input
+
+
+__all__ = ["UQTestFun"]
+
+
+class UQTestFun(abc.ABC):
+    """The abstract class for UQ test functions."""
+    _spatial_dimension = None
+    _input = None
+    _parameters = None
+
+    @property
+    def spatial_dimension(self):
+        """The number of input variables (spatial dim.) of the function."""
+        return self._spatial_dimension
+
+    @property
+    def input(self):
+        """The probabilistic input to the test function."""
+        return self._input
+
+    @input.setter
+    def input(self, value):
+        self._input = value
+
+    @property
+    def parameters(self):
+        """The parameters passed to the test function."""
+        self._parameters
+
+    @parameters.setter
+    def parameters(self, value):
+        self._parameters = value
+
+    def transform_inputs(
+            self,
+            xx: np.ndarray,
+            min_value: float = -1.0,
+            max_value: float = 1.0
+    ) -> np.ndarray:
+        """Transform sample values from a uniform domain to the function domain.
+
+        Parameters
+        ----------
+        xx : np.ndarray
+            Sampled input values (realizations) in a uniform domain.
+            By default, the uniform domain is [-1, 1].
+        min_value : float, optional
+            Minimum value of the uniform domain. Default value is -1.0.
+        max_value : float, optional
+            Maximum value of the uniform domain. Default value is 1.0.
+
+        Returns
+        -------
+        np.ndarray
+            Transformed sampled values from the specified uniform domain to
+            the domain of the function as defined the `input` property.
+        """
+        # TODO: Verify input
+
+        # Create an input in the canonical uniform domain
+        canonical_input = create_canonical_uniform_input(
+            self.spatial_dimension, min_value, max_value
+        )
+
+        # Transform the sampled value to the function domain
+        xx_trans = canonical_input.transform_sample(self.input, xx)
+
+        return xx_trans
+
+    @abc.abstractmethod
+    def evaluate(self, xx: np.ndarray, *args, **kwargs):
+        """Abstract method for the test function evaluation."""
+        pass
+
+    def __call__(self, xx: np.ndarray, *args, **kwargs):
+        """Evaluation of the test function by calling the object."""
+
+        return self.evaluate(xx)

--- a/src/uqtestfuns/core/utils.py
+++ b/src/uqtestfuns/core/utils.py
@@ -1,0 +1,21 @@
+"""
+Utility module for all the UQ test functions.
+"""
+from .prob_input import MultivariateInput
+
+
+def create_canonical_uniform_input(
+        spatial_dimension: int, min_value: float, max_value: float
+) -> MultivariateInput:
+    """Create a MultivariateInput in a canonical domain of [-1, 1]"""
+    input_dicts = []
+    for i in range(spatial_dimension):
+        input_dicts.append(
+            {
+                "name": f"X{i+1}",
+                "distribution": "uniform",
+                "parameters": [min_value, max_value]
+            }
+        )
+
+    return MultivariateInput(input_dicts)

--- a/src/uqtestfuns/test_functions/__init__.py
+++ b/src/uqtestfuns/test_functions/__init__.py
@@ -1,0 +1,4 @@
+"""
+
+"""
+from .wing_weight import WingWeight

--- a/src/uqtestfuns/test_functions/utils.py
+++ b/src/uqtestfuns/test_functions/utils.py
@@ -1,0 +1,22 @@
+"""
+Utility module for the test_functions sub-package.
+"""
+import numpy as np
+
+
+def deg2rad(xx: np.ndarray) -> np.ndarray:
+    """Convert angles given in degree to radians.
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        Angles in degree.
+
+    Returns
+    -------
+    np.ndarray
+        Angles in radians.
+    """
+    yy = np.pi / 180.0 * xx
+
+    return yy

--- a/src/uqtestfuns/test_functions/wing_weight.py
+++ b/src/uqtestfuns/test_functions/wing_weight.py
@@ -1,0 +1,104 @@
+"""
+Module with an implementation of Wing Weight test function.
+"""
+import numpy as np
+
+from ..core import UQTestFun
+from ..core import MultivariateInput
+from .utils import deg2rad
+
+
+__all__ = ["WingWeight"]
+
+# Define the default input of the Wing Weight test function
+DEFAULT_INPUT_DICTS = [
+    {
+        "name": "Sw",
+        "distribution": "uniform",
+        "parameters": [150, 200]
+    },
+    {
+        "name": "Wfw",
+        "distribution": "uniform",
+        "parameters": [220, 300]
+    },
+    {
+        "name": "A",
+        "distribution": "uniform",
+        "parameters": [6, 10]
+    },
+    {
+        "name": "Lambda",
+        "distribution": "uniform",
+        "parameters": [-10, 10]
+    },
+    {
+        "name": "q",
+        "distribution": "uniform",
+        "parameters": [16, 45]
+    },
+    {
+        "name": "lambda",
+        "distribution": "uniform",
+        "parameters": [0.5, 1.0]
+    },
+    {
+        "name": "tc",
+        "distribution": "uniform",
+        "parameters": [0.08, 0.18]
+    },
+    {
+        "name": "Nz",
+        "distribution": "uniform",
+        "parameters": [2.5, 6.0]
+    },
+    {
+        "name": "Wdg",
+        "distribution": "uniform",
+        "parameters": [1700, 2500]
+    },
+    {
+        "name": "Wp",
+        "distribution": "uniform",
+        "parameters": [0.025, 0.08]
+    }
+]
+
+DEFAULT_INPUT = MultivariateInput(DEFAULT_INPUT_DICTS)
+DEFAULT_PARAMETERS = None
+
+
+class WingWeight(UQTestFun):
+    """Implementation of the Wing Weight test function."""
+
+    def __init__(self, input: MultivariateInput = DEFAULT_INPUT):
+        if not isinstance(input, MultivariateInput):
+            raise TypeError("Input must be MultivariateInput type!")
+        if input.spatial_dimension != DEFAULT_INPUT.spatial_dimension:
+            raise ValueError("Input dimensionality is inconsistent! "
+                             f"Expected {DEFAULT_INPUT.spatial_dimension}, "
+                             f"but got {input.spatial_dimension}.")
+
+        self._spatial_dimension = DEFAULT_INPUT.spatial_dimension
+        self.input = DEFAULT_INPUT
+        self.parameters = DEFAULT_PARAMETERS
+
+    def evaluate(self, xx: np.ndarray):
+        """Evaluate the Wing Weight function on a set of input values."""
+        if xx.shape[1] != self.spatial_dimension:
+            raise ValueError(
+                f"Wrong dimensionality of the input array!"
+                f"Expected {self.spatial_dimension}, got {xx.shape[1]}."
+            )
+
+        term_1 = 0.036 * xx[:, 0]**0.758 * xx[:, 1]**0.0035
+        term_2 = (xx[:, 2] / np.cos(deg2rad(xx[:, 3]))**2)**0.6
+        term_3 = xx[:, 4]**0.006
+        term_4 = xx[:, 5]**0.04
+        term_5 = (100 * xx[:, 6] / np.cos(np.pi / 180.0 * xx[:, 3]))**(-0.3)
+        term_6 = (xx[:, 7] * xx[:, 8])**0.49
+        term_7 = xx[:, 0] * xx[:, 9]
+
+        yy = term_1 * term_2 * term_3 * term_4 * term_5 * term_6 + term_7
+
+        return yy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,3 +56,15 @@ def create_random_input_dicts(length: int) -> List[Dict]:
         )
 
     return input_dicts
+
+
+def assert_call(fct, *args, **kwargs):
+    """Assert that a call runs as expected."""
+    try:
+        fct(*args, **kwargs)
+    except Exception as e:
+        print(type(e))
+        raise AssertionError(
+            f"The function was not called properly. "
+            f"It raised the exception:\n\n {e.__class__.__name__}: {e}"
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,8 @@ def create_random_input_dicts(length: int) -> List[Dict]:
         input_dicts.append(
             {"name": f"X{i+1}",
              "distribution": random.choice(SUPPORTED_MARGINALS),
-             "parameters": np.sort(np.random.rand(2))
+             "parameters": np.sort(np.random.rand(2)),
+             "description": create_random_alphanumeric(10)
              }
         )
 

--- a/tests/test_multivariate_input.py
+++ b/tests/test_multivariate_input.py
@@ -1,6 +1,6 @@
 import pytest
 import numpy as np
-import random
+from tabulate import tabulate
 
 from uqtestfuns.core.prob_input.multivariate_input import MultivariateInput
 from conftest import create_random_input_dicts
@@ -138,6 +138,55 @@ def test_transform_dependent_sample():
     with pytest.raises(ValueError) as e_info:
         my_multivariate_input_1.copulas = []
         my_multivariate_input_1.transform_sample(my_multivariate_input_2, xx)
+
+
+def test_str():
+    """Test __str__ method of an instance of MultivariateInput."""
+
+    # Create a test instance
+    input_dicts = create_random_input_dicts(2)
+    my_multivariate_input = MultivariateInput(input_dicts)
+
+    # Create the reference string
+    header_names = ["name", "distribution", "parameters", "description"]
+    str_ref = [
+        [i+1] + list(map(input_dict.get, header_names)) for
+        i, input_dict in enumerate(input_dicts)
+    ]
+    header_names.insert(0, "No.")
+    str_ref = tabulate(
+        str_ref,
+        headers=list(map(str.capitalize, header_names)),
+        stralign="center"
+    )
+
+    # Assertion
+    assert my_multivariate_input.__str__() == str_ref
+
+
+def test_repr_html():
+    """Test _repr_html_ method of an instance of MultivariateInput."""
+
+    # Create a test instance
+    input_dicts = create_random_input_dicts(5)
+    my_multivariate_input = MultivariateInput(input_dicts)
+
+    # Create the reference string
+    header_names = ["name", "distribution", "parameters", "description"]
+    str_ref = [
+        [i+1] + list(map(input_dict.get, header_names)) for
+        i, input_dict in enumerate(input_dicts)
+    ]
+    header_names.insert(0, "No.")
+    str_ref = tabulate(
+        str_ref,
+        headers=list(map(str.capitalize, header_names)),
+        stralign="center",
+        tablefmt="html"
+    )
+
+    # Assertion
+    assert my_multivariate_input._repr_html_() == str_ref
 
 #
 # def test_get_cdf_values():

--- a/tests/test_wing_weight.py
+++ b/tests/test_wing_weight.py
@@ -1,0 +1,61 @@
+import numpy as np
+
+from uqtestfuns import WingWeight
+from uqtestfuns.test_functions import wing_weight
+from conftest import assert_call
+
+def test_create_instance():
+    """Test the creation of the default instance of the Wing Weight function."""
+    my_wing_weight = WingWeight()
+
+    # Assertions
+    assert my_wing_weight.spatial_dimension == \
+           wing_weight.DEFAULT_INPUT.spatial_dimension
+    assert my_wing_weight.input == wing_weight.DEFAULT_INPUT
+
+
+def test_call_instance():
+    """Test calling an instance of the test function."""
+    my_wing_weight = WingWeight()
+
+    xx = np.random.rand(10, my_wing_weight.spatial_dimension)
+
+    # Assertions
+    assert_call(my_wing_weight, xx)
+    assert_call(my_wing_weight.evaluate, xx)
+
+
+def test_transform_input():
+    """Test transforming an input."""
+    my_wing_weight = WingWeight()
+
+    # Transformation from the default uniform domain to the input domain.
+    np.random.seed(315)
+    xx_1 = -1 + 2 * np.random.rand(100, my_wing_weight.spatial_dimension)
+    xx_1 = my_wing_weight.transform_inputs(xx_1)
+
+    # Directly sample from the input property.
+    np.random.seed(315)
+    xx_2 = my_wing_weight.input.get_sample(100)
+
+    # Assertion: two sampled values are equal
+    assert np.allclose(xx_1, xx_2)
+
+
+def test_transform_input_non_default():
+    """Test transforming an input from non-default domain."""
+    my_wing_weight = WingWeight()
+
+    # Transformation from non-default uniform domain to the input domain.
+    np.random.seed(315)
+    xx_1 = np.random.rand(100, my_wing_weight.spatial_dimension)
+    xx_1 = my_wing_weight.transform_inputs(xx_1, min_value=0.0, max_value=1.0)
+
+    # Directly sample from the input property.
+    np.random.seed(315)
+    xx_2 = my_wing_weight.input.get_sample(100)
+
+    # Assertion: two sampled values are equal.
+    assert np.allclose(xx_1, xx_2)
+
+# TODO: Test the correctness of results


### PR DESCRIPTION
An instance of `MultivariateInput` can now be pretty printed with the help of the "tabulate" package.
Furthermore, a method `_repr_html_` is added so a HTML version can be rendered in Jupyter notebook.