### PR TITLE
Add Truncated Normal Distribution Type for Univariate Input

### DIFF
--- a/src/uqtestfuns/core/prob_input/univariate_distributions/beta.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/beta.py
@@ -5,19 +5,19 @@ The Beta distribution in UQTestFuns is parameterized by four parameters:
 r, s, a, and b. r and s are the shape parameters, while a and b are the lower
 and upper bounds, respectively.
 
-The underlying implementation is based the implementation from scipy.stats.
-In the SciPy convention, the Beta distribution is parameterized by four
-parameters: a, b, loc, and scale.
-a and b are the shape parameters, while loc and scale are the shifting and
-scaling parameters, respectively.
+The underlying implementation is based on the implementation of scipy.stats.
+In the SciPy implementation, the Beta distribution is parameterized also
+by four parameters: ``a``, ``b``, ``loc``, and ``scale``.
+``a`` and ``b`` are the shape parameters, while ``loc`` and ``scale`` are
+the shifting and scaling parameters, respectively.
 
-Below is the translation of the parameterization of the SciPy implementation
-to the parameterization of UQTestFuns:
+The translation between parameterization of the distribution in UQTestFuns
+and SciPy is as follows:
 
-- a is r
-- b is s
-- loc is a
-- scale is (b-a)
+- ``a`` = ``r``
+- ``b`` = ``s``
+- ``loc`` = ``a``
+- ``scale`` = ``(b-a)``
 """
 import numpy as np
 from scipy.stats import beta

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/lognormal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/lognormal.py
@@ -1,15 +1,21 @@
 """
 Module with routines involving the lognormal probability distribution.
 
-The lognormal distribution in UQTestFuns is parametrized by two parameters:
-lambda and xi, the mean and standard deviation of the corresponding normal
+The lognormal distribution in UQTestFuns is parameterized by two parameters:
+``lambda`` and ``xi``, the mean and standard deviation of the underlying normal
 distribution, respectively.
 
-The underlying implementation is based on the implementation from scipy.stats.
-In the SciPy convention, the shape distribution ``s`` corresponds to standard
-deviation of the corresponding normal distribution, while the scale parameter
-corresponds to the exponent of the mean of the corresponding normal
-distribution.
+The underlying implementation is based on the implementation of scipy.stats.
+In the SciPy implementation, the lognormal distribution is parameterized by
+two parameters: ``s`` and ``scale``, the shape and scaling parameters,
+respectively. The shape parameter ``s`` corresponds to the standard deviation
+of the underlying normal distribution.
+
+The translation between parameterization of the distribution in UQTestFuns
+and SciPy is as follows:
+
+- ``s`` = ``xi``
+- ``scale`` = ``np.exp(lambda)``
 """
 import numpy as np
 from scipy.stats import lognorm

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/normal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/normal.py
@@ -1,5 +1,5 @@
 """
