### PR TITLE
Add an implementation of the OTL circuit test function

### DIFF
--- a/src/uqtestfuns/test_functions/default.py
+++ b/src/uqtestfuns/test_functions/default.py
@@ -8,7 +8,7 @@ the available built-in default values.
 from typing import Callable, Any, Optional
 from types import ModuleType
 
-from . import wing_weight, ishigami, borehole, ackley
+from . import wing_weight, ishigami, borehole, ackley, otl_circuit
 from ..core import UQTestFun, MultivariateInput
 
 __all__ = ["get_default_args", "create_from_default", "AVAILABLE_FUNCTIONS"]
@@ -20,6 +20,7 @@ AVAILABLE_FUNCTIONS = {
     ishigami.DEFAULT_NAME.lower(): ishigami,
     wing_weight.DEFAULT_NAME.lower(): wing_weight,
     ackley.DEFAULT_NAME.lower(): ackley,
+    otl_circuit.DEFAULT_NAME.lower(): otl_circuit,
 }
 
 

--- a/src/uqtestfuns/test_functions/ishigami.py
+++ b/src/uqtestfuns/test_functions/ishigami.py
@@ -15,6 +15,11 @@ References
    in Monte Carlo computations of a global sensitivity index,”
    Computer Physics Communications, vol. 117, no. 1, pp. 52–61, 1999.
    DOI:10.1016/S0010-4655(98)00156-8
