### PR TITLE
Add the Beta type distribution for Univariate Input

### DIFF
--- a/src/uqtestfuns/core/prob_input/univariate_distributions/beta.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/beta.py
@@ -1,0 +1,239 @@
+"""
+Module with routines involving the Beta probability distribution.
+
+The Beta distribution in UQTestFuns is parameterized by four parameters:
+r, s, a, and b. r and s are the shape parameters, while a and b are the lower
+and upper bounds, respectively.
+
+The underlying implementation is based the implementation from scipy.stats.
+In the SciPy convention, the Beta distribution is parameterized by four
+parameters: a, b, loc, and scale.
+a and b are the shape parameters, while loc and scale are the shifting and
+scaling parameters, respectively.
+
+Below is the translation of the parameterization of the SciPy implementation
+to the parameterization of UQTestFuns:
+
+- a is r
+- b is s
+- loc is a
+- scale is (b-a)
+"""
+import numpy as np
+from scipy.stats import beta
+
+
+DISTRIBUTION_NAME = "beta"
+
+
+def verify_parameters(parameters: np.ndarray):
+    """Verify the parameters of a Beta distribution.
+
+    Parameters
+    ----------
+    parameters : np.ndarray
+        The parameters of a Beta distribution
+        (i.e., the two shape parameters and the lower and upper bounds).
+
+    Returns
+    ------
+    None
+
+    Raises
+    ------
+    ValueError
+        If any of the parameter values are invalid
+        or the shapes are inconsistent.
+    """
+    # Check overall shape
+    if parameters.size != 4:
+        raise ValueError(
+            f"A Beta distribution requires four parameters!"
+            f"Expected 4, got {parameters.size}."
+        )
+
+    # Check validity of values
+    if parameters[0] <= 0.0 or parameters[1] <= 0.0:
+        raise ValueError(
+            f"The shape parameters {parameters[0]} and {parameters[1]}"
+            f"must be larger than 0.0 (positive)!"
+        )
+
+    if parameters[2] >= parameters[3]:
+        raise ValueError(
+            f"The lower bound {parameters[2]} "
+            f"cannot be equal or greater than the upper bound {parameters[3]}!"
+        )
+
+
+def lower(parameters: np.ndarray) -> float:
+    """Get the lower bound of a Beta distribution.
+
+    Parameters
+    ----------
+    parameters : np.ndarray
+        The parameters of a Beta distribution.
+
+    Returns
+    -------
+    float
+        The lower bound of the Beta distribution.
+    """
+    lower_bound = parameters[2]
+
+    return lower_bound
+
+
+def upper(parameters: np.ndarray) -> float:
+    """Get the upper bound of a Beta distribution.
+
+    Parameters
+    ----------
+    parameters : np.ndarray
+        The parameters of a Beta distribution
+
+    Returns
+    -------
+    float
+        The upper bound of the Beta distribution.
+    """
+    upper_bound = parameters[3]
+
+    return upper_bound
+
+
+def pdf(
+        xx: np.ndarray,
+        parameters: np.ndarray,
+        lower_bound: float,
+        upper_bound: float
+) -> np.ndarray:
+    """Get the PDF values of a Beta distribution.
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        Sample values (realizations) of a Beta distribution.
+    parameters : np.ndarray
+        Parameters of the Beta distribution.
+    lower_bound : np.ndarray
+        Lower bound of the Beta distribution.
+    upper_bound : np.ndarray
+        Upper bound of the Beta distribution.
+
+    Returns
+    -------
+    np.ndarray
+        PDF values of the Beta distribution on the sample values.
+
+    Notes
+    -----
+    - The values outside the bounds are set to 0.0.
+    """
+    yy = np.zeros(xx.shape)
+    idx = np.logical_and(xx >= lower_bound, xx <= upper_bound)
+    yy[idx] = beta.pdf(
+        xx[idx],
+        a=parameters[0],
+        b=parameters[1],
+        loc=parameters[2],
+        scale=parameters[3]-parameters[2]
+    )
+
+    return yy
+
+
+def cdf(
+        xx: np.ndarray,
+        parameters: np.ndarray,
+        lower_bound: float,
+        upper_bound: float
+) -> np.ndarray:
+    """Get the CDF values of the Beta distribution.
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        Sample values (realizations) of a Beta distribution.
+    parameters : np.ndarray
+        Parameters of the Beta distribution.
+    lower_bound : np.ndarray
+        Lower bound of the Beta distribution.
+    upper_bound : np.ndarray
+        Upper bound of the Beta distribution.
+
+    Returns
+    -------
+    np.ndarray
+        CDF values of the Beta distribution on the sample values.
+
+    Notes
+    -----
+    - CDF for sample with values smaller (resp. larger) than the lower bound
+      (resp. upper bound) are set to 0.0 (resp. 1.0).
+    """
+    yy = np.empty(xx.shape)
+    idx_lower = xx < lower_bound
+    idx_upper = xx > upper_bound
+    idx_rest = np.logical_and(
+        np.logical_not(idx_lower), np.logical_not(idx_upper)
+    )
+
+    yy[idx_lower] = 0.0
+    yy[idx_upper] = 1.0
+    yy[idx_rest] = beta.cdf(
+        xx[idx_rest],
+        a=parameters[0],
+        b=parameters[1],
+        loc=parameters[2],
+        scale=parameters[3]-parameters[2]
+    )
+
+    return yy
+
+
+def icdf(
+        xx: np.ndarray,
+        parameters: np.ndarray,
+        lower_bound: float,
+        upper_bound: float
+) -> np.ndarray:
+    """Get the inverse CDF values of a Beta distribution.
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        Sample values (realizations) in the [0, 1] domain.
+    parameters : np.ndarray
+        Parameters of a Beta distribution.
+    lower_bound : np.ndarray
+        Lower bound of the Beta distribution.
+    upper_bound : np.ndarray
+        Upper bound of the Beta distribution.
+
+    Returns
+    -------
+    np.ndarray
+        Transformed values in the domain of the Beta distribution.
+
+    Notes
+    -----
+    - ICDF for sample with values of 0.0 and 1.0 are automatically set to the
+      lower bound and upper bound, respectively.
+    """
+    yy = np.zeros(xx.shape)
+    idx_lower = xx == 0.0
+    idx_upper = xx == 1.0
+    idx_rest = np.logical_not(idx_upper)
+
+    yy[idx_lower] = lower_bound
+    yy[idx_upper] = upper_bound
+    yy[idx_rest] = beta.ppf(
+        xx[idx_rest],
+        a=parameters[0],
+        b=parameters[1],
+        loc=parameters[2],
+        scale=parameters[3]-parameters[2]
+    )
+
+    return yy

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/lognormal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/lognormal.py
@@ -1,14 +1,15 @@
 """
-Module with routines involving lognormal density functions.
+Module with routines involving the lognormal probability distribution.
 
-The lognormal distribution in UQTestFuns is parametrized by the parameters
+The lognormal distribution in UQTestFuns is parametrized by two parameters:
 lambda and xi, the mean and standard deviation of the corresponding normal
 distribution, respectively.
 
-The underlying implementation used the implementation from scipy.stats.
-In scipy convention, the shape distribution ``s`` corresponds to the normal
-distribution standard deviation, while the scale parameters corresponds to
-the exponent of the normal distribution mean.
+The underlying implementation is based on the implementation from scipy.stats.
+In the SciPy convention, the shape distribution ``s`` corresponds to standard
+deviation of the corresponding normal distribution, while the scale parameter
+corresponds to the exponent of the mean of the corresponding normal
+distribution.
 """
 import numpy as np
 from scipy.stats import lognorm
