### PR TITLE
Add wheel and sdist building to the CI pipeline.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,3 +63,25 @@ jobs:
            run: python -m pip install tox
          - name: Run pytest
            run: tox -e ${{ matrix.python.toxenv }}
+   build_wheels:
+      name: Build wheels on ${{ matrix.os }}
+      runs-on: ${{ matrix.os }}
+      strategy:
+         matrix:
+            os:
+               - ubuntu-20.04
+               - windows-2019
+               - macOS-10.15
+      steps:
+         - uses: actions/checkout@v3
+         - uses: actions/setup-python@v4.0.0
+           with:
+              python-version: "3.10"
+         - name: Install cibuildwheel
+           run: python -m pip install cibuildwheel
+         - name: Build wheels
+           run: pyuthon -m cibuildwheel --output-dir wheels
+         - uses: actions/upload-artifact@v3
+           with:
+              path: ./wheels/*.whl
+           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,8 +74,22 @@ jobs:
          - name: Install build
            run: python -m pip install build
          - name: Build wheels
-           run: pyproject-build
+           run: python -m build --wheel
          - uses: actions/upload-artifact@v3
            with:
               path: ./dist/*.whl
-           
+   build_sdist:
+      name: Build source distribution on Ubuntu 20.04
+      runs-on: ubuntu-20.04
+      steps:
+         - uses: actions/checkout@v3
+         - uses: actions/setup-python@v4.0.0
+           with:
+              python-version: "3.10"
+         - name: Install build
+           run: python -m pip install build
+         - name: Build wheels
+           run: python -m build --sdist
+         - uses: actions/upload-artifact@v3
+           with:
+              path: ./dist/*.tar.gz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,24 +64,18 @@ jobs:
          - name: Run pytest
            run: tox -e ${{ matrix.python.toxenv }}
    build_wheels:
-      name: Build wheels on ${{ matrix.os }}
-      runs-on: ${{ matrix.os }}
-      strategy:
-         matrix:
-            os:
-               - ubuntu-20.04
-               - windows-2019
-               - macOS-10.15
+      name: Build wheels on Ubuntu 20.04
+      runs-on: ubuntu-20.04
       steps:
          - uses: actions/checkout@v3
          - uses: actions/setup-python@v4.0.0
            with:
               python-version: "3.10"
-         - name: Install cibuildwheel
-           run: python -m pip install cibuildwheel
+         - name: Install build
+           run: python -m pip install build
          - name: Build wheels
-           run: python -m cibuildwheel --output-dir wheels
+           run: pyproject-build
          - uses: actions/upload-artifact@v3
            with:
-              path: ./wheels/*.whl
+              path: ./dist/*.whl
            

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
          - name: Install cibuildwheel
            run: python -m pip install cibuildwheel
          - name: Build wheels
-           run: pyuthon -m cibuildwheel --output-dir wheels
+           run: python -m cibuildwheel --output-dir wheels
          - uses: actions/upload-artifact@v3
            with:
               path: ./wheels/*.whl


### PR DESCRIPTION
Wheel and source distribution building uses the `build` package as the package is pure Python.