### PR TITLE
Add truncated Gumbel distribution

### DIFF
--- a/src/uqtestfuns/core/prob_input/univariate_distributions/trunc_gumbel.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/trunc_gumbel.py
@@ -1,0 +1,286 @@
+"""
+Module with routines involving the truncated Gumbel (max.) probability dist.
+
+The truncated Gumbel (max.) distribution in UQTestFuns is parameterized by
+four parameters: ``mu``, ``beta``, ``lb``, and ``ub`` that correspond to
+the mode, the scale, lower bound, and upper bound, respectively.
+
+The underlying implementation is based on the re-implementation of regular
+Gumbel (max.) distribution in UQTestFuns (which in turn, based on scipy.stats).
+"""
+import numpy as np
+
+from scipy.stats import gumbel_r
+from typing import Tuple
+
+from . import gumbel
+from ....global_settings import ARRAY_FLOAT
+
+DISTRIBUTION_NAME = "trunc-gumbel"
+
+
+def _get_parameters(
+    parameters: ARRAY_FLOAT,
+) -> Tuple[float, float, float, float]:
+    """Get the parameters of a truncated Gumbel (max.) distribution.
+
+    Parameters
+    ----------
+    parameters : ARRAY_FLOAT
+        The parameters of a truncated Gumbel (max.) distribution.
+
+    Returns
+    -------
+    Tuple[float, float, float, float]
+        The mode (mu), scale (beta) lower bound, and upper bound
+        of the truncated Gumbel (max.) distribution
+        (in that order, as a tuple).
+    """
+    mu = float(parameters[0])
+    beta = float(parameters[1])
+    lb = float(parameters[2])
+    ub = float(parameters[3])
+
+    return mu, beta, lb, ub
+
+
+def _compute_normalizing_factor(parameters: ARRAY_FLOAT) -> float:
+    """Compute the normalizing factor of the truncated distribution.
+
+    Parameters
+    ----------
+    parameters : ARRAY_FLOAT
+        The parameters of a truncated Gumbel (max.) distribution.
+
+    Returns
+    -------
+    float
+        The normalizing factor for the truncated distribution.
+    """
+    mu, beta, lb, ub = _get_parameters(parameters)
+
+    lb_quantile = gumbel_r.cdf(lb, loc=mu, scale=beta)
+    ub_quantile = gumbel_r.cdf(ub, loc=mu, scale=beta)
+
+    normalizing_factor = ub_quantile - lb_quantile
+
+    return normalizing_factor
+
+
+def verify_parameters(parameters: ARRAY_FLOAT) -> None:
+    """Verify the parameters of a truncated Gumbel (max.) distribution."""
+    # Check overall shape
+    if parameters.size != 4:
+        raise ValueError(
+            f"A truncated Gumbel (max.) distribution requires four parameters!"
+            f"Expected 4, got {parameters.size}."
+        )
+
+    mu, beta, lb, ub = _get_parameters(parameters)
+
+    # Verify the first two parameters
+    gumbel.verify_parameters(parameters[:2])
+
+    # Check the validity of the parameter values w.r.t the bounds
+    if lb >= ub:
+        raise ValueError(
+            f"The lower bound of a truncated Gumbel (max.) distribution {lb} "
+            f"cannot be equal or greater than the upper bound {ub}!"
+        )
+
+    if mu > ub or mu < lb:
+        raise ValueError(
+            f"The mode of a truncated Gumbel distribution (max.) {mu} "
+            f"must be between the bounds [{lb}, {ub}]!"
+        )
+
+
+def lower(parameters: ARRAY_FLOAT) -> float:
+    """Get the lower bound of a truncated Gumbel (max.) distribution.
+
+    Parameters
+    ----------
+    parameters : ARRAY_FLOAT
+        The parameters of a truncated Gumbel (max.) distribution.
+
+    Returns
+    -------
+    float
+        The lower bound of the truncated Gumbel (max.) distribution.
+    """
+    _, _, lower_bound, _ = _get_parameters(parameters)
+
+    return lower_bound
+
+
+def upper(parameters: ARRAY_FLOAT) -> float:
+    """Get the upper bound of a truncated Gumbel (max.) distribution.
+
+    Parameters
+    ----------
+    parameters : ARRAY_FLOAT
+        The parameters of a truncated Gumbel (max.) distribution.
+
+    Returns
+    -------
+    float
+        The upper bound of the truncated Gumbel (max.) distribution.
+    """
+    _, _, _, upper_bound = _get_parameters(parameters)
+
+    return upper_bound
+
+
+def pdf(
+    xx: ARRAY_FLOAT,
+    parameters: ARRAY_FLOAT,
+    lower_bound: float,
+    upper_bound: float,
+) -> ARRAY_FLOAT:
+    """Get the PDF values of a truncated Gumbel (max.) distribution.
+
+    Parameters
+    ----------
+    xx : ARRAY_FLOAT
+        Sample values (realizations) of a truncated Gumbel (max.) distribution.
+    parameters : ARRAY_FLOAT
+        Parameters of the truncated Gumbel (max.) distribution.
+    lower_bound : float
+        Lower bound of the truncated Gumbel (max.) distribution.
+    upper_bound : float
+        Upper bound of the truncated Gumbel (max.) distribution.
+
+    Returns
+    -------
+    ARRAY_FLOAT
+        PDF values of the truncated Gumbel (max.) distribution
+        on the sample values.
+
+    Notes
+    -----
+    - The values outside the bounds are set to 0.0.
+    - ``lower_bound`` and ``upper_bound`` in the function parameters are the
+      same as the ones in ``parameters``. For a truncated Gumbel (max.)
+      distribution, the bounds are part of the parameterization.
+    """
+    # Get the parameters
+    mu, beta, _, _ = _get_parameters(parameters)
+
+    # Get the non-zero indices (within the bounds)
+    idx_non_zero = np.logical_and(xx >= lower_bound, xx <= upper_bound)
+
+    # Compute the normalizing factor
+    normalizing_factor = _compute_normalizing_factor(parameters)
+
+    # Compute the PDF
+    yy = np.zeros(xx.shape)
+    yy[idx_non_zero] = gumbel_r.pdf(xx[idx_non_zero], loc=mu, scale=beta)
+    yy[idx_non_zero] = yy[idx_non_zero] / normalizing_factor
+
+    return yy
+
+
+def cdf(
+    xx: ARRAY_FLOAT,
+    parameters: ARRAY_FLOAT,
+    lower_bound: float,
+    upper_bound: float,
+) -> ARRAY_FLOAT:
+    """Get the CDF values of the truncated Gumbel (max.) distribution.
+
+    Parameters
+    ----------
+    xx : ARRAY_FLOAT
+        Sample values (realizations) of a truncated Gumbel (max.) distribution.
+    parameters : ARRAY_FLOAT
+        Parameters of the truncated Gumbel (max.) distribution.
+    lower_bound : float
+        Lower bound of the truncated Gumbel (max.) distribution.
+    upper_bound : float
+        Upper bound of the truncated Gumbel (max.) distribution.
+
+    Returns
+    -------
+    ARRAY_FLOAT
+        CDF values of the truncated Gumbel (max.) distribution
+        on the sample values.
+
+    Notes
+    -----
+    - CDF for sample with values smaller (resp. larger) than the lower bound
+      (resp. upper bound) are set to 0.0 (resp. 1.0).
+    - ``lower_bound`` and ``upper_bound`` in the function parameters are the
+      same as the ones in ``parameters``. For a truncated Gumbel (max.)
+      distribution, the bounds are part of the parameterization.
+    """
+    # Get the parameters
+    mu, beta, _, _ = _get_parameters(parameters)
+
+    # Get the relevant indices
+    idx_lower = xx < lower_bound
+    idx_upper = xx > upper_bound
+    idx_rest = np.logical_and(
+        np.logical_not(idx_lower), np.logical_not(idx_upper)
+    )
+
+    # Compute the normalizing factor
+    normalizing_factor = _compute_normalizing_factor(parameters)
+
+    # Compute the CDF
+    yy = np.empty(xx.shape)
+    yy[idx_lower] = 0.0
+    yy[idx_upper] = 1.0
+    yy[idx_rest] = gumbel_r.cdf(xx[idx_rest], loc=mu, scale=beta)
+    yy[idx_rest] = yy[idx_rest] - gumbel_r.cdf(lower_bound, loc=mu, scale=beta)
+    yy[idx_rest] = yy[idx_rest] / normalizing_factor
+
+    return yy
+
+
+def icdf(
+    xx: ARRAY_FLOAT,
+    parameters: ARRAY_FLOAT,
+    lower_bound: float,
+    upper_bound: float,
+) -> ARRAY_FLOAT:
+    """Get the inverse CDF values of a truncated Gumbel (max.) distribution.
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        Sample values (realizations) in the [0, 1] domain.
+    parameters : np.ndarray
+        Parameters of a truncated Gumbel (max.) distribution.
+    lower_bound : float
+        Lower bound of the truncated Gumbel (max.) distribution.
+    upper_bound : float
+        Upper bound of the truncated Gumbel (max.) distribution.
+
+    Returns
+    -------
+    ARRAY_FLOAT
+        Transformed values in the domain of the truncated Gumbel (max.)
+        distribution.
+
+    Notes
+    -----
+    - ICDF for sample with values of 0.0 and 1.0 are automatically set to the
+      lower bound and upper bound, respectively.
+    - ``lower_bound`` and ``upper_bound`` in the function parameters are the
+      same as the ones in ``parameters``. For a truncated  Gumbel (max.)
+      distribution, the bounds are part of the parameterization.
+    TODO: values outside [0, 1] must either be an error or NaN
+    """
+    # Get the parameters
+    mu, beta, _, _ = _get_parameters(parameters)
+
+    # Compute the normalizing factor
+    normalizing_factor = _compute_normalizing_factor(parameters)
+
+    # Compute the ICDF
+    cdf_values = (
+        gumbel_r.cdf(lower_bound, loc=mu, scale=beta) + normalizing_factor * xx
+    )
+    yy = gumbel_r.ppf(cdf_values, loc=mu, scale=beta)
+
+    return yy

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/trunc_normal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/trunc_normal.py
@@ -39,7 +39,7 @@ from typing import Tuple
 
 from ....global_settings import ARRAY_FLOAT
 
