### PR TITLE
Use black as the code formatter (#37)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 # uqtestfuns
 
 A Python3 library of test functions from the uncertainty quantification community with a common interface for benchmarking purpose.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
 [build-system]
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 79
+target-version = ["py37", "py38", "py39", "py310"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,3 +79,10 @@ show_error_context = True
 pretty = True
 namespace_packages = True
 check_untyped_defs = True
+
+[testenv:format]
+skip_install = True
+deps = 
+   black
+commands = black {posargs: --check --diff src tests}
+

--- a/src/uqtestfuns/core/prob_input/multivariate_input.py
+++ b/src/uqtestfuns/core/prob_input/multivariate_input.py
@@ -35,6 +35,7 @@ class MultivariateInput:
     univariate_inputs : List[Dict]
         List of dictionaries that defines each of the univariate inputs.
     """
+
     spatial_dimension: int = field(init=False)
     marginals: Tuple[UnivariateInput, ...] = field(init=False)
     univariate_inputs: InitVar[Union[List[Dict], Tuple[Dict]]] = None
@@ -58,8 +59,9 @@ class MultivariateInput:
         xx_trans = xx.copy()
         if self.copulas is None:
             # Independent inputs, transform marginal by marginal
-            for idx_dim, (marginal_self, marginal_other) in \
-                    enumerate(zip(self.marginals, other.marginals)):
+            for idx_dim, (marginal_self, marginal_other) in enumerate(
+                zip(self.marginals, other.marginals)
+            ):
                 xx_trans[:, idx_dim] = marginal_self.transform_sample(
                     xx[:, idx_dim], marginal_other
                 )
@@ -122,11 +124,7 @@ class MultivariateInput:
         # Get the values for each field as a list
         list_values = get_values_as_list(self.marginals)
 
-        return tabulate(
-            list_values,
-            headers=header_names,
-            stralign="center"
-        )
+        return tabulate(list_values, headers=header_names, stralign="center")
 
     def _repr_html_(self):
         # Get the header names
@@ -141,7 +139,7 @@ class MultivariateInput:
             list_values,
             headers=header_names,
             stralign="center",
-            tablefmt="html"
+            tablefmt="html",
         )
 
 
@@ -159,7 +157,7 @@ def get_values_as_list(univariate_inputs: Tuple[UnivariateInput, ...]):
     """"""
     list_values = []
     for i, marginal in enumerate(univariate_inputs):
-        values = [i+1]
+        values = [i + 1]
         for marginal_field in fields(marginal):
             if marginal_field.repr:
                 values.append(getattr(marginal, marginal_field.name))

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/beta.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/beta.py
@@ -103,10 +103,10 @@ def upper(parameters: np.ndarray) -> float:
 
 
 def pdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the PDF values of a Beta distribution.
 
@@ -137,17 +137,17 @@ def pdf(
         a=parameters[0],
         b=parameters[1],
         loc=parameters[2],
-        scale=parameters[3]-parameters[2]
+        scale=parameters[3] - parameters[2],
     )
 
     return yy
 
 
 def cdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the CDF values of the Beta distribution.
 
@@ -186,17 +186,17 @@ def cdf(
         a=parameters[0],
         b=parameters[1],
         loc=parameters[2],
-        scale=parameters[3]-parameters[2]
+        scale=parameters[3] - parameters[2],
     )
 
     return yy
 
 
 def icdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the inverse CDF values of a Beta distribution.
 
@@ -233,7 +233,7 @@ def icdf(
         a=parameters[0],
         b=parameters[1],
         loc=parameters[2],
-        scale=parameters[3]-parameters[2]
+        scale=parameters[3] - parameters[2],
     )
 
     return yy

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/logitnormal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/logitnormal.py
@@ -102,10 +102,10 @@ def upper(parameters: np.ndarray) -> float:
 
 
 def pdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the PDF values of a logit-normal distribution.
 
@@ -132,17 +132,20 @@ def pdf(
     xx_trans = logit(xx)
     yy = np.zeros(xx.shape)
     idx = np.logical_and(xx > 0.0, xx < 1.0)
-    yy[idx] = norm.pdf(xx_trans[idx], loc=parameters[0], scale=parameters[1]) \
-              / xx[idx] / (1 - xx[idx])
+    yy[idx] = (
+        norm.pdf(xx_trans[idx], loc=parameters[0], scale=parameters[1])
+        / xx[idx]
+        / (1 - xx[idx])
+    )
 
     return yy
 
 
 def cdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the CDF values of a logit-normal distribution.
 
@@ -185,10 +188,10 @@ def cdf(
 
 
 def icdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the inverse CDF values of a normal distribution.
 

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/lognormal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/lognormal.py
@@ -108,10 +108,10 @@ def upper(parameters: np.ndarray) -> float:
 
 
 def pdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the PDF values of a lognormal distribution.
 
@@ -145,10 +145,10 @@ def pdf(
 
 
 def cdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the CDF values of a lognormal distribution.
 
@@ -190,10 +190,10 @@ def cdf(
 
 
 def icdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the inverse CDF values of a lognormal distribution.
 

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/normal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/normal.py
@@ -100,10 +100,10 @@ def upper(parameters: np.ndarray) -> float:
 
 
 def pdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the PDF values of a normal distribution.
 
@@ -135,10 +135,10 @@ def pdf(
 
 
 def cdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the CDF values of a normal distribution.
 
@@ -180,10 +180,10 @@ def cdf(
 
 
 def icdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the inverse CDF values of a normal distribution.
 

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/truncnormal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/truncnormal.py
@@ -104,8 +104,7 @@ def verify_parameters(parameters: np.ndarray):
 
     if lb >= mu or ub <= mu:
         raise ValueError(
-            f"The mean {mu} "
-            f"must be between the bounds [{lb}, {ub}]!"
+            f"The mean {mu} must be between the bounds [{lb}, {ub}]!"
         )
 
 
@@ -146,10 +145,10 @@ def upper(parameters: np.ndarray) -> float:
 
 
 def pdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the PDF values of a truncated normal distribution.
 
@@ -183,20 +182,20 @@ def pdf(
 
     yy[idx] = truncnorm.pdf(
         xx[idx],
-        a=(lb_param - mu)/sigma,
-        b=(ub_param - mu)/sigma,
+        a=(lb_param - mu) / sigma,
+        b=(ub_param - mu) / sigma,
         loc=mu,
-        scale=sigma
+        scale=sigma,
     )
 
     return yy
 
 
 def cdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the CDF values of the truncated normal distribution.
 
@@ -237,20 +236,20 @@ def cdf(
     yy[idx_upper] = 1.0
     yy[idx_rest] = truncnorm.cdf(
         xx[idx_rest],
-        a=(lb_param - mu)/sigma,
-        b=(ub_param - mu)/sigma,
+        a=(lb_param - mu) / sigma,
+        b=(ub_param - mu) / sigma,
         loc=mu,
-        scale=sigma
+        scale=sigma,
     )
 
     return yy
 
 
 def icdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the inverse CDF values of a truncated normal distribution.
 
@@ -289,10 +288,10 @@ def icdf(
     yy[idx_upper] = upper_bound
     yy[idx_rest] = truncnorm.ppf(
         xx[idx_rest],
-        a=(lb_param - mu)/sigma,
-        b=(ub_param - mu)/sigma,
+        a=(lb_param - mu) / sigma,
+        b=(ub_param - mu) / sigma,
         loc=mu,
-        scale=sigma
+        scale=sigma,
     )
 
     return yy

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/uniform.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/uniform.py
@@ -79,10 +79,10 @@ def upper(parameters: np.ndarray) -> float:
 
 
 def pdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the PDF values of a uniform distribution.
 
@@ -121,10 +121,10 @@ def pdf(
 
 
 def cdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the CDF values of a uniform distribution.
 
@@ -164,10 +164,10 @@ def cdf(
 
 
 def icdf(
-        xx: np.ndarray,
-        parameters: np.ndarray,
-        lower_bound: float,
-        upper_bound: float
+    xx: np.ndarray,
+    parameters: np.ndarray,
+    lower_bound: float,
+    upper_bound: float,
 ) -> np.ndarray:
     """Get the inverse CDF values of a uniform distribution.
 

--- a/src/uqtestfuns/core/prob_input/univariate_input.py
+++ b/src/uqtestfuns/core/prob_input/univariate_input.py
@@ -33,6 +33,7 @@ class UnivariateInput:
     parameters : Union[List[float, ...], np.ndarray, List[np.ndarray, ...]]
         Parameters of the probability distribution.
     """
+
     name: str
     distribution: str
     parameters: Union[Sequence[Union[int, float, np.ndarray]], np.ndarray]
@@ -72,7 +73,7 @@ class UnivariateInput:
             other.distribution,
             other.parameters,
             other.lower,
-            other.upper
+            other.upper,
         )
 
     def get_sample(self, sample_size: int = 1):

--- a/src/uqtestfuns/core/prob_input/utils.py
+++ b/src/uqtestfuns/core/prob_input/utils.py
@@ -3,7 +3,12 @@ Utility module for probabilistic input modeling.
 """
 
 from .univariate_distributions import (
-    uniform, lognormal, normal, beta, truncnormal, logitnormal
+    uniform,
+    lognormal,
+    normal,
+    beta,
+    truncnormal,
+    logitnormal,
 )
 
 SUPPORTED_MARGINALS = {

--- a/src/uqtestfuns/core/uqtestfun.py
+++ b/src/uqtestfuns/core/uqtestfun.py
@@ -43,6 +43,7 @@ class UQTestFun:
         The number of spatial dimension (i.e., input variables) to the test
         function.
     """
+
     evaluate: Callable
     input: MultivariateInput
     spatial_dimension: int = field(init=False)
@@ -60,10 +61,10 @@ class UQTestFun:
             return self.evaluate(xx, self.parameters)
 
     def transform_inputs(
-            self,
-            xx: np.ndarray,
-            min_value: float = -1.0,
-            max_value: float = 1.0
+        self,
+        xx: np.ndarray,
+        min_value: float = -1.0,
+        max_value: float = 1.0,
     ) -> np.ndarray:
         """Transform sample values from a uniform domain to the function domain.
 
@@ -96,8 +97,10 @@ class UQTestFun:
         return xx_trans
 
     def __str__(self):
-        out = f"Name              : {self.name}\n" \
-              f"Spatial dimension : {self.spatial_dimension}\n" \
-              f"Evaluate          : {get_fun_str(self.evaluate)}"
+        out = (
+            f"Name              : {self.name}\n"
+            f"Spatial dimension : {self.spatial_dimension}\n"
+            f"Evaluate          : {get_fun_str(self.evaluate)}"
+        )
 
         return out

--- a/src/uqtestfuns/core/utils.py
+++ b/src/uqtestfuns/core/utils.py
@@ -5,7 +5,7 @@ from .prob_input import MultivariateInput
 
 
 def create_canonical_uniform_input(
-        spatial_dimension: int, min_value: float, max_value: float
+    spatial_dimension: int, min_value: float, max_value: float
 ) -> MultivariateInput:
     """Create a MultivariateInput in a canonical domain of [-1, 1]"""
     input_dicts = []
@@ -14,7 +14,7 @@ def create_canonical_uniform_input(
             {
                 "name": f"X{i+1}",
                 "distribution": "uniform",
-                "parameters": [min_value, max_value]
+                "parameters": [min_value, max_value],
             }
         )
 

--- a/src/uqtestfuns/meta/basis_functions.py
+++ b/src/uqtestfuns/meta/basis_functions.py
@@ -54,14 +54,14 @@ def null(xx: np.ndarray) -> np.ndarray:
 
 def non_monotonic(xx: np.ndarray) -> np.ndarray:
     """Compute the parabola function on a set of 1-dimensional points."""
-    yy = 4 * (xx - 0.5)**2
+    yy = 4 * (xx - 0.5) ** 2
 
     return yy
 
 
 def inverse(xx: np.ndarray) -> np.ndarray:
     """Compute the inverse function on a set of 1-dimensional points."""
-    yy = (10 - 1/1.1)**(-1) * (xx + 0.1)**(-1)
+    yy = (10 - 1 / 1.1) ** (-1) * (xx + 0.1) ** (-1)
 
     return yy
 

--- a/src/uqtestfuns/meta/metaspec.py
+++ b/src/uqtestfuns/meta/metaspec.py
@@ -13,8 +13,7 @@ __all__ = ["UQMetaFunSpec", "UQTestFunSpec"]
 
 
 def _preprocess_effects(
-        effects_dict: Dict[int, Optional[int]],
-        spatial_dimension: int
+    effects_dict: Dict[int, Optional[int]], spatial_dimension: int
 ) -> Dict[int, int]:
     """Preprocess the effects dictionary.
 
@@ -80,7 +79,7 @@ def _select_basis(spatial_dimension: int, num_basis: int) -> Tuple[int, ...]:
 
 
 def _create_effects_tuples(
-        spatial_dimension: int, effects_dict: Dict[int, int]
+    spatial_dimension: int, effects_dict: Dict[int, int]
 ) -> Dict[int, Tuple[Tuple[int, ...], ...]]:
     """Create a dictionary of effect matrices.
 
@@ -119,7 +118,9 @@ def _create_effects_tuples(
     effects_tuples = dict()
 
     for key in effects_dict:
-        if effects_dict[key] != 0 and key <= spatial_dimension:  # pragma: no cover
+        if (
+            effects_dict[key] != 0 and key <= spatial_dimension
+        ):  # pragma: no cover
             effects_tuples[key] = tuple(
                 itertools.combinations(np.arange(spatial_dimension), key)
             )
@@ -128,8 +129,8 @@ def _create_effects_tuples(
 
 
 def _select_effects(
-        all_effects: Dict[int, Tuple[Tuple[int, ...], ...]],
-        effects_dict: Dict[int, int]
+    all_effects: Dict[int, Tuple[Tuple[int, ...], ...]],
+    effects_dict: Dict[int, int],
 ) -> Dict[int, Tuple[Tuple[int, ...], ...]]:
     """Randomly select effects from all possible terms.
 
@@ -156,14 +157,16 @@ def _select_effects(
             selected_effects[key] = all_effects[key]
         else:
             # Randomly select the interaction tuples
-            idx = np.random.choice(len(all_effects[key]), length, replace=False)
+            idx = np.random.choice(
+                len(all_effects[key]), length, replace=False
+            )
             selected_effects[key] = tuple([all_effects[key][i] for i in idx])
 
     return selected_effects
 
 
 def _generate_effect_coeffs(
-        coeffs_gen: Callable, effects_dict: Dict[int, int]
+    coeffs_gen: Callable, effects_dict: Dict[int, int]
 ) -> Dict[int, np.ndarray]:
     """Generate the coefficient values for each effect term.
 
@@ -189,7 +192,7 @@ def _generate_effect_coeffs(
 
 
 def _select_inputs(
-        inputs: Union[List[Dict], Tuple[Dict, ...]], spatial_dimension: int
+    inputs: Union[List[Dict], Tuple[Dict, ...]], spatial_dimension: int
 ) -> Union[List[Dict], Tuple[Dict, ...]]:
     """Randomly select marginals of a given dimension from a set of inputs.
 
@@ -208,7 +211,9 @@ def _select_inputs(
         the given dimension for a test function realization.
     """
     inputs_list = []
-    indices = np.random.randint(low=0, high=len(inputs), size=spatial_dimension)
+    indices = np.random.randint(
+        low=0, high=len(inputs), size=spatial_dimension
+    )
 
     for num, idx in enumerate(indices):
         # Create an independent copy to avoid unintended mutation
@@ -247,6 +252,7 @@ class UQTestFunSpec:
         Input marginals to construct a multi-dimensional probabilistic input of
         the test function.
     """
+
     spatial_dimension: int
     basis_functions: Dict[int, Callable]
     selected_basis: Tuple[int, ...]
@@ -274,6 +280,7 @@ class UQMetaFunSpec:
     coeffs_generator : Callable
         Function to generate the coefficient values for each effect term.
     """
+
     spatial_dimension: int
     basis_functions: Dict[int, Callable]
     effects: Dict[int, int] = field(init=False)
@@ -292,10 +299,12 @@ class UQMetaFunSpec:
             )
         self._effects_tuples = None
         # Clean up the effects dictionary
-        self.effects = _preprocess_effects(effects_dict, self.spatial_dimension)
+        self.effects = _preprocess_effects(
+            effects_dict, self.spatial_dimension
+        )
 
     def get_sample(
-            self, sample_size: int = 1
+        self, sample_size: int = 1
     ) -> Optional[Union[UQTestFunSpec, List[UQTestFunSpec]]]:
         """Get realizations of UQTestFunSpec.
 
@@ -344,9 +353,7 @@ class UQMetaFunSpec:
             )
 
             # Randomly select input marginals and create an instance
-            inputs = _select_inputs(
-                self.inputs, self.spatial_dimension
-            )
+            inputs = _select_inputs(self.inputs, self.spatial_dimension)
 
             # Create an instance of UQTestFunSpec
             uqtestfun_spec = UQTestFunSpec(
@@ -355,7 +362,7 @@ class UQMetaFunSpec:
                 selected_basis,
                 effects_tuples,
                 effects_coeffs,
-                inputs
+                inputs,
             )
 
             sample.append(uqtestfun_spec)
@@ -368,4 +375,5 @@ class UQMetaFunSpec:
 
 if __name__ == "__main__":  # pragma: no cover
     import doctest
+
     doctest.testmod()

--- a/src/uqtestfuns/meta/uqmetatestfun.py
+++ b/src/uqtestfuns/meta/uqmetatestfun.py
@@ -62,9 +62,9 @@ def default_coeffs_gen(sample_size: int) -> np.ndarray:
 
 
 def _evaluate_test_function(
-        xx: np.ndarray, uqtestfun_spec: UQTestFunSpec
+    xx: np.ndarray, uqtestfun_spec: UQTestFunSpec
 ) -> np.ndarray:
-    """"""
+    """Alternative way to evaluate metafunction realizations."""
 
     basis_functions = uqtestfun_spec.basis_functions
     selected_basis = uqtestfun_spec.selected_basis
@@ -103,10 +103,11 @@ class UQMetaTestFun:
         An instance of meta specification that fully defines a
         meta.
     """
+
     metafun_spec: UQMetaFunSpec
 
     def get_sample(
-            self, sample_size=1
+        self, sample_size=1
     ) -> Optional[Union[UQTestFun, List[UQTestFun]]]:
         """Generate realizations of test function.
 
@@ -151,17 +152,15 @@ class UQMetaTestFun:
             # Assign the realized spec as a parameter
             parameters = testfun_specs[i]
 
-            sample.append(
-                UQTestFun(evaluate, inputs, name, parameters)
-            )
+            sample.append(UQTestFun(evaluate, inputs, name, parameters))
 
         return sample
 
     @classmethod
     def from_default(
-            cls,
-            spatial_dimension: Union[int, Sized],
-            input_id: Optional[int] = None
+        cls,
+        spatial_dimension: Union[int, Sized],
+        input_id: Optional[int] = None,
     ):
         """Create a metafunction with parameters according to Becker (2019).
 
@@ -171,7 +170,7 @@ class UQMetaTestFun:
             Number of dimensions of the test functions generated
             by the meta. If a set of values are given, a single value
             will be selected at random.
-            
+
         Returns
         -------
         UQMetaTestFun
@@ -183,7 +182,7 @@ class UQMetaTestFun:
         effects_dict = {
             1: None,  # Take all
             2: math.floor(0.5 * spatial_dimension),
-            3: math.floor(0.2 * spatial_dimension)
+            3: math.floor(0.2 * spatial_dimension),
         }
 
         if input_id is None:
@@ -191,12 +190,15 @@ class UQMetaTestFun:
 
         inputs = [
             {"distribution": "uniform", "parameters": [0, 1]},
-            {"distribution": "truncnormal", "parameters": [0.5, 0.15, 0., 1.]},
-            {"distribution": "beta", "parameters": [8., 2., 0., 1.]},
-            {"distribution": "beta", "parameters": [2., 8., 0., 1.]},
-            {"distribution": "beta", "parameters": [2., 0.8, 0., 1.]},
-            {"distribution": "beta", "parameters": [0.8, 2., 0., 1.]},
-            {"distribution": "logitnormal", "parameters": [0., 3.16]}
+            {
+                "distribution": "truncnormal",
+                "parameters": [0.5, 0.15, 0.0, 1.0],
+            },
+            {"distribution": "beta", "parameters": [8.0, 2.0, 0.0, 1.0]},
+            {"distribution": "beta", "parameters": [2.0, 8.0, 0.0, 1.0]},
+            {"distribution": "beta", "parameters": [2.0, 0.8, 0.0, 1.0]},
+            {"distribution": "beta", "parameters": [0.8, 2.0, 0.0, 1.0]},
+            {"distribution": "logitnormal", "parameters": [0.0, 3.16]},
         ]
 
         if input_id < 7:
@@ -207,7 +209,7 @@ class UQMetaTestFun:
             basis_functions=BASIS_BY_ID,
             effects_dict=effects_dict,
             inputs=inputs,
-            coeffs_generator=default_coeffs_gen
+            coeffs_generator=default_coeffs_gen,
         )
 
         return cls(metafun_spec)

--- a/src/uqtestfuns/test_functions/borehole.py
+++ b/src/uqtestfuns/test_functions/borehole.py
@@ -33,50 +33,50 @@ DEFAULT_INPUT_DICTS = [
         "name": "rw",
         "distribution": "normal",
         "parameters": [0.10, 0.0161812],
-        "description": "radius of the borehole [m]"
+        "description": "radius of the borehole [m]",
     },
     {
         "name": "r",
         "distribution": "lognormal",
         "parameters": [7.71, 1.0056],
-        "description": "radius of influence [m]"
+        "description": "radius of influence [m]",
     },
     {
         "name": "Tu",
         "distribution": "uniform",
-        "parameters": [63070., 115600.],
-        "description": "transmissivity of upper aquifer [m^2/year]"
+        "parameters": [63070.0, 115600.0],
+        "description": "transmissivity of upper aquifer [m^2/year]",
     },
     {
         "name": "Hu",
         "distribution": "uniform",
-        "parameters": [990., 1100.],
-        "description": "potentiometric head of upper aquifer [m]"
+        "parameters": [990.0, 1100.0],
+        "description": "potentiometric head of upper aquifer [m]",
     },
     {
         "name": "Tl",
         "distribution": "uniform",
         "parameters": [63.1, 116.0],
-        "description": "transmissivity of lower aquifer [m^2/year]"
+        "description": "transmissivity of lower aquifer [m^2/year]",
     },
     {
         "name": "Hl",
         "distribution": "uniform",
-        "parameters": [700., 820.],
-        "description": "potentiometric head of lower aquifer [m]"
+        "parameters": [700.0, 820.0],
+        "description": "potentiometric head of lower aquifer [m]",
     },
     {
         "name": "L",
         "distribution": "uniform",
-        "parameters": [1120., 1680.],
-        "description": "length of the borehole [m]"
+        "parameters": [1120.0, 1680.0],
+        "description": "length of the borehole [m]",
     },
     {
         "name": "Kw",
         "distribution": "uniform",
-        "parameters": [9985., 12045.],
-        "description": "hydraulic conductivity of the borehole [m/year]"
-    }
+        "parameters": [9985.0, 12045.0],
+        "description": "hydraulic conductivity of the borehole [m/year]",
+    },
 ]
 
 DEFAULT_INPUT = MultivariateInput(DEFAULT_INPUT_DICTS)
@@ -88,14 +88,14 @@ ALTERNATIVE_INPUT_DICTS[0:2] = [
         "name": "rw",
         "distribution": "uniform",
         "parameters": [0.05, 0.15],
-        "description": "radius of the borehole [m]"
+        "description": "radius of the borehole [m]",
     },
     {
         "name": "r",
         "distribution": "uniform",
         "parameters": [100, 50000],
-        "description": "radius of influence [m]"
-    }
+        "description": "radius of influence [m]",
+    },
 ]
 
 ALTERNATIVE_INPUT = MultivariateInput(ALTERNATIVE_INPUT_DICTS)