@@ -51,23 +52,23 @@ def verify_parameters(parameters: np.ndarray):
 
 
 def lower(parameters: np.ndarray) -> float:
-    """Get the lower bound of the uniform distribution.
+    """Get the lower bound of a lognormal distribution.
 
     Parameters
     ----------
     parameters : np.ndarray
-        The parameters of the lognormal distribution.
+        The parameters of a lognormal distribution.
 
     Returns
     -------
     float
-        The lower bound of the uniform distribution.
+        The lower bound of the lognormal distribution.
 
     Notes
     -----
     - The parameters are not used in determining the lower bound of
       the distribution; it must, however, appear for interface consistency.
-      The lower bound of a lognormal distribution is 0.0 and it is finite.
+      The lower bound of a lognormal distribution is finite and it is 0.0.
     """
     lower_bound = 0.0
 
@@ -75,17 +76,17 @@ def lower(parameters: np.ndarray) -> float:
 
 
 def upper(parameters: np.ndarray) -> float:
-    """Get the upper bound of the lognormal distribution.
+    """Get the upper bound of a lognormal distribution.
 
     Parameters
     ----------
     parameters : np.ndarray
-        The parameters of the uniform distribution
+        The parameters of a lognormal distribution.
 
     Returns
     -------
     float
-        The upper bound of the uniform distribution.
+        The upper bound of the lognormal distribution.
 
     Notes
     -----
@@ -106,7 +107,7 @@ def pdf(
         lower_bound: float,
         upper_bound: float
 ) -> np.ndarray:
-    """Get the PDF values of the lognormal distribution.
+    """Get the PDF values of a lognormal distribution.
 
     Parameters
     ----------
@@ -143,7 +144,7 @@ def cdf(
         lower_bound: float,
         upper_bound: float
 ) -> np.ndarray:
-    """Get the CDF values of the lognormal distribution.
+    """Get the CDF values of a lognormal distribution.
 
     Parameters
     ----------
@@ -195,7 +196,7 @@ def icdf(
     xx : np.ndarray
         Sample values (realizations) in the [0, 1] domain.
     parameters : np.ndarray
-        Parameters of the lognormal distribution.
+        Parameters of a lognormal distribution.
     lower_bound : np.ndarray
         Lower bound of the lognormal distribution.
     upper_bound : np.ndarray

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/normal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/normal.py
@@ -1,10 +1,12 @@
 """
 Module with routines involving normal density functions.
 