-Module with routines involving normal density functions.
+Module with routines involving the normal (Gaussian) probability distribution.
 
 The normal distribution in UQTestFuns is parametrized by two parameters:
 mu and sigma, the mean and standard deviation, respectively.

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/truncnormal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/truncnormal.py
@@ -1,0 +1,298 @@
+"""
+Module with routines involving the truncated normal probability distribution.
+
+The truncated normal distribution in UQTestFuns is parameterized by four
+parameters: ``mu``, ``sigma``, ``lb``, and ``ub`` that correspond to
+the mean, the standard deviation, lower bound, and upper bound, respectively.
+
+The underlying implementation is based on the implementation of scipy.stats.
+In the SciPy implementation, the truncated normal is parameterized also by
+four parameters but with different meaning: a, b, loc, and scale. loc and scale
+correspond to the mu and sigma of the underlying normal distribution, while
+a and b correspond to the lower and upper bound, respectively.
+However, the lower and upper bounds correspond to the standard normal
+distribution.
+
+One might think that, for instance, with loc = 0.5 and scale = 0.1,
+and a = 0 and b = 1, the distribution will be centered on 0.5
+and cut at 0 and 1.
+Yet, this is not what the scipy.stats.beta does.
+Instead, it is a truncated standard normal at 0 and 1 then shift to the new
+``loc`` of 0.5; the lower and upper bounds are actually, 0.5 and 1.5,
+respectively.
+
+The translation between parameterization of the distribution in UQTestFuns
+and SciPy is as follows:
+
+- ``a`` = ``(lb - mu) / sigma``
+- ``b`` = ``(ub - mu) / sigma``
+- ``loc`` = ``mu``
+- ``scale`` = ``sigma``
+
+where lb and ub are the desired lower and upper bounds of the truncated
+normal distribution, respectively.
+"""
+import numpy as np
+from scipy.stats import truncnorm
+
+
+DISTRIBUTION_NAME = "truncnormal"
+
+
+def _get_parameters(parameters: np.ndarray) -> tuple:
+    """Get the parameters of a truncated normal dist. w/ intuitive names.
+
+    Parameters
+    ----------
+    parameters : np.ndarray
+        The parameters of a truncated normal distribution.
+
+    Returns
+    -------
+    tuple
+        The mean, standard deviation, lower bound, and upper bound of the
+        truncated normal distribution.
+    """
+    mu = parameters[0]
+    sigma = parameters[1]
+    lb = parameters[2]
+    ub = parameters[3]
+
+    return mu, sigma, lb, ub
+
+
+def verify_parameters(parameters: np.ndarray):
+    """Verify the parameters of a truncated normal distribution.
+
+    Parameters
+    ----------
+    parameters : np.ndarray
+        The parameters of a truncated normal distribution
+        (i.e., the mean, standard deviation, and the lower and upper bounds).
+
+    Returns
+    ------
+    None
+
+    Raises
+    ------
+    ValueError
+        If any of the parameter values are invalid
+        or the shapes are inconsistent.
+    """
+    # Check overall shape
+    if parameters.size != 4:
+        raise ValueError(
+            f"A truncated normal distribution requires four parameters!"
+            f"Expected 4, got {parameters.size}."
+        )
+
+    mu, sigma, lb, ub = _get_parameters(parameters)
+
+    # Check validity of values
+    if sigma <= 0.0:
+        raise ValueError(
+            f"The standard deviation {sigma} "
+            f"must be larger than 0.0 (positive)!"
+        )
+
+    if lb >= ub:
+        raise ValueError(
+            f"The lower bound {lb} "
+            f"cannot be equal or greater than the upper bound {ub}!"
+        )
+
+    if lb >= mu or ub <= mu:
+        raise ValueError(
+            f"The mean {mu} "
+            f"must be between the bounds [{lb}, {ub}]!"
+        )
+
+
+def lower(parameters: np.ndarray) -> float:
+    """Get the lower bound of a truncated normal distribution.
+
+    Parameters
+    ----------
+    parameters : np.ndarray
+        The parameters of a truncated normal distribution.
+
+    Returns
+    -------
+    float
+        The lower bound of the truncated normal distribution.
+    """
+    _, _, lower_bound, _ = _get_parameters(parameters)
+
+    return lower_bound
+
+
+def upper(parameters: np.ndarray) -> float:
+    """Get the upper bound of a truncated normal distribution.
+
+    Parameters
+    ----------
+    parameters : np.ndarray
+        The parameters of a truncated normal distribution
+
+    Returns
+    -------
+    float
+        The upper bound of the truncated normal distribution.
+    """
+    _, _, _, upper_bound = _get_parameters(parameters)
+
+    return upper_bound
+
+
+def pdf(
+        xx: np.ndarray,
+        parameters: np.ndarray,
+        lower_bound: float,
+        upper_bound: float
+) -> np.ndarray:
+    """Get the PDF values of a truncated normal distribution.
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        Sample values (realizations) of a truncated normal distribution.
+    parameters : np.ndarray
+        Parameters of the truncated normal distribution.
+    lower_bound : float
+        Lower bound of the truncated normal distribution.
+    upper_bound : float
+        Upper bound of the truncated normal distribution.
+
+    Returns
+    -------
+    np.ndarray
+        PDF values of the truncated normal distribution on the sample values.
+
+    Notes
+    -----
+    - The values outside the bounds are set to 0.0.
+    - ``lower_bound`` and ``upper_bound`` in the function parameters are the
+      same as the ones in ``parameters``. For a truncated normal distribution,
+      the bounds are part of the parameterization.
+    """
+    yy = np.zeros(xx.shape)
+    idx = np.logical_and(xx >= lower_bound, xx <= upper_bound)
+
+    mu, sigma, lb_param, ub_param = _get_parameters(parameters)
+
+    yy[idx] = truncnorm.pdf(
+        xx[idx],
+        a=(lb_param - mu)/sigma,
+        b=(ub_param - mu)/sigma,
+        loc=mu,
+        scale=sigma
+    )
+
+    return yy
+
+
+def cdf(
+        xx: np.ndarray,
+        parameters: np.ndarray,
+        lower_bound: float,
+        upper_bound: float
+) -> np.ndarray:
+    """Get the CDF values of the truncated normal distribution.
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        Sample values (realizations) of a truncated normal distribution.
+    parameters : np.ndarray
+        Parameters of the truncated normal distribution.
+    lower_bound : np.ndarray
+        Lower bound of the truncated normal distribution.
+    upper_bound : np.ndarray
+        Upper bound of the truncated normal distribution.
+
+    Returns
+    -------
+    np.ndarray
+        CDF values of the truncated normal distribution on the sample values.
+
+    Notes
+    -----
+    - CDF for sample with values smaller (resp. larger) than the lower bound
+      (resp. upper bound) are set to 0.0 (resp. 1.0).
+    - ``lower_bound`` and ``upper_bound`` in the function parameters are the
+      same as the ones in ``parameters``. For a truncated normal distribution,
+      the bounds are part of the parameterization.
+    """
+    yy = np.empty(xx.shape)
+    idx_lower = xx < lower_bound
+    idx_upper = xx > upper_bound
+    idx_rest = np.logical_and(
+        np.logical_not(idx_lower), np.logical_not(idx_upper)
+    )
+
+    mu, sigma, lb_param, ub_param = _get_parameters(parameters)
+
+    yy[idx_lower] = 0.0
+    yy[idx_upper] = 1.0
+    yy[idx_rest] = truncnorm.cdf(
+        xx[idx_rest],
+        a=(lb_param - mu)/sigma,
+        b=(ub_param - mu)/sigma,
+        loc=mu,
+        scale=sigma
+    )
+
+    return yy
+
+
+def icdf(
+        xx: np.ndarray,
+        parameters: np.ndarray,
+        lower_bound: float,
+        upper_bound: float
+) -> np.ndarray:
+    """Get the inverse CDF values of a truncated normal distribution.
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        Sample values (realizations) in the [0, 1] domain.
+    parameters : np.ndarray
+        Parameters of a truncated normal distribution.
+    lower_bound : float
+        Lower bound of the truncated normal distribution.
+    upper_bound : float
+        Upper bound of the truncated normal distribution.
+
+    Returns
+    -------
+    np.ndarray
+        Transformed values in the domain of the truncated normal distribution.
+
+    Notes
+    -----
+    - ICDF for sample with values of 0.0 and 1.0 are automatically set to the
+      lower bound and upper bound, respectively.
+    - ``lower_bound`` and ``upper_bound`` in the function parameters are the
+      same as the ones in ``parameters``. For a truncated normal distribution,
+      the bounds are part of the parameterization.
+    """
+    yy = np.zeros(xx.shape)
+    idx_lower = xx == 0.0
+    idx_upper = xx == 1.0
+    idx_rest = np.logical_not(idx_upper)
+
+    mu, sigma, lb_param, ub_param = _get_parameters(parameters)
+
+    yy[idx_lower] = lower_bound
+    yy[idx_upper] = upper_bound
+    yy[idx_rest] = truncnorm.ppf(
+        xx[idx_rest],
+        a=(lb_param - mu)/sigma,
+        b=(ub_param - mu)/sigma,
+        loc=mu,
+        scale=sigma
+    )
+
+    return yy

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/uniform.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/uniform.py
@@ -1,5 +1,5 @@
 """
-Module with routines involving uniform density functions.
+Module with routines involving the uniform probability distribution.
 
 The uniform distribution in UQTestFuns is parametrized by two parameters:
 the lower and upper bounds.

--- a/src/uqtestfuns/core/prob_input/utils.py
+++ b/src/uqtestfuns/core/prob_input/utils.py
@@ -2,13 +2,16 @@
 Utility module for probabilistic input modeling.
 """
 