+3. A. Marrel, B. Iooss, B. Laurent, and O. Roustant, "Calculations of
+   Sobol indices for the Gaussian process metamodel,”
+   Reliability Engineering & System Safety,
+   vol. 94, no. 3, pp. 742–751, 2009.
+   DOI:10.1016/j.ress.2008.07.008
 """
 import numpy as np
 
@@ -50,8 +55,8 @@ DEFAULT_INPUTS = {
 DEFAULT_INPUT_SELECTION = "ishigami"
 
 DEFAULT_PARAMETERS = {
-    "marrel": (7, 0.1),
     "sobol-levitan": (7, 0.05),  # from [2].
+    "marrel": (7, 0.1),  # from [3].
 }
 
 DEFAULT_PARAMETERS_SELECTION = "sobol-levitan"

--- a/src/uqtestfuns/test_functions/otl_circuit.py
+++ b/src/uqtestfuns/test_functions/otl_circuit.py
@@ -1,0 +1,127 @@
+"""
+Module with an implementation of the OTL circuit test function.
+
+The OTL circuit test function is a six-dimensional scalar-valued function
+that computes the mid-point voltage
+of an output transformerless (OTL) push-pull circuit.
+The function has been used as a test function in metamodeling exercises [1].
+A 20-dimensional variant was used for sensitivity analysis in [2]
+by introducing additional 14 inert input variables.
+
+References
+----------
+
+TODO: Give proper citation
+"""
+import numpy as np
+
+from copy import copy
+
+from ..core import UnivariateInput, MultivariateInput
+
+
+DEFAULT_NAME = "OTL"
+
+DEFAULT_INPUT_MARGINALS_BEN_ARI = [
+    UnivariateInput(
+        name="Rb1",
+        distribution="uniform",
+        parameters=[50.0, 150.0],
+        description="Resistance b1 [kOhm]",
+    ),
+    UnivariateInput(
+        name="Rb2",
+        distribution="uniform",
+        parameters=[25.0, 70.0],
+        description="Resistance b2 [kOhm]",
+    ),
+    UnivariateInput(
+        name="Rf",
+        distribution="uniform",
+        parameters=[0.5, 3.0],
+        description="Resistance f [kOhm]",
+    ),
+    UnivariateInput(
+        name="Rc1",
+        distribution="uniform",
+        parameters=[1.2, 2.5],
+        description="Resistance c1 [kOhm]",
+    ),
+    UnivariateInput(
+        name="Rc2",
+        distribution="uniform",
+        parameters=[0.25, 1.20],
+        description="Resistance c2 [kOhm]",
+    ),
+    UnivariateInput(
+        name="beta",
+        distribution="uniform",
+        parameters=[50.0, 300.0],
+        description="Current gain [A]",
+    ),
+]
+
+DEFAULT_INPUT_MARGINALS_MOON = [
+    copy(_) for _ in DEFAULT_INPUT_MARGINALS_BEN_ARI
+]
+for i in range(14):
+    DEFAULT_INPUT_MARGINALS_MOON.append(
+        UnivariateInput(
+            name=f"Inert {i+1}",
+            distribution="uniform",
+            parameters=[100.0, 200.0],
+            description="Inert input [-]",
+        )
+    )
+
+DEFAULT_INPUTS = {
+    "ben-ari": MultivariateInput(DEFAULT_INPUT_MARGINALS_BEN_ARI),
+    "moon": MultivariateInput(DEFAULT_INPUT_MARGINALS_MOON),
+}
+
+DEFAULT_INPUT_SELECTION = "ben-ari"
+
+DEFAULT_PARAMETERS = None
+
+
+def evaluate(xx: np.ndarray) -> np.ndarray:
+    """Evaluate the OTL circuit test function on a set of input values.
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        (At least) 6-dimensional input values given by N-by-6 arrays
+        where N is the number of input values.
+
+    Returns
+    -------
+    np.ndarray
+        The output of the OTL circuit test function,
+        i.e., the mid-point voltage in Volt.
+        The output is a one-dimensional array of length N.
+
+    Notes
+    -----
+    - The variant of this test function has 14 additional inputs,
+      but they are all taken to be inert and therefore should not affect
+      the output.
+    """
+    rr_b1 = xx[:, 0]  # Resistance b1
+    rr_b2 = xx[:, 1]  # Resistance b2
+    rr_f = xx[:, 2]  # Resistance f
+    rr_c1 = xx[:, 3]  # Resistance c1
+    rr_c2 = xx[:, 4]  # Resistance c2
+    beta = xx[:, 5]  # Current gain
+
+    # Compute the voltage across b1
+    vb1 = 12 * rr_b1 / (rr_b1 + rr_b2)
+
+    # Compute the mid-point voltage
+    denom = beta * (rr_c2 + 9) + rr_f
+    term_1 = ((vb1 + 0.74) * beta * (rr_c2 + 9)) / denom
+    term_2 = 11.35 * rr_f / denom
+    term_3 = 0.74 * rr_f * beta * (rr_c2 + 9) / (rr_c1 * denom)
+
+    vm = term_1 + term_2 + term_3
+
+    return vm

--- a/tests/test_otl_circuit.py
+++ b/tests/test_otl_circuit.py
@@ -1,0 +1,31 @@
+"""
+Test module for the OTL circuit test function.
+
+Notes
+-----
+- The tests defined in this module deals with the correctness
+  of the evaluation of this particular test function.
+"""
+import numpy as np
+
+from uqtestfuns import create_from_default
+
+
+def test_inert_inputs():
+    """Test whether the inputs from 'Moon' specification are indeed inert."""
+    otl_ben_ari = create_from_default("otl", input_selection="ben-ari")
+    otl_moon = create_from_default("otl", input_selection="moon")
+
+    # Generate sample and compare both
+    num_sample = 1000000
+    xx_otl_ben_ari = otl_ben_ari.input.get_sample(num_sample)
+    xx_otl_moon = otl_moon.input.get_sample(num_sample)
+
+    yy_otl_ben_ari = otl_ben_ari(xx_otl_ben_ari)
+    yy_otl_moon = otl_moon(xx_otl_moon)
+
+    # Assertions
+    assert np.allclose(
+        np.mean(yy_otl_moon), np.mean(yy_otl_ben_ari), rtol=1e-2
+    )
+    assert np.allclose(np.var(yy_otl_moon), np.var(yy_otl_ben_ari), rtol=1e-2)


### PR DESCRIPTION
- The six-dimensional and its 20-dimensional variant OTL circuit test function has been added.
- The test suite has been expanded to verify whether the 14 inert inputs in the 20-dimensional variant are indeed inert.

This PR should resolve Issue #52.