-The normal distribution in UQTestFuns is parametrized by the parameters
+The normal distribution in UQTestFuns is parametrized by two parameters:
 mu and sigma, the mean and standard deviation, respectively.
 
-The underlying implementation is based on the implementation from scicpy.stats.
+The underlying implementation is based on the implementation from scipy.stats.
+In the SciPy convention, the mean (mu) corresponds to the ``loc`` parameter,
+while the standard deviation (sigma) corresponds to the ``scale`` parameter.
 """
 import numpy as np
 from scipy.stats import norm
@@ -19,7 +21,7 @@ def verify_parameters(parameters: np.ndarray):
     Parameters
     ----------
     parameters : np.ndarray
-        The parameters of the normal distribution
+        The parameters of a normal distribution
         (i.e., the mean and standard deviation).
 
     Returns
@@ -60,8 +62,8 @@ def lower(parameters: np.ndarray) -> float:
 
     Notes
     -----
-    - Strictly speaking, a normal distribution is unbounded on the left
-      (and right). However, for numerical reason a lower bound is set.
+    - Strictly speaking, a normal distribution is unbounded on the left.
+      However, for numerical reason a lower bound is set.
     - The lower bound of the normal distribution is chosen such that
       the difference between 1.0 and the CDF from the lower bound to the upper
       bound is smaller than 1e-15.
@@ -108,13 +110,13 @@ def pdf(
     Parameters
     ----------
     xx : np.ndarray
-        Sample values (realizations) of a lognormal distribution.
+        Sample values (realizations) of a normal distribution.
     parameters : np.ndarray
-        Parameters of a lognormal distribution.
+        Parameters of the normal distribution.
     lower_bound : np.ndarray
-        Lower bound of a lognormal distribution.
+        Lower bound of the normal distribution.
     upper_bound : np.ndarray
-        Upper bound of a lognormal distribution.
+        Upper bound of the normal distribution.
 
     Returns
     -------
@@ -145,11 +147,11 @@ def cdf(
     xx : np.ndarray
         Sample values (realizations) of a normal distribution.
     parameters : np.ndarray
-        Parameters of a normal distribution.
+        Parameters of the normal distribution.
     lower_bound : np.ndarray
-        Lower bound of a normal distribution.
+        Lower bound of the normal distribution.
     upper_bound : np.ndarray
-        Upper bound of a normal distribution.
+        Upper bound of the normal distribution.
 
     Returns
     -------
@@ -190,7 +192,7 @@ def icdf(
     xx : np.ndarray
         Sample values (realizations) in the [0, 1] domain.
     parameters : np.ndarray
-        Parameters of the normal distribution.
+        Parameters of a normal distribution.
     lower_bound : np.ndarray
         Lower bound of the normal distribution.
     upper_bound : np.ndarray
@@ -199,7 +201,7 @@ def icdf(
     Returns
     -------
     np.ndarray
-        Transformed values in the domain of the lognormal distribution.
+        Transformed values in the domain of the normal distribution.
 
     Notes
     -----

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/uniform.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/uniform.py
@@ -1,8 +1,8 @@
 """
 Module with routines involving uniform density functions.
 