@@ -124,8 +124,12 @@ def evaluate(xx: np.ndarray) -> np.ndarray:
     # Compute the Borehole function
     nom = 2 * np.pi * xx[:, 2] * (xx[:, 3] - xx[:, 5])
     denom_1 = np.log(xx[:, 1] / xx[:, 0])
-    denom_2 = 2 * xx[:, 6] * xx[:, 2] / \
-              (np.log(xx[:, 1] / xx[:, 0]) * xx[:, 0] ** 2 * xx[:, 7])
+    denom_2 = (
+        2
+        * xx[:, 6]
+        * xx[:, 2]
+        / (np.log(xx[:, 1] / xx[:, 0]) * xx[:, 0] ** 2 * xx[:, 7])
+    )
     denom_3 = xx[:, 2] / xx[:, 4]
 
     yy = nom / (denom_1 * (1 + denom_2 + denom_3))

--- a/src/uqtestfuns/test_functions/default.py
+++ b/src/uqtestfuns/test_functions/default.py
@@ -40,7 +40,7 @@ def get_default_args(fun_name: str) -> dict:
         "name": fun_mod.DEFAULT_NAME,
         "evaluate": fun_mod.evaluate,
         "input": fun_mod.DEFAULT_INPUT,
-        "parameters": fun_mod.DEFAULT_PARAMETERS
+        "parameters": fun_mod.DEFAULT_PARAMETERS,
     }
 
     return default_args

