### PR TITLE
Remove unnecessary spatial dimension info from test module

### DIFF
--- a/src/uqtestfuns/test_functions/ackley.py
+++ b/src/uqtestfuns/test_functions/ackley.py
@@ -48,9 +48,7 @@ DEFAULT_PARAMETERS = {"ackley": (20, 0.2, 2 * np.pi)}
 
 DEFAULT_PARAMETERS_SELECTION = "ackley"
 
-SPATIAL_DIMENSION = None  # Variable dimension
-
-DEFAULT_DIMENSION = 2
+DEFAULT_DIMENSION = 2  # The dimension is variable so a default is given
 
 
 def evaluate(xx: np.ndarray, params: tuple) -> np.ndarray:

--- a/src/uqtestfuns/test_functions/borehole.py
+++ b/src/uqtestfuns/test_functions/borehole.py
@@ -105,8 +105,6 @@ DEFAULT_INPUT_SELECTION = "harper"
 
 DEFAULT_PARAMETERS = None
 
-SPATIAL_DIMENSION = len(DEFAULT_INPUT_MARGINALS_1)
-
 
 def evaluate(xx: np.ndarray) -> np.ndarray:
     """Evaluate the Borehole function on a set of input values.

--- a/src/uqtestfuns/test_functions/ishigami.py
+++ b/src/uqtestfuns/test_functions/ishigami.py
@@ -56,8 +56,6 @@ DEFAULT_PARAMETERS = {
 
 DEFAULT_PARAMETERS_SELECTION = "sobol-levitan"
 
-SPATIAL_DIMENSION = len(DEFAULT_INPUT_MARGINALS)
-
 
 def evaluate(xx: np.ndarray, params: tuple) -> np.ndarray:
     """Evaluate the Ishigami function on a set of input values.

--- a/src/uqtestfuns/test_functions/wing_weight.py
+++ b/src/uqtestfuns/test_functions/wing_weight.py
@@ -89,8 +89,6 @@ DEFAULT_INPUT_SELECTION = "forrester"
 
 DEFAULT_PARAMETERS = None
 
-SPATIAL_DIMENSION = len(DEFAULT_INPUT_MARGINALS)
-
 
 def evaluate(xx: np.ndarray) -> np.ndarray:
     """Evaluate the Wing Weight function on a set of input values.


### PR DESCRIPTION
- For test functions with non-variable dimension, the number of spatial dimensions can be inferred directly.

This PR should resolve Issue #63.