-The uniform distribution in UQTestFuns is parametrized by its lower and upper
-bounds.
+The uniform distribution in UQTestFuns is parametrized by two parameters:
+the lower and upper bounds.
 """
 import numpy as np
 
@@ -43,12 +43,12 @@ def verify_parameters(parameters: np.ndarray):
 
 
 def lower(parameters: np.ndarray) -> float:
-    """Get the lower bound of the uniform distribution.
+    """Get the lower bound of a uniform distribution.
 
     Parameters
     ----------
     parameters : np.ndarray
-        The parameters of the uniform distribution.
+        The parameters of a uniform distribution.
 
     Returns
     -------
@@ -61,12 +61,12 @@ def lower(parameters: np.ndarray) -> float:
 
 
 def upper(parameters: np.ndarray) -> float:
-    """Get the upper bound of the uniform distribution.
+    """Get the upper bound of a uniform distribution.
 
     Parameters
     ----------
     parameters : np.ndarray
-        The parameters of the uniform distribution.
+        The parameters of a uniform distribution.
 
     Returns
     -------
@@ -104,12 +104,12 @@ def pdf(
 
     Notes
     -----
-    - The sample values `xx` themselves are not used in the computation of
-      density value (it is a constant), but required nevertheless as
+    - The sample values ``xx`` themselves are not used in the computation of
+      density value (it is, after all, a constant), but required nevertheless as
       the function is vectorized.
-      Given a vector input it should return the PDF values of the same length
-      as the input. Furthermore, this signature is consistent with
-      the other distributions.
+      Given a vector input, the function should return the PDF values of the
+      same length as the input.
+      Moreover, this signature is consistent with the other distributions.
     - The values outside the bounds are set to 0.0.
     """
     yy = np.zeros(xx.shape)