--- a/src/uqtestfuns/test_functions/ishigami.py
+++ b/src/uqtestfuns/test_functions/ishigami.py
@@ -28,20 +28,20 @@ DEFAULT_INPUT_DICTS = [
         "name": "X1",
         "distribution": "uniform",
         "parameters": [-np.pi, np.pi],
-        "description": "None"
+        "description": "None",
     },
     {
         "name": "X2",
         "distribution": "uniform",
         "parameters": [-np.pi, np.pi],
-        "description": "None"
+        "description": "None",
     },
     {
         "name": "X2",
         "distribution": "uniform",
         "parameters": [-np.pi, np.pi],
-        "description": "None"
-    }
+        "description": "None",
+    },
 ]
 
 DEFAULT_INPUT = MultivariateInput(DEFAULT_INPUT_DICTS)
@@ -72,8 +72,8 @@ def evaluate(xx: np.ndarray, params: tuple = DEFAULT_PARAMETERS) -> np.ndarray:
 
     # Compute the Ishigami function
     term_1 = np.sin(xx[:, 0])
-    term_2 = params[0] * np.sin(xx[:, 1])**2
-    term_3 = params[1] * xx[:, 2]**4 * np.sin(xx[:, 0])
+    term_2 = params[0] * np.sin(xx[:, 1]) ** 2
+    term_3 = params[1] * xx[:, 2] ** 4 * np.sin(xx[:, 0])
 
     yy = term_1 + term_2 + term_3
 