-from .univariate_distributions import uniform, lognormal, normal, beta
+from .univariate_distributions import (
+    uniform, lognormal, normal, beta, truncnormal
+)
 
 SUPPORTED_MARGINALS = {
     uniform.DISTRIBUTION_NAME: uniform,
     lognormal.DISTRIBUTION_NAME: lognormal,
     normal.DISTRIBUTION_NAME: normal,
     beta.DISTRIBUTION_NAME: beta,
+    truncnormal.DISTRIBUTION_NAME: truncnormal,
 }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,8 +53,18 @@ def create_random_input_dicts(length: int) -> List[Dict]:
         distribution = random.choice(MARGINALS)
         if distribution == "beta":
             parameters = np.sort(1 + 2 * np.random.rand(4))
+        elif distribution == "truncnormal":
+            # mu must be inside the bounds
+            parameters = np.sort(1 + 2 * np.random.rand(3))
+            parameters[[0, 1]] = parameters[[1, 0]]
+            # Insert sigma as the second parameter
+            parameters = np.insert(parameters, 1, np.random.rand(1))
+        elif distribution == "lognormal":
+            # Limit the size of the parameters
+            parameters = 1 + np.random.rand(2)
         else:
             parameters = np.sort(1 + 2 * np.random.rand(2))
+
         input_dicts.append(
             {
                 "name": f"X{i+1}",

--- a/tests/test_univariate_beta.py
+++ b/tests/test_univariate_beta.py
@@ -80,7 +80,7 @@ def test_estimate_mean():
 
     my_univariate_input = UnivariateInput(name, distribution, parameters)
 
-    sample_size = 10000
+    sample_size = 100000
     xx = my_univariate_input.get_sample(sample_size)
 
     # Estimated result
@@ -90,7 +90,7 @@ def test_estimate_mean():
     mean_ref = _mean(parameters)
     
     # Assertion
-    np.allclose(mean, mean_ref)
+    assert np.isclose(mean, mean_ref, rtol=1e-03, atol=1e-04)
 
 
 def test_estimate_std():
@@ -103,7 +103,7 @@ def test_estimate_std():
 
     my_univariate_input = UnivariateInput(name, distribution, parameters)
 
-    sample_size = 10000
+    sample_size = 100000
     xx = my_univariate_input.get_sample(sample_size)
 
     # Estimated result
@@ -113,4 +113,4 @@ def test_estimate_std():
     std_ref = _std(parameters)
 
     # Assertion
-    np.allclose(std, std_ref)
+    assert np.allclose(std, std_ref, rtol=1e-03, atol=1e-04)

--- a/tests/test_univariate_input.py
+++ b/tests/test_univariate_input.py
@@ -21,6 +21,15 @@ def univariate_input(request):
         parameters = np.sort(np.random.rand(2))
     elif request.param == "beta":
         parameters = np.sort(np.random.rand(4))
+    elif distribution == "truncnormal":
+        # mu must be inside the bounds
+        parameters = np.sort(1 + 2 * np.random.rand(3))
+        parameters[[0, 1]] = parameters[[1, 0]]
+        # Insert sigma as the second parameter
+        parameters = np.insert(parameters, 1, np.random.rand(1))
+    elif distribution == "lognormal":
+        # Limit the size of the parameters
+        parameters = 1 + np.random.rand(2)
     else:
         parameters = 5 * np.random.rand(2)
         parameters[1] += 1.0

--- a/tests/test_univariate_truncnormal.py
+++ b/tests/test_univariate_truncnormal.py
@@ -1,0 +1,151 @@
+"""
+Test module for UnivariateInput instances with a truncated normal distribution.
+"""
+import pytest
+import numpy as np
+
+from scipy.stats import norm
+
+from uqtestfuns.core.prob_input.univariate_input import UnivariateInput
+from conftest import create_random_alphanumeric
+
+
+DISTRIBUTION_NAME = "truncnormal"
+
+
+def _calc_mean(parameters: np.ndarray) -> float:
+    """Compute the analytical mean of a given truncated normal distribution."""
+    mu, sigma, lb, ub = parameters[:]
+
+    alpha = (lb - mu)/sigma
+    beta = (ub - mu)/sigma
+    phi_alpha = norm.pdf(alpha)
+    phi_beta = norm.pdf(beta)
+    z = norm.cdf(beta) - norm.cdf(alpha)
+
+    mean = mu - (phi_beta - phi_alpha) / z * sigma
+
+    return mean
+
+
+def _calc_std(parameters: np.ndarray) -> float:
+    """Compute the analytical standard deviation of a given trunc. normal."""
+    mu, sigma, lb, ub = parameters[:]
+
+    alpha = (lb - mu) / sigma
+    beta = (ub - mu) / sigma
+    phi_alpha = norm.pdf(alpha)
+    phi_beta = norm.pdf(beta)
+    z = norm.cdf(beta) - norm.cdf(alpha)
+
+    term_1 = 1
+    term_2 = (beta * phi_beta - alpha * phi_alpha) / z
+    term_3 = ((phi_beta - phi_alpha) / z) ** 2
+    var = sigma ** 2 * (term_1 - term_2 - term_3)
+
+    return np.sqrt(var)
+
+
+def test_wrong_number_of_parameters():
+    """Test the failure when specifying invalid number of parameters."""
+    name = create_random_alphanumeric(5)
+    distribution = DISTRIBUTION_NAME
+    # A truncated normal distribution expects 4 parameters not 6!
+    parameters = np.sort(np.random.rand(6))
+
+    with pytest.raises(ValueError):
+        UnivariateInput(
+            name=name, distribution=distribution, parameters=parameters
+        )
+
+
+def test_failed_parameter_verification():
+    """Test the failure when specifying the wrong parameter values"""
+    name = create_random_alphanumeric(10)
+    distribution = DISTRIBUTION_NAME
+
+    # The 2nd parameter of the Beta distribution must be strictly positive!
+    parameters = [7.71, -10, 1, 2]
+
+    with pytest.raises(ValueError):
+        UnivariateInput(
+            name=name, distribution=distribution, parameters=parameters
+        )
+
+    # The mean must be inside the bounds!
+    parameters = [5, 2, 1, 3]
+
+    with pytest.raises(ValueError):
+        UnivariateInput(
+            name=name, distribution=distribution, parameters=parameters
+        )
+
+    # The mean must be inside the bounds!
+    parameters = [0, 2, 1, 3]
+
+    with pytest.raises(ValueError):
+        UnivariateInput(
+            name=name, distribution=distribution, parameters=parameters
+        )
+
+    # The lower bound must be smaller than upper bound!
+    parameters = [3.5, 2, 4, 3]
+
+    with pytest.raises(ValueError):
+        UnivariateInput(
+            name=name, distribution=distribution, parameters=parameters
+        )
+
+
+def test_estimate_mean():
+    """Test the mean estimation of a truncated normal distribution."""
+
+    # Create an instance of a truncated normal UnivariateInput
+    name = create_random_alphanumeric(10)
+    distribution = DISTRIBUTION_NAME
+    # mu must be inside the bounds
+    parameters = np.sort(1 + 2 * np.random.rand(3))
+    parameters[[0, 1]] = parameters[[1, 0]]
+    # Insert sigma as the second parameter
+    parameters = np.insert(parameters, 1, np.random.rand(1))
+
+    my_univariate_input = UnivariateInput(name, distribution, parameters)
+
+    sample_size = 100000
+    xx = my_univariate_input.get_sample(sample_size)
+
+    # Estimated result
+    mean = np.mean(xx)
+
+    # Analytical result
+    mean_ref = _calc_mean(parameters)
+
+    # Assertion
+    assert np.isclose(mean, mean_ref, rtol=1e-03, atol=1e-04)
+
+
+def test_estimate_std():
+    """Test the standard deviation estimation of a trunc. normal dist."""
+
+    # Create an instance of a truncated normal UnivariateInput
+    name = create_random_alphanumeric(10)
+    distribution = DISTRIBUTION_NAME
+    # mu must be inside the bounds
+    parameters = np.sort(1 + 2 * np.random.rand(3))
+    parameters[[0, 1]] = parameters[[1, 0]]
+    # Insert sigma as the second parameter
+    parameters = np.insert(parameters, 1, np.random.rand(1))
+
+    my_univariate_input = UnivariateInput(name, distribution, parameters)
+
+    sample_size = 1000000
+    xx = my_univariate_input.get_sample(sample_size)
+
+    # Estimated result
+    std = np.std(xx)
+
+    # Analytical result
+    std_ref = _calc_std(parameters)
+
+    # Assertion
+    assert np.isclose(std, std_ref, rtol=1e-03, atol=1e-04)


### PR DESCRIPTION
An implementation of a truncated normal distribution type has been added (Issue #29). The implementation is based on the implementation of scipy.stats with re-parameterization.