@@ -176,7 +176,7 @@ def icdf(
     xx : np.ndarray
         Sample values (realizations) in the [0, 1] domain.
     parameters : np.ndarray
-        Parameters of the uniform distribution.
+        Parameters of a uniform distribution.
     lower_bound : float
         Lower bound of the uniform distribution.
         This parameter is not used but must appear for interface consistency.

--- a/src/uqtestfuns/core/prob_input/univariate_input.py
+++ b/src/uqtestfuns/core/prob_input/univariate_input.py
@@ -1,5 +1,5 @@
 """
-Module with an implementation of UnivariateInput class.
+Module with an implementation of the ``UnivariateInput`` class.
 
 The UnivariateInput class represents a univariate probabilistic input.
 Each input has a probability distribution and the associated parameters.

--- a/src/uqtestfuns/core/prob_input/utils.py
+++ b/src/uqtestfuns/core/prob_input/utils.py
@@ -2,12 +2,13 @@
 Utility module for probabilistic input modeling.
 """
 
-from .univariate_distributions import uniform, lognormal, normal
+from .univariate_distributions import uniform, lognormal, normal, beta
 
 SUPPORTED_MARGINALS = {
     uniform.DISTRIBUTION_NAME: uniform,
     lognormal.DISTRIBUTION_NAME: lognormal,
-    normal.DISTRIBUTION_NAME: normal
+    normal.DISTRIBUTION_NAME: normal,
+    beta.DISTRIBUTION_NAME: beta,
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,11 +50,17 @@ def create_random_input_dicts(length: int) -> List[Dict]:
     input_dicts = []
 
     for i in range(length):
+        distribution = random.choice(MARGINALS)
+        if distribution == "beta":
+            parameters = np.sort(1 + 2 * np.random.rand(4))
+        else:
+            parameters = np.sort(1 + 2 * np.random.rand(2))
         input_dicts.append(
-            {"name": f"X{i+1}",
-             "distribution": random.choice(MARGINALS),
-             "parameters": np.sort(1 + 2 * np.random.rand(2)),
-             "description": create_random_alphanumeric(10)
+            {
+                "name": f"X{i+1}",
+                "distribution": distribution,
+                "parameters": parameters,
+                "description": create_random_alphanumeric(10)
              }
         )
 
@@ -71,3 +77,4 @@ def assert_call(fct, *args, **kwargs):
             f"The function was not called properly. "
             f"It raised the exception:\n\n {e.__class__.__name__}: {e}"
         )
+

--- a/tests/test_univariate_beta.py
+++ b/tests/test_univariate_beta.py
@@ -1,0 +1,116 @@
+"""
+Test module for UnivariateInput instances with a Beta distribution.
+"""
+import pytest
+import numpy as np
+
+from uqtestfuns.core.prob_input.univariate_input import UnivariateInput
+from conftest import create_random_alphanumeric
+
+
+def _mean(parameters: np.ndarray) -> float:
+    """Compute the analytical mean of a Beta distribution."""
+    mean = parameters[2] + (parameters[3] - parameters[2]) * \
+           (parameters[0] / (parameters[0] + parameters[1]))
+
+    return mean
+
+
+def _std(parameters: np.ndarray) -> float:
+    """Compute the analytical standard deviation of a Beta distribution."""
+    std = (parameters[3] - parameters[2]) / (parameters[0] + parameters[1]) * \
+           np.sqrt(
+               (parameters[0] * parameters[1]) /
+               (parameters[0] + parameters[1] + 1)
+           )
+
+    return std
+
+
+def test_wrong_number_of_parameters():
+    """Test the failure when specifying invalid number of parameters."""
+    name = create_random_alphanumeric(5)
+    distribution = "beta"
+    # Beta distribution expects 4 parameters not 6!
+    parameters = np.sort(np.random.rand(6))
+
+    with pytest.raises(ValueError):
+        UnivariateInput(
+            name=name, distribution=distribution, parameters=parameters
+        )
+
+
+def test_failed_parameter_verification():
+    """Test the failure when specifying the wrong parameter values"""
+    name = create_random_alphanumeric(10)
+    distribution = "beta"
+
+    # The 1st parameter of the Beta distribution must be strictly positive!
+    parameters = [-7.71, 10, 1, 2]
+
+    with pytest.raises(ValueError):
+        UnivariateInput(
+            name=name, distribution=distribution, parameters=parameters
+        )
+
+    # The 2nd parameter of the Beta distribution must be strictly positive!
+    parameters = [7.71, -10, 1, 2]
+
+    with pytest.raises(ValueError):
+        UnivariateInput(
+            name=name, distribution=distribution, parameters=parameters
+        )
+
+    # The lower bound must be smaller than upper bound!
+    parameters = [1, 2, 4, 3]
+
+    with pytest.raises(ValueError):
+        UnivariateInput(
+            name=name, distribution=distribution, parameters=parameters
+        )
+
+
+def test_estimate_mean():
+    """Test the mean estimation of a Beta distribution."""
+
+    # Create an instance of a Beta UnivariateInput
+    name = create_random_alphanumeric(10)
+    distribution = "beta"
+    parameters = np.sort(2 * np.random.rand(4))
+
+    my_univariate_input = UnivariateInput(name, distribution, parameters)
+
+    sample_size = 10000
+    xx = my_univariate_input.get_sample(sample_size)
+
+    # Estimated result
+    mean = np.mean(xx)
+
+    # Analytical result
+    mean_ref = _mean(parameters)
+    
+    # Assertion
+    np.allclose(mean, mean_ref)
+
+
+def test_estimate_std():
+    """Test the standard deviation estimation of a Beta distribution."""
+
+    # Create an instance of a Beta UnivariateInput
+    name = create_random_alphanumeric(10)
+    distribution = "beta"
+    parameters = np.sort(2 * np.random.rand(4))
+
+    my_univariate_input = UnivariateInput(name, distribution, parameters)
+
+    sample_size = 10000
+    xx = my_univariate_input.get_sample(sample_size)
+
+    # Estimated result
+    std = np.std(xx)
+
+    # Analytical result
+    std_ref = _std(parameters)
+
+    # Assertion
+    np.allclose(std, std_ref)

--- a/tests/test_univariate_input.py
+++ b/tests/test_univariate_input.py
@@ -14,11 +14,13 @@ MARGINALS = list(SUPPORTED_MARGINALS.keys())
 
 @pytest.fixture(params=MARGINALS)
 def univariate_input(request):
-    """Test fixture, an instance of UnivariateInput"""
+    """Test fixture, an instance of UnivariateInput."""
     name = create_random_alphanumeric(8)
     distribution = request.param
     if request.param == "uniform":
         parameters = np.sort(np.random.rand(2))
+    elif request.param == "beta":
+        parameters = np.sort(np.random.rand(4))
     else:
         parameters = 5 * np.random.rand(2)
         parameters[1] += 1.0
@@ -80,16 +82,6 @@ def test_get_pdf_values(univariate_input):
     # Assertions
     assert my_univariate_input.pdf(my_univariate_input.lower-0.1) <= 1e-15
     assert my_univariate_input.pdf(my_univariate_input.upper+0.1) <= 1e-15
-    assert np.all(
-        np.logical_and(
-            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
-                my_univariate_input.lower
-            ),
-            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
-                my_univariate_input.upper
-            )
-        )
-    )
 
 
 def test_get_cdf_values(univariate_input):

