### PR TITLE
Reorder the transform sample signature for consistency

### DIFF
--- a/src/uqtestfuns/core/prob_input/multivariate_input.py
+++ b/src/uqtestfuns/core/prob_input/multivariate_input.py
@@ -5,6 +5,8 @@ The MultivariateInput class represents a multivariate probabilistic input.
 Each multivariate input has a set of marginals defined by an instance of
 the UnivariateInput class.
 """
+from __future__ import annotations
+
 import numpy as np
 from tabulate import tabulate
 from typing import List, Any, Union, Tuple
@@ -40,7 +42,7 @@ class MultivariateInput:
         # Protect marginals by making it immutable
         self.marginals = tuple(self.marginals)
 
-    def transform_sample(self, other, xx: np.ndarray):
+    def transform_sample(self, xx: np.ndarray, other: MultivariateInput):
         """Transform a sample from the distribution to another."""
         # Make sure the dimensionality is consistent
         if self.spatial_dimension != other.spatial_dimension:

--- a/src/uqtestfuns/core/uqtestfun.py
+++ b/src/uqtestfuns/core/uqtestfun.py
@@ -99,7 +99,7 @@ class UQTestFun:
         )
 
         # Transform the sampled value to the function domain
-        xx_trans = canonical_input.transform_sample(self.input, xx)
+        xx_trans = canonical_input.transform_sample(xx, self.input)
 
         return xx_trans
 

--- a/tests/test_multivariate_input.py
+++ b/tests/test_multivariate_input.py
@@ -104,9 +104,7 @@ def test_transform_sample(spatial_dimension):
     marginals_2 = create_random_marginals(spatial_dimension)
     my_multivariate_input_2 = MultivariateInput(marginals_2)
 
-    xx_trans = my_multivariate_input_1.transform_sample(
-        my_multivariate_input_2, xx
-    )
+    xx_trans = my_multivariate_input_1.transform_sample(xx, my_multivariate_input_2)
 
     # Assertions
     for i, marginal in enumerate(my_multivariate_input_2.marginals):
@@ -127,7 +125,7 @@ def test_failed_transform_sample():
 
     # Transformation between two random variables of different dimensions
     with pytest.raises(ValueError):
-        my_multivariate_input_1.transform_sample(my_multivariate_input_2, xx)
+        my_multivariate_input_1.transform_sample(xx, my_multivariate_input_2)
 
 
 def test_transform_dependent_sample():
@@ -142,7 +140,7 @@ def test_transform_dependent_sample():
 
     with pytest.raises(ValueError):
         my_multivariate_input_1.copulas = "a"
-        my_multivariate_input_1.transform_sample(my_multivariate_input_2, xx)
+        my_multivariate_input_1.transform_sample(xx, my_multivariate_input_2)
 
 
 def test_str():

--- a/tests/test_multivariate_input.py
+++ b/tests/test_multivariate_input.py
@@ -104,7 +104,9 @@ def test_transform_sample(spatial_dimension):
     marginals_2 = create_random_marginals(spatial_dimension)
     my_multivariate_input_2 = MultivariateInput(marginals_2)
 
-    xx_trans = my_multivariate_input_1.transform_sample(xx, my_multivariate_input_2)
+    xx_trans = my_multivariate_input_1.transform_sample(
+        xx, my_multivariate_input_2
+    )
 
     # Assertions
     for i, marginal in enumerate(my_multivariate_input_2.marginals):


### PR DESCRIPTION
- The method 'transform_sample()' in UnivariateInput and MultivariateInput now has the same ordering of arguments.

This should resolve Issue #55.