--- a/src/uqtestfuns/test_functions/wing_weight.py
+++ b/src/uqtestfuns/test_functions/wing_weight.py
@@ -25,62 +25,62 @@ DEFAULT_INPUT_DICTS = [
         "name": "Sw",
         "distribution": "uniform",
         "parameters": [150, 200],
-        "description": "wing area [ft^2]"
+        "description": "wing area [ft^2]",
     },
     {
         "name": "Wfw",
         "distribution": "uniform",
         "parameters": [220, 300],
-        "description": "weight of fuel in the wing [lb]"
+        "description": "weight of fuel in the wing [lb]",
     },
     {
         "name": "A",
         "distribution": "uniform",
         "parameters": [6, 10],
-        "description": "aspect ratio [-]"
+        "description": "aspect ratio [-]",
     },
     {
         "name": "Lambda",
         "distribution": "uniform",
         "parameters": [-10, 10],
-        "description": "quarter-chord sweep [degrees]"
+        "description": "quarter-chord sweep [degrees]",
     },
     {
         "name": "q",
         "distribution": "uniform",
         "parameters": [16, 45],
-        "description": "dynamic pressure at cruise [lb/ft^2]"
+        "description": "dynamic pressure at cruise [lb/ft^2]",
     },
     {
         "name": "lambda",
         "distribution": "uniform",
         "parameters": [0.5, 1.0],
-        "description": "taper ratio [-]"
+        "description": "taper ratio [-]",
     },
     {
         "name": "tc",
         "distribution": "uniform",
         "parameters": [0.08, 0.18],
-        "description": "aerofoil thickness to chord ratio [-]"
+        "description": "aerofoil thickness to chord ratio [-]",
     },
     {
         "name": "Nz",
         "distribution": "uniform",
         "parameters": [2.5, 6.0],
-        "description": "ultimate load factor [-]"
+        "description": "ultimate load factor [-]",
     },
     {
         "name": "Wdg",
         "distribution": "uniform",
         "parameters": [1700, 2500],
-        "description": "flight design gross weight [lb]"
+        "description": "flight design gross weight [lb]",
     },
     {
         "name": "Wp",
         "distribution": "uniform",
         "parameters": [0.025, 0.08],
-        "description": "paint weight [lb/ft^2]"
-    }
+        "description": "paint weight [lb/ft^2]",
+    },
 ]
 
 DEFAULT_INPUT = MultivariateInput(DEFAULT_INPUT_DICTS)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,8 @@ def create_random_alphanumeric(length: int) -> str:
     """
 
     out = "".join(
-        random.choice(string.ascii_letters+string.digits) for _ in range(length)
+        random.choice(string.ascii_letters + string.digits)
+        for _ in range(length)
     )
 
     return out
@@ -70,8 +71,8 @@ def create_random_input_dicts(length: int) -> List[Dict]:
                 "name": f"X{i+1}",
                 "distribution": distribution,
                 "parameters": parameters,
-                "description": create_random_alphanumeric(10)
-             }
+                "description": create_random_alphanumeric(10),
+            }
         )
 
     return input_dicts
@@ -87,4 +88,3 @@ def assert_call(fct, *args, **kwargs):
             f"The function was not called properly. "
             f"It raised the exception:\n\n {e.__class__.__name__}: {e}"
         )
-

--- a/tests/test_ishigami.py
+++ b/tests/test_ishigami.py
@@ -25,7 +25,7 @@ def ishigami_fun(request):
         name=default_args["name"],
         evaluate=default_args["evaluate"],
         input=default_args["input"],
-        parameters=request.param
+        parameters=request.param,
     )
 
     return ishigami
@@ -58,7 +58,7 @@ def test_compute_variance(ishigami_fun):
 
     # Analytical mean
     a, b = ishigami_fun.parameters
-    var_ref = a**2 / 8 + b * np.pi**4/5 + b**2 * np.pi**8/18 + 0.5
+    var_ref = a**2 / 8 + b * np.pi**4 / 5 + b**2 * np.pi**8 / 18 + 0.5
 
     # Assertion
     assert np.allclose(var_mc, var_ref, rtol=1e-2)

--- a/tests/test_multivariate_input.py
+++ b/tests/test_multivariate_input.py
@@ -19,13 +19,18 @@ def test_create_instance_numpy_parameters(spatial_dimension):
     assert my_multivariate_input.spatial_dimension == spatial_dimension
     for i in range(spatial_dimension):
         # Test the name of the marginals
-        assert input_dicts[i]["name"] == my_multivariate_input.marginals[i].name
+        assert (
+            input_dicts[i]["name"] == my_multivariate_input.marginals[i].name
+        )
         # Test the type of distributions
-        assert input_dicts[i]["distribution"] == \
-               my_multivariate_input.marginals[i].distribution
+        assert (
+            input_dicts[i]["distribution"]
+            == my_multivariate_input.marginals[i].distribution
+        )
         # Test the parameter values
         assert np.all(
-            input_dicts[i]["parameters"] == my_multivariate_input.marginals[i].parameters
+            input_dicts[i]["parameters"]
+            == my_multivariate_input.marginals[i].parameters
         )
 
 
@@ -151,7 +156,7 @@ def test_str():
     header_names = ["name", "distribution", "parameters", "description"]
     str_ref_list: List[List] = []
     for i, input_dict in enumerate(input_dicts):
-        str_ref_placeholder: List[Any] = [i+1]
+        str_ref_placeholder: List[Any] = [i + 1]
         for header_name in header_names:
             str_ref_placeholder.append(input_dict.get(header_name))
         str_ref_list.append(str_ref_placeholder)
@@ -159,7 +164,7 @@ def test_str():
     str_ref = tabulate(
         str_ref_list,
         headers=list(map(str.capitalize, header_names)),
-        stralign="center"
+        stralign="center",
     )
 
     # Assertion
@@ -174,11 +179,10 @@ def test_repr_html():
     my_multivariate_input = MultivariateInput(input_dicts)
 
     # Create the reference string
-    # Create the reference string
     header_names = ["name", "distribution", "parameters", "description"]
     str_ref_list: List[List] = []
     for i, input_dict in enumerate(input_dicts):
-        str_ref_placeholder: List[Any] = [i+1]
+        str_ref_placeholder: List[Any] = [i + 1]
         for header_name in header_names:
             str_ref_placeholder.append(input_dict.get(header_name))
         str_ref_list.append(str_ref_placeholder)
@@ -187,11 +191,12 @@ def test_repr_html():
         str_ref_list,
         headers=list(map(str.capitalize, header_names)),
         stralign="center",
-        tablefmt="html"
+        tablefmt="html",
     )
 
     # Assertion
     assert my_multivariate_input._repr_html_() == str_ref
+
 
 #
 # def test_get_cdf_values():

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -1,4 +1,5 @@
 import uqtestfuns
 
+
 def test_always_passes():
     assert True

--- a/tests/test_test_functions.py
+++ b/tests/test_test_functions.py
@@ -34,8 +34,10 @@ def test_create_instance(default_testfun):
     testfun, testfun_mod = default_testfun
 
     # Assertions
-    assert testfun.spatial_dimension == \
-           testfun_mod.DEFAULT_INPUT.spatial_dimension
+    assert (
+        testfun.spatial_dimension
+        == testfun_mod.DEFAULT_INPUT.spatial_dimension
+    )
     assert testfun.input == testfun_mod.DEFAULT_INPUT
 
 
@@ -93,7 +95,7 @@ def test_wrong_input_dim(default_testfun):
     testfun, _ = default_testfun
 
     # Compute variance via Monte Carlo
-    xx = np.random.rand(10, testfun.spatial_dimension*2)
+    xx = np.random.rand(10, testfun.spatial_dimension * 2)
 
     with pytest.raises(ValueError):
         testfun(xx)

--- a/tests/test_univariate_beta.py
+++ b/tests/test_univariate_beta.py
@@ -10,19 +10,23 @@ from conftest import create_random_alphanumeric
 
 def _mean(parameters: np.ndarray) -> float:
     """Compute the analytical mean of a Beta distribution."""
-    mean = parameters[2] + (parameters[3] - parameters[2]) * \
-           (parameters[0] / (parameters[0] + parameters[1]))
+    mean = parameters[2] + (parameters[3] - parameters[2]) * (
+        (parameters[0] / (parameters[0] + parameters[1]))
+    )
 
     return mean
 
 
 def _std(parameters: np.ndarray) -> float:
     """Compute the analytical standard deviation of a Beta distribution."""
-    std = (parameters[3] - parameters[2]) / (parameters[0] + parameters[1]) * \
-           np.sqrt(
-               (parameters[0] * parameters[1]) /
-               (parameters[0] + parameters[1] + 1)
-           )
+    std = (
+        (parameters[3] - parameters[2])
+        / (parameters[0] + parameters[1])
+        * np.sqrt(
+            (parameters[0] * parameters[1])
+            / (parameters[0] + parameters[1] + 1)
+        )
+    )
 
     return std
 
@@ -88,7 +92,7 @@ def test_estimate_mean():
 
     # Analytical result
     mean_ref = _mean(parameters)
-    
+
     # Assertion
     assert np.isclose(mean, mean_ref, rtol=1e-03, atol=1e-04)
 

--- a/tests/test_univariate_input.py
+++ b/tests/test_univariate_input.py
@@ -37,7 +37,7 @@ def univariate_input(request):
     specs = {
         "name": name,
         "distribution": distribution,
-        "parameters": parameters
+        "parameters": parameters,
     }
 
     my_univariate_input = UnivariateInput(**specs)
@@ -89,8 +89,8 @@ def test_get_pdf_values(univariate_input):
     xx = my_univariate_input.get_sample(sample_size)
 
     # Assertions
-    assert my_univariate_input.pdf(my_univariate_input.lower-0.1) <= 1e-15
-    assert my_univariate_input.pdf(my_univariate_input.upper+0.1) <= 1e-15
+    assert my_univariate_input.pdf(my_univariate_input.lower - 0.1) <= 1e-15
+    assert my_univariate_input.pdf(my_univariate_input.upper + 0.1) <= 1e-15
 
 
 def test_get_cdf_values(univariate_input):
@@ -127,13 +127,9 @@ def test_get_icdf_values(univariate_input):
     # Test the upper bound of sampled ICDF
     assert np.max(icdf_values) <= my_univariate_input.upper
     # Test the lower bound of ICDF
-    assert np.isclose(
-        my_univariate_input.icdf(0.0), my_univariate_input.lower
-    )
+    assert np.isclose(my_univariate_input.icdf(0.0), my_univariate_input.lower)
     # Test the upper bound of ICDF
-    assert np.isclose(
-        my_univariate_input.icdf(1.0), my_univariate_input.upper
-    )
+    assert np.isclose(my_univariate_input.icdf(1.0), my_univariate_input.upper)
 
 
 def test_transform_sample():

--- a/tests/test_univariate_logitnormal.py
+++ b/tests/test_univariate_logitnormal.py
@@ -50,12 +50,10 @@ def test_get_pdf_values():
     # Assertions (PDF values of zero at the boundaries)
     assert np.all(
         np.logical_and(
-            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
-                my_univariate_input.lower
-            ),
-            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
-                my_univariate_input.upper
-            )
+            my_univariate_input.pdf(xx)
+            >= my_univariate_input.pdf(my_univariate_input.lower),
+            my_univariate_input.pdf(xx)
+            >= my_univariate_input.pdf(my_univariate_input.upper),
         )
     )
 

--- a/tests/test_univariate_lognormal.py
+++ b/tests/test_univariate_lognormal.py
@@ -48,11 +48,9 @@ def test_get_pdf_values():
     # Assertions (PDF values of zero at the boundaries)
     assert np.all(
         np.logical_and(
-            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
-                my_univariate_input.lower
-            ),
-            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
-                my_univariate_input.upper
-            )
+            my_univariate_input.pdf(xx)
+            >= my_univariate_input.pdf(my_univariate_input.lower),
+            my_univariate_input.pdf(xx)
+            >= my_univariate_input.pdf(my_univariate_input.upper),
         )
     )

--- a/tests/test_univariate_normal.py
+++ b/tests/test_univariate_normal.py
@@ -49,11 +49,9 @@ def test_get_pdf_values():
     # Assertions (PDF values of zero at the boundaries)
     assert np.all(
         np.logical_and(
-            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
-                my_univariate_input.lower
-            ),
-            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
-                my_univariate_input.upper
-            )
+            my_univariate_input.pdf(xx)
+            >= my_univariate_input.pdf(my_univariate_input.lower),
+            my_univariate_input.pdf(xx)
+            >= my_univariate_input.pdf(my_univariate_input.upper),
         )
     )

--- a/tests/test_univariate_truncnormal.py
+++ b/tests/test_univariate_truncnormal.py
@@ -17,8 +17,8 @@ def _calc_mean(parameters: np.ndarray) -> float:
     """Compute the analytical mean of a given truncated normal distribution."""
     mu, sigma, lb, ub = parameters[:]
 
-    alpha = (lb - mu)/sigma
-    beta = (ub - mu)/sigma
+    alpha = (lb - mu) / sigma
+    beta = (ub - mu) / sigma
     phi_alpha = norm.pdf(alpha)
     phi_beta = norm.pdf(beta)
     z = norm.cdf(beta) - norm.cdf(alpha)
@@ -41,7 +41,7 @@ def _calc_std(parameters: np.ndarray) -> float:
     term_1 = 1
     term_2 = (beta * phi_beta - alpha * phi_alpha) / z
     term_3 = ((phi_beta - phi_alpha) / z) ** 2
-    var = sigma ** 2 * (term_1 - term_2 - term_3)
+    var = sigma**2 * (term_1 - term_2 - term_3)
 
     return np.sqrt(var)
 

--- a/tests/test_univariate_uniform.py
+++ b/tests/test_univariate_uniform.py
@@ -49,11 +49,9 @@ def test_get_pdf_values():
     # Assertions (PDF values of zero at the boundaries)
     assert np.all(
         np.logical_and(
-            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
-                my_univariate_input.lower
-            ),
-            my_univariate_input.pdf(xx) >= my_univariate_input.pdf(
-                my_univariate_input.upper
-            )
+            my_univariate_input.pdf(xx)
+            >= my_univariate_input.pdf(my_univariate_input.lower),
+            my_univariate_input.pdf(xx)
+            >= my_univariate_input.pdf(my_univariate_input.upper),
         )
     )

--- a/tests/test_uqmetaspec.py
+++ b/tests/test_uqmetaspec.py
@@ -17,25 +17,20 @@ def uqtestfunspec():
 
     spatial_dimension = random.randint(1, 25)
 
-    basis_functions = {
-        0: lambda x: x,
-        1: lambda x: x**2
-    }
+    basis_functions = {0: lambda x: x, 1: lambda x: x**2}
     num_basis = len(basis_functions)
 
     selected_basis = tuple(np.random.randint(0, num_basis, spatial_dimension))
 
     effects_tuples = {}
     effects_coeffs = {}
-    for i in range(1, spatial_dimension+1):
+    for i in range(1, spatial_dimension + 1):
         effects_tuples[i] = tuple(
             itertools.combinations(np.arange(spatial_dimension), i)
         )
         effects_coeffs[i] = np.random.rand(len(effects_tuples[i]))
 
-    inputs = [
-        {"name": "X1", "distribution": "uniform", "parameters": [0, 1]}
-    ]
+    inputs = [{"name": "X1", "distribution": "uniform", "parameters": [0, 1]}]
 
     my_args = {
         "spatial_dimension": spatial_dimension,
@@ -57,28 +52,35 @@ def test_create_instance(uqtestfunspec):
     uqtestfunspec_instance, uqtestfunspec_dict = uqtestfunspec
 
     # Assertions
-    assert uqtestfunspec_instance.spatial_dimension == \
-           uqtestfunspec_dict["spatial_dimension"]
-    assert uqtestfunspec_instance.basis_functions == \
-           uqtestfunspec_dict["basis_functions"]
-    assert uqtestfunspec_instance.selected_basis == \
-           uqtestfunspec_dict["selected_basis"]
-    assert uqtestfunspec_instance.effects_tuples == \
-           uqtestfunspec_dict["effects_tuples"]
-    assert uqtestfunspec_instance.effects_coeffs == \
-            uqtestfunspec_dict["effects_coeffs"]
-    assert uqtestfunspec_instance.inputs == \
-           uqtestfunspec_dict["inputs"]
+    assert (
+        uqtestfunspec_instance.spatial_dimension
+        == uqtestfunspec_dict["spatial_dimension"]
+    )
+    assert (
+        uqtestfunspec_instance.basis_functions
+        == uqtestfunspec_dict["basis_functions"]
+    )
+    assert (
+        uqtestfunspec_instance.selected_basis
+        == uqtestfunspec_dict["selected_basis"]
+    )
+    assert (
+        uqtestfunspec_instance.effects_tuples
+        == uqtestfunspec_dict["effects_tuples"]
+    )
+    assert (
+        uqtestfunspec_instance.effects_coeffs
+        == uqtestfunspec_dict["effects_coeffs"]
+    )
+    assert uqtestfunspec_instance.inputs == uqtestfunspec_dict["inputs"]
+
 
 def test_create_instance_uqmetafunspec():
 
     # Create an instance
     spatial_dimension = 3
 
-    basis_functions = {
-        0: lambda x: x,
-        1: lambda x: x**2
-    }
+    basis_functions = {0: lambda x: x, 1: lambda x: x**2}
 
     effects_dict = {
         1: None,
@@ -93,9 +95,7 @@ def test_create_instance_uqmetafunspec():
         2: 1,
     }
 
-    inputs = create_random_input_dicts(
-        spatial_dimension
-    )
+    inputs = create_random_input_dicts(spatial_dimension)
     coeffs_generator = np.random.rand
 
     metafun_spec = UQMetaFunSpec(
@@ -103,7 +103,7 @@ def test_create_instance_uqmetafunspec():
         basis_functions,
         effects_dict,
         inputs,
-        coeffs_generator
+        coeffs_generator,
     )
 
     # Assertions
@@ -117,9 +117,9 @@ def _create_args_effects_dict(spatial_dimension):
     """Create a dictionary of effects-length specification."""
     effects_dict = dict()
 
-    for i in range(1, spatial_dimension+1):
+    for i in range(1, spatial_dimension + 1):
         max_num = math.comb(spatial_dimension, i)
-        effects_dict[i] = np.random.randint(1, max_num+1)
+        effects_dict[i] = np.random.randint(1, max_num + 1)
 
     return effects_dict
 
@@ -128,7 +128,7 @@ def _create_effects_tuples_coeffs(spatial_dimension, coeffs_generator):
     """Create a dictionary of effect tuples and coefficients specifications."""
     effects_tuples = {}
     effects_coeffs = {}
-    for i in range(1, spatial_dimension+1):
+    for i in range(1, spatial_dimension + 1):
         effects_tuples[i] = tuple(
             itertools.combinations(np.arange(spatial_dimension), i)
         )
@@ -143,15 +143,11 @@ def test_get_sample_uqmetafunspec(spatial_dimension):
     # Create an instance
     spatial_dimension = 1
 
-    basis_functions = {
-        0: lambda x: x,
-    }
+    basis_functions = {0: lambda x: x}
 
     effects_dict = _create_args_effects_dict(spatial_dimension)
 
-    inputs = create_random_input_dicts(
-        spatial_dimension
-    )
+    inputs = create_random_input_dicts(spatial_dimension)
     coeffs_generator = np.random.rand
 
     metafun_spec = UQMetaFunSpec(
@@ -159,7 +155,7 @@ def test_get_sample_uqmetafunspec(spatial_dimension):
         basis_functions,
         effects_dict,
         inputs,
-        coeffs_generator
+        coeffs_generator,
     )
 
     # Get 0 sample
@@ -181,7 +177,7 @@ def test_get_sample_uqmetafunspec(spatial_dimension):
         selected_basis,
         effects_tuples,
         effects_coeffs,
-        inputs
+        inputs,
     )
     # Assertions
     assert testfun_spec.spatial_dimension == testfun_spec_ref.spatial_dimension

--- a/tests/test_uqmetatestfun.py
+++ b/tests/test_uqmetatestfun.py
@@ -21,9 +21,9 @@ def _create_args_effects_dict(spatial_dimension):
     """
     effects_dict = dict()
 