--- a/tests/test_univariate_lognormal.py
+++ b/tests/test_univariate_lognormal.py
@@ -31,3 +31,28 @@ def test_failed_parameter_verification():
         UnivariateInput(
             name=name, distribution=distribution, parameters=parameters
         )
+
+
+def test_get_pdf_values():
+    """Test the PDF values from an instance of UnivariateInput."""
+
+    name = create_random_alphanumeric(5)
+    distribution = "lognormal"
+    parameters = np.sort(np.random.rand(2))
+
+    my_univariate_input = UnivariateInput(name, distribution, parameters)
+
+    sample_size = 1000
+    xx = my_univariate_input.get_sample(sample_size)
+
+    # Assertions (PDF values of zero at the boundaries)
+    assert np.all(
+        np.logical_and(
+            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
+                my_univariate_input.lower
+            ),
+            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
+                my_univariate_input.upper
+            )
+        )
+    )

--- a/tests/test_univariate_normal.py
+++ b/tests/test_univariate_normal.py
@@ -32,3 +32,28 @@ def test_failed_parameter_verification():
         UnivariateInput(
             name=name, distribution=distribution, parameters=parameters
         )
+
+
+def test_get_pdf_values():
+    """Test the PDF values from an instance of UnivariateInput."""
+
+    name = create_random_alphanumeric(5)
+    distribution = "normal"
+    parameters = np.sort(np.random.rand(2))
+
+    my_univariate_input = UnivariateInput(name, distribution, parameters)
+
+    sample_size = 1000
+    xx = my_univariate_input.get_sample(sample_size)
+
+    # Assertions (PDF values of zero at the boundaries)
+    assert np.all(
+        np.logical_and(
+            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
+                my_univariate_input.lower
+            ),
+            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
+                my_univariate_input.upper
+            )
+        )
+    )

--- a/tests/test_univariate_uniform.py
+++ b/tests/test_univariate_uniform.py
@@ -32,3 +32,28 @@ def test_failed_parameter_verification():
         UnivariateInput(
             name=name, distribution=distribution, parameters=parameters
         )
+
+
+def test_get_pdf_values():
+    """Test the PDF values from an instance of UnivariateInput."""
+
+    name = create_random_alphanumeric(5)
+    distribution = "uniform"
+    parameters = np.sort(np.random.rand(2))
+
+    my_univariate_input = UnivariateInput(name, distribution, parameters)
+
+    sample_size = 1000
+    xx = my_univariate_input.get_sample(sample_size)
+
+    # Assertions (PDF values of zero at the boundaries)
+    assert np.all(
+        np.logical_and(
+            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
+                my_univariate_input.lower
+            ),
+            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
+                my_univariate_input.upper
+            )
+        )
+    )


### PR DESCRIPTION
The Beta Distribution has been added as a distribution for `UnivariateInput` (Issue #28). The implementation is based on `scipy.stats.beta` with a more intuitive parameterization: instead of shape parameters `a` and `b` and `loc` and `scale`, the Beta distribution is parametrized by `r` and `s` (the shape parameters) and the lower and upper bounds.