-DISTRIBUTION_NAME = "truncnormal"
+DISTRIBUTION_NAME = "trunc-normal"
 
 
 def _get_parameters(

--- a/src/uqtestfuns/core/prob_input/utils.py
+++ b/src/uqtestfuns/core/prob_input/utils.py
@@ -11,7 +11,8 @@ from .univariate_distributions import (
     gumbel,
     lognormal,
     triangular,
-    truncnormal,
+    trunc_gumbel,
+    trunc_normal,
     logitnormal,
     uniform,
 )
@@ -23,7 +24,8 @@ SUPPORTED_MARGINALS = {
     normal.DISTRIBUTION_NAME: normal,
     gumbel.DISTRIBUTION_NAME: gumbel,
     triangular.DISTRIBUTION_NAME: triangular,
-    truncnormal.DISTRIBUTION_NAME: truncnormal,
+    trunc_gumbel.DISTRIBUTION_NAME: trunc_gumbel,
+    trunc_normal.DISTRIBUTION_NAME: trunc_normal,
     logitnormal.DISTRIBUTION_NAME: logitnormal,
     uniform.DISTRIBUTION_NAME: uniform,
 }

--- a/src/uqtestfuns/meta/uqmetatestfun.py
+++ b/src/uqtestfuns/meta/uqmetatestfun.py
@@ -200,7 +200,7 @@ class UQMetaTestFun:
         input_marginals = [
             UnivariateInput(distribution="uniform", parameters=[0, 1]),
             UnivariateInput(
-                distribution="truncnormal",
+                distribution="trunc-normal",
                 parameters=[0.5, 0.15, 0.0, 1.0],
             ),
             UnivariateInput(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,11 +60,11 @@ def create_random_marginals(length: int) -> List[UnivariateInput]:
             parameters = np.insert(
                 parameters, 2, np.random.uniform(parameters[0], parameters[1])
             )
-        elif distribution == "truncnormal":
+        elif distribution in ["trunc-normal", "trunc-gumbel"]:
             # mu must be inside the bounds
             parameters = np.sort(1 + 2 * np.random.rand(3))
             parameters[[0, 1]] = parameters[[1, 0]]
-            # Insert sigma as the second parameter
+            # Insert sigma/beta as the second parameter
             parameters = np.insert(parameters, 1, np.random.rand(1))
         elif distribution == "lognormal":
             # Limit the size of the parameters

--- a/tests/test_univariate_gumbel.py
+++ b/tests/test_univariate_gumbel.py
@@ -6,13 +6,50 @@ import pytest
 import numpy as np
 
 from uqtestfuns.core.prob_input.univariate_input import UnivariateInput
+from uqtestfuns.global_settings import ARRAY_FLOAT
 from conftest import create_random_alphanumeric
+
+DISTRIBUTION_NAME = "gumbel"
+
+
+def _calc_mean(parameters: ARRAY_FLOAT) -> float:
+    """Compute the analytical mean of a Gumbel (max.) distribution."""
+    mu, beta = parameters[:]
+
+    mean = mu + beta * np.euler_gamma
+
+    return mean
+
+
+def _calc_mode(parameters: ARRAY_FLOAT) -> float:
+    """Compute the analytical mode of a Gumbel (max.) distribution."""
+    mu, _ = parameters[:]
+
+    return mu
+
+
+def _calc_median(parameters: ARRAY_FLOAT) -> float:
+    """Compute the analytical median of a Gumbel (max.) distribution."""
+    mu, beta = parameters[:]
+
+    median = mu - beta * np.log(np.log(2))
+
+    return median
+
+
+def _calc_variance(parameters: ARRAY_FLOAT) -> float:
+    """Compute the analytical variance of a Gumbel (max.) distribution."""
+    mu, beta = parameters[:]
+
+    var = np.pi**2 / 6.0 * beta**2
+
+    return var
 
 
 def test_wrong_number_of_parameters() -> None:
     """Test the failure of specifying wrong number of parameters."""
     name = create_random_alphanumeric(5)
-    distribution = "gumbel"
+    distribution = DISTRIBUTION_NAME
     # Gumbel distribution expects 2 parameters not 5!
     parameters = np.sort(np.random.rand(5))
 
@@ -25,7 +62,7 @@ def test_wrong_number_of_parameters() -> None:
 def test_failed_parameter_verification() -> None:
     """Test the failure of specifying invalid parameter values."""
     name = create_random_alphanumeric(10)
-    distribution = "gumbel"
+    distribution = DISTRIBUTION_NAME
     # The 2nd parameter of the Gumbel (max.) dist. must be strictly positive!
     parameters = [7.71, -5.0]
 
@@ -33,3 +70,100 @@ def test_failed_parameter_verification() -> None:
         UnivariateInput(
             name=name, distribution=distribution, parameters=parameters
         )
+
+
+def test_estimate_mean() -> None:
+    """Test the mean estimation of a Gumbel (max.) distribution."""
+    # Create a set of random parameters
+    parameters = np.sort(1 + 5 * np.random.rand(2))
+
+    # Create an instance
+    my_univariate_input = UnivariateInput(
+        distribution=DISTRIBUTION_NAME, parameters=parameters
+    )
+
+    # Generate a sample
+    sample_size = 100000  # Should give 1e-2 accuracy
+    xx = my_univariate_input.get_sample(sample_size)
+
+    # Estimated result
+    mean = np.mean(xx)
+
+    # Analytical result
+    mean_ref = _calc_mean(parameters)
+
+    # Assertion
+    assert np.isclose(mean, mean_ref, rtol=1e-2, atol=1e-2)
+
+
+def test_estimate_variance() -> None:
+    """Test the variance estimation of a Gumbel (max.) distribution."""
+    # Create a set of random parameters
+    parameters = np.sort(1 + 5 * np.random.rand(2))
+
+    # Create an instance
+    my_univariate_input = UnivariateInput(
+        distribution=DISTRIBUTION_NAME, parameters=parameters
+    )
+
+    # Generate a sample
+    sample_size = 100000  # Should give 1e-2 accuracy
+    xx = my_univariate_input.get_sample(sample_size)
+
+    # Estimated result
+    var = np.var(xx)
+
+    # Analytical result
+    var_ref = _calc_variance(parameters)
+
+    # Assertion
+    assert np.isclose(var, var_ref, rtol=1e-2, atol=1e-2)
+
+
+def test_estimate_median() -> None:
+    """Test the median estimation of a Gumbel (max.) distribution."""
+    # Create a set of random parameters
+    parameters = np.sort(1 + 5 * np.random.rand(2))
+
+    # Create an instance
+    my_univariate_input = UnivariateInput(
+        distribution=DISTRIBUTION_NAME, parameters=parameters
+    )
+
+    # Generate a sample
+    sample_size = 100000  # Should give 1e-2 accuracy
+    xx = my_univariate_input.get_sample(sample_size)
+
+    # Estimated result
+    median = np.median(xx)
+
+    # Analytical result
+    median_ref = _calc_median(parameters)
+
+    # Assertion
+    assert np.isclose(median, median_ref, rtol=1e-2, atol=1e-2)
+
+
+def test_estimate_mode() -> None:
+    """Test the mode estimation of a Gumbel (max.) distribution."""
+    # Create a set of random parameters
+    parameters = np.sort(1 + 5 * np.random.rand(2))
+
+    # Create an instance
+    my_univariate_input = UnivariateInput(
+        distribution=DISTRIBUTION_NAME, parameters=parameters
+    )
+
+    # Generate a sample
+    sample_size = 1000000  # Should give 1e-0 accuracy
+    xx = my_univariate_input.get_sample(sample_size)
+
+    # Estimated result
+    y, edges = np.histogram(xx, bins="auto")
+    mode = edges[np.argmax(y)]
+
+    # Analytical result
+    mode_ref = _calc_mode(parameters)
+
+    # Assertion
+    assert np.isclose(mode, mode_ref, rtol=1, atol=1)

--- a/tests/test_univariate_input.py
+++ b/tests/test_univariate_input.py
@@ -32,7 +32,7 @@ def univariate_input(
         parameters = np.insert(
             parameters, 2, np.random.uniform(parameters[0], parameters[1])
         )
-    elif distribution == "truncnormal":
+    elif distribution in ["trunc-normal", "trunc-gumbel"]:
         # mu must be inside the bounds
         parameters = np.sort(1 + 2 * np.random.rand(3))
         parameters[[0, 1]] = parameters[[1, 0]]

--- a/tests/test_univariate_triangular.py
+++ b/tests/test_univariate_triangular.py
@@ -7,30 +7,30 @@ import numpy as np
 from uqtestfuns.core.prob_input.univariate_input import UnivariateInput
 from conftest import create_random_alphanumeric
 
+DISTRIBUTION_NAME = "triangular"
+
 
 def test_wrong_number_of_parameters() -> None:
     """Test the failure of specifying wrong number of parameters."""
     name = create_random_alphanumeric(5)
-    distribution = "triangular"
-    # Normal distribution expects 3 parameters not 10!
+    # A triangular distribution expects 3 parameters not 10!
     parameters = np.sort(np.random.rand(10))
 
     with pytest.raises(ValueError):
         UnivariateInput(
-            name=name, distribution=distribution, parameters=parameters
+            name=name, distribution=DISTRIBUTION_NAME, parameters=parameters
         )
 
 
 def test_failed_parameter_verification() -> None:
     """Test the failure of specifying invalid parameter values."""
     name = create_random_alphanumeric(10)
-    distribution = "triangular"
     # The lower bound must be smaller than the upper bound!
     parameters = [5, 1, 3]
 
     with pytest.raises(ValueError):
         UnivariateInput(
-            name=name, distribution=distribution, parameters=parameters
+            name=name, distribution=DISTRIBUTION_NAME, parameters=parameters
         )
 
     # The mid-point value must be between lower and upper bounds!
@@ -38,5 +38,31 @@ def test_failed_parameter_verification() -> None:
 
     with pytest.raises(ValueError):
         UnivariateInput(
-            name=name, distribution=distribution, parameters=parameters
+            name=name, distribution=DISTRIBUTION_NAME, parameters=parameters
         )
+
+
+def test_estimate_mode() -> None:
+    """Test the mode estimation of a Gumbel (max.) distribution."""
+    # Create a set of random parameters
+    parameters = np.sort(1 + 5 * np.random.rand(3))
+    parameters[[2, 1]] = parameters[[1, 2]]
+
+    # Create an instance
+    my_univariate_input = UnivariateInput(
+        distribution=DISTRIBUTION_NAME, parameters=parameters
+    )
+
+    # Generate a sample
+    sample_size = 1000000  # Should give 1e-0 accuracy
+    xx = my_univariate_input.get_sample(sample_size)
+
+    # Estimated result
+    y, edges = np.histogram(xx, bins="auto")
+    mode = edges[np.argmax(y)]
+
+    # Analytical result
+    mode_ref = parameters[2]
+
+    # Assertion
+    assert np.isclose(mode, mode_ref, rtol=1, atol=1)

--- a/tests/test_univariate_trunc_gumbel.py
+++ b/tests/test_univariate_trunc_gumbel.py
@@ -1,0 +1,154 @@
+"""
+Test module for UnivariateInput instances with a truncated Gumbel (max.) dist.
+"""
+import pytest
+import numpy as np
+import scipy.integrate as integrate
+
+from scipy.stats import gumbel_r
+
+from uqtestfuns.core.prob_input.univariate_input import UnivariateInput
+from uqtestfuns.global_settings import ARRAY_FLOAT
+from conftest import create_random_alphanumeric
+
+
+DISTRIBUTION_NAME = "trunc-gumbel"
+
+
+def _calc_median(parameters: ARRAY_FLOAT) -> float:
+    """Compute the analytical median of a given trunc. Gumbel (max.) dist."""
+    mu, beta, lb, ub = parameters[:]
+
+    lb_quantile = gumbel_r.cdf(lb, loc=mu, scale=beta)
+    ub_quantile = gumbel_r.cdf(ub, loc=mu, scale=beta)
+
+    median = gumbel_r.ppf(
+        (lb_quantile + ub_quantile) / 2.0, loc=mu, scale=beta
+    )
+
+    return float(median)
+
+
+def _calc_mode(parameters: ARRAY_FLOAT) -> float:
+    """Compute the analytical mode of a Gumbel (max.) distribution."""
+    mu, _, _, _ = parameters[:]
+
+    return mu
+
+
+def _calc_mean(parameters: ARRAY_FLOAT) -> float:
+    """Compute the mean of a truncated Gumbel (max.) distribution.
+
+    Notes
+    -----
+    - The computation is carried via numerical integration.
+    """
+    mu, beta, lb, ub = parameters[:]
+
+    def _integrand(x):
+        return gumbel_r.pdf(x, loc=mu, scale=beta) * x
+
+    lb_quantile = gumbel_r.cdf(lb, loc=mu, scale=beta)
+    ub_quantile = gumbel_r.cdf(ub, loc=mu, scale=beta)
+    normalizing_factor = ub_quantile - lb_quantile
+
+    mean = integrate.quad(_integrand, lb, ub)[0] / normalizing_factor
+
+    return mean
+
+
+def test_wrong_number_of_parameters() -> None:
+    """Test the failure of specifying wrong number of parameters."""
+    name = create_random_alphanumeric(5)
+    distribution = DISTRIBUTION_NAME
+    # Gumbel distribution expects 4 parameters not 5!
+    parameters = np.sort(np.random.rand(5))
+
+    with pytest.raises(ValueError):
+        UnivariateInput(
+            name=name, distribution=distribution, parameters=parameters
+        )
+
+
+def test_failed_parameter_verification() -> None:
+    """Test the failure of specifying invalid parameter values."""
+    name = create_random_alphanumeric(10)
+    distribution = DISTRIBUTION_NAME
+    # The 2nd parameter of the Gumbel (max.) dist. must be strictly positive!
+    parameters = [7.71, -5.0, 0, 10]
+
+    with pytest.raises(ValueError):
+        UnivariateInput(
+            name=name, distribution=distribution, parameters=parameters
+        )
+
+    # The 1st parameter of the Gumbel (max.) dist. must be within the bounds!
+    parameters = [7.71, 0.5, 0, 5]
+
+    with pytest.raises(ValueError):
+        UnivariateInput(
+            name=name, distribution=distribution, parameters=parameters
+        )
+
+    # The lower bound is larger than the upper bound!
+    parameters = [2.71, 0.5, 5, 0]
+
+    with pytest.raises(ValueError):
+        UnivariateInput(
+            name=name, distribution=distribution, parameters=parameters
+        )
+
+
+def test_estimate_mode() -> None:
+    """Test the mode estimation of a Gumbel (max.) distribution."""
+    # Create a set of random parameters
+    parameters = np.sort(1 + 5 * np.random.rand(3))
+    parameters[[0, 1]] = parameters[[1, 0]]
+    # Insert beta as the second parameter
+    parameters = np.insert(parameters, 1, np.random.rand(1))
+
+    # Create an instance
+    my_univariate_input = UnivariateInput(
+        distribution=DISTRIBUTION_NAME, parameters=parameters
+    )
+
+    # Generate a sample
+    sample_size = 1000000  # Should give 1e-0 accuracy
+    xx = my_univariate_input.get_sample(sample_size)
+
+    # Estimated result
+    y, edges = np.histogram(xx, bins="auto")
+    mode = edges[np.argmax(y)]
+
+    # Analytical result
+    mode_ref = _calc_mode(parameters)
+
+    # Assertion
+    assert np.isclose(mode, mode_ref, rtol=1, atol=1)
+
+
+def test_estimate_median() -> None:
+    """Test the median estimation of a Gumbel (max.) distribution."""
+    # Create a set of random parameters
+    parameters = np.sort(1 + 5 * np.random.rand(3))
+    parameters[[0, 1]] = parameters[[1, 0]]
+    # Insert beta as the second parameter
+    parameters = np.insert(parameters, 1, np.random.rand(1))
+
+    # Create an instance
+    my_univariate_input = UnivariateInput(
+        distribution=DISTRIBUTION_NAME, parameters=parameters
+    )
+
+    # Generate a sample
+    sample_size = 100000  # Should give 1e-2 accuracy
+    xx = my_univariate_input.get_sample(sample_size)
+
+    # Estimated result
+    median = np.median(xx)
+
+    # Analytical result
+    median_ref = _calc_median(parameters)
+
+    # Assertion
+    assert np.isclose(median, median_ref, rtol=1e-2, atol=1e-2)

--- a/tests/test_univariate_trunc_normal.py
+++ b/tests/test_univariate_trunc_normal.py
@@ -11,7 +11,7 @@ from uqtestfuns.global_settings import ARRAY_FLOAT
 from conftest import create_random_alphanumeric
 
 
-DISTRIBUTION_NAME = "truncnormal"
+DISTRIBUTION_NAME = "trunc-normal"
 
 
 def _calc_mean(parameters: ARRAY_FLOAT) -> float:


### PR DESCRIPTION
- The truncated Gumbel (max.) distribution type has been added for the UnivariateType.
- The test suite has been accordingly extended.
- 'truncnorm' distribution has been renamed to 'trunc-norm'.
- The test suite for the Gumbel (max.) and triangular distributions has been extended to include the estimation of moments.

This PR should resolve Issue #82.