-    for i in range(1, spatial_dimension+1):
+    for i in range(1, spatial_dimension + 1):
         max_num = math.comb(spatial_dimension, i)
-        effects_dict[i] = np.random.randint(1, max_num+1)
+        effects_dict[i] = np.random.randint(1, max_num + 1)
 
     return effects_dict
 
@@ -55,16 +55,11 @@ def uqmetafunspec(request):
 
     spatial_dimension = request.param
 
-    basis_functions = {
-        0: lambda x: x,
-        1: lambda x: x ** 2
-    }
+    basis_functions = {0: lambda x: x, 1: lambda x: x**2}
 
     effects_dict = _create_args_effects_dict(spatial_dimension)
 
-    inputs = create_random_input_dicts(
-        spatial_dimension
-    )
+    inputs = create_random_input_dicts(spatial_dimension)
 
     coeffs_generator = np.random.rand
 
@@ -73,7 +68,7 @@ def uqmetafunspec(request):
         "basis_functions": basis_functions,
         "effects_dict": effects_dict,
         "inputs": inputs,
-        "coeffs_generator": coeffs_generator
+        "coeffs_generator": coeffs_generator,
     }
 
     my_metafun_spec = UQMetaFunSpec(
@@ -81,7 +76,7 @@ def uqmetafunspec(request):
         basis_functions,
         effects_dict,
         inputs,
-        coeffs_generator
+        coeffs_generator,
     )
 
     return my_metafun_spec, my_args
@@ -96,16 +91,22 @@ def test_create_instance(uqmetafunspec):
     my_metafun = UQMetaTestFun(my_metafun_spec)
 
     # Assertions
-    assert my_metafun.metafun_spec.spatial_dimension == \
-           my_args["spatial_dimension"]
-    assert my_metafun.metafun_spec.basis_functions == \
-            my_args["basis_functions"]
+    assert (
+        my_metafun.metafun_spec.spatial_dimension
+        == my_args["spatial_dimension"]
+    )
+    assert (
+        my_metafun.metafun_spec.basis_functions == my_args["basis_functions"]
+    )
     assert my_metafun.metafun_spec.inputs == my_args["inputs"]
-    assert my_metafun.metafun_spec.coeffs_generator == \
-           my_args["coeffs_generator"]
+    assert (
+        my_metafun.metafun_spec.coeffs_generator == my_args["coeffs_generator"]
+    )
     for key in my_metafun.metafun_spec.effects:
-        assert my_metafun.metafun_spec.effects[key] == \
-               my_args["effects_dict"][key]
+        assert (
+            my_metafun.metafun_spec.effects[key]
+            == my_args["effects_dict"][key]
+        )
 
 
 @pytest.mark.parametrize("spatial_dimension", [1, 2, 3, 4, 5, 10])
@@ -207,7 +208,7 @@ def test_evaluate_sample(spatial_dimension):
         basis_functions,
         effects_dict,
         inputs,
-        coeffs_generator
+        coeffs_generator,
     )
     my_metafun = UQMetaTestFun(my_metafun_spec)
 

--- a/tests/test_uqtestfun.py
+++ b/tests/test_uqtestfun.py
@@ -4,7 +4,9 @@ from inspect import signature
 
 from uqtestfuns import UQTestFun, MultivariateInput, get_default_args
 from conftest import (
-    assert_call, create_random_input_dicts, create_random_alphanumeric
+    assert_call,
+    create_random_input_dicts,
+    create_random_alphanumeric,
 )
 
 
@@ -19,14 +21,14 @@ def uqtestfun():
         "name": "Test function",
         "evaluate": evaluate,
         "input": MultivariateInput(input_dicts),
-        "parameters": 10
+        "parameters": 10,
     }
 
     uqtestfun_instance = UQTestFun(
         name="Test function",
-        evaluate= evaluate,
+        evaluate=evaluate,
         input=MultivariateInput(input_dicts),
-        parameters=10
+        parameters=10,
     )
 
     return uqtestfun_instance, my_args
@@ -40,8 +42,10 @@ def test_create_instance(uqtestfun):
     # Assertions
     assert uqtestfun_instance.name == uqtestfun_dict["name"]
     assert uqtestfun_instance.evaluate == uqtestfun_dict["evaluate"]
-    assert uqtestfun_instance.spatial_dimension == \
-           uqtestfun_dict["input"].spatial_dimension
+    assert (
+        uqtestfun_instance.spatial_dimension
+        == uqtestfun_dict["input"].spatial_dimension
+    )
     assert uqtestfun_instance.parameters == uqtestfun_dict["parameters"]
 
 
@@ -60,11 +64,13 @@ def test_str(uqtestfun):
     """Test the __str__ method of UQTestFun."""
     uqtestfun_instance, _ = uqtestfun
 
-    str_ref = f"Name              : {uqtestfun_instance.name}\n" \
-              f"Spatial dimension : {uqtestfun_instance.spatial_dimension}\n" \
-              f"Evaluate          : {uqtestfun_instance.evaluate.__module__}." \
-              f"{uqtestfun_instance.evaluate.__name__}" \
-              f"{signature(uqtestfun_instance.evaluate)}"
+    str_ref = (
+        f"Name              : {uqtestfun_instance.name}\n"
+        f"Spatial dimension : {uqtestfun_instance.spatial_dimension}\n"
+        f"Evaluate          : {uqtestfun_instance.evaluate.__module__}."
+        f"{uqtestfun_instance.evaluate.__name__}"
+        f"{signature(uqtestfun_instance.evaluate)}"
+    )
 
     assert uqtestfun_instance.__str__() == str_ref
 


### PR DESCRIPTION
This PR should resolve issue #37. The codebase has been updated to conform to black code style and tox has been configured to use black as the code formatter.