### PR TITLE
Fix issue with CDF/ICDF values at the tails

### DIFF
--- a/src/uqtestfuns/core/prob_input/univariate_distributions/lognormal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/lognormal.py
@@ -101,10 +101,14 @@ def upper(parameters: ARRAY_FLOAT) -> float:
     - Strictly speaking, a lognormal distribution is unbounded on the right.
       However, for numerical reason an upper bound is set.
     - The upper bound of the lognormal distribution is chosen such that
-      the difference between 1.0 and the CDF from the lower bound to the upper
-      bound is smaller than 1e-15.
+      the probability mass between 0.0 (the lower bound) and the upper bound
+      is at least 1 - 1e-15.
     """
-    upper_bound = float(np.exp(8.22 * parameters[1] + parameters[0]))
+    # 8.209536151601387 is the quantile values with probability of 1-1e-16
+    # for the corresponding standard Normal dist. (mu = 0.0, beta = 1.0)
+    upper_bound = float(
+        np.exp(8.209536151601387 * parameters[1] + parameters[0])
+    )
 
     return upper_bound
 
@@ -219,7 +223,6 @@ def icdf(
     -----
     - ICDF for sample with values of 0.0 and 1.0 are automatically set to the
       lower bound and upper bound, respectively.
-
     """
     yy = np.zeros(xx.shape)
     idx_lower = xx == 0.0

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/normal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/normal.py
@@ -67,10 +67,12 @@ def lower(parameters: ARRAY_FLOAT) -> float:
     - Strictly speaking, a normal distribution is unbounded on the left.
       However, for numerical reason a lower bound is set.
     - The lower bound of the normal distribution is chosen such that
-      the difference between 1.0 and the CDF from the lower bound to the upper
-      bound is smaller than 1e-15.
+      the probability mass between the lower and upper bound is at least
+      1 - 1e.15.
     """
-    lower_bound = float(-8.22 * parameters[1] + parameters[0])
+    # -8.222082216130435 is the quantile values with probability of 1e-16
+    # for the standard Normal distribution (mu = 0.0, sigma = 1.0)
+    lower_bound = float(-8.222082216130435 * parameters[1] + parameters[0])
 
     return lower_bound
 
@@ -93,10 +95,12 @@ def upper(parameters: ARRAY_FLOAT) -> float:
     - Strictly speaking, a normal distribution is unbounded on the right.
       However, for numerical reason an upper bound is set.
     - The upper bound of the normal distribution is chosen such that
-      the difference between 1.0 and the CDF from the lower bound to the upper
-      bound is smaller than 1e-15.
+      tbe probability mass between the lower and upper bound is at least
+      1 - 1e-15.
     """
-    upper_bound = float(8.22 * parameters[1] + parameters[0])
+    # 8.209536151601387 is the quantile values with probability of 1-1e-16
+    # for the standard Normal distribution (mu = 0.0, sigma = 1.0)
+    upper_bound = float(8.209536151601387 * parameters[1] + parameters[0])
 
     return upper_bound
 

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/trunc_gumbel.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/trunc_gumbel.py
@@ -48,7 +48,7 @@ def _compute_normalizing_factor(
     mu: float,
     beta: float,
     lb: float,
-    ub: float
+    ub: float,
 ) -> float:
     """Compute the normalizing factor of the truncated distribution.
 

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/trunc_normal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/trunc_normal.py
@@ -190,19 +190,22 @@ def pdf(
     Notes
     -----
     - The values outside the bounds are set to 0.0.
-    - ``lower_bound`` and ``upper_bound`` in the function parameters are the
-      same as the ones in ``parameters``. For a truncated normal distribution,
-      the bounds are part of the parameterization.
+    - ``lower_bound`` and ``upper_bound`` in the function parameters may not
+      be the same as the ones in ``parameters`` as the former are already
+      processed setting the numerical bounds when the given bounds are outside
+      them.
     """
     yy = np.zeros(xx.shape)
     idx = np.logical_and(xx >= lower_bound, xx <= upper_bound)
 
-    mu, sigma, lb_param, ub_param = _get_parameters(parameters)
+    # NOTE: Don't use the original bounds as "lower_bound" and "upper_bound"
+    # may have been further truncated for numerical reason.
+    mu, sigma, _, _ = _get_parameters(parameters)
 
     yy[idx] = truncnorm.pdf(
         xx[idx],
-        a=(lb_param - mu) / sigma,
-        b=(ub_param - mu) / sigma,
+        a=(lower_bound - mu) / sigma,
+        b=(upper_bound - mu) / sigma,
         loc=mu,
         scale=sigma,
     )
@@ -238,9 +241,10 @@ def cdf(
     -----
     - CDF for sample with values smaller (resp. larger) than the lower bound
       (resp. upper bound) are set to 0.0 (resp. 1.0).
-    - ``lower_bound`` and ``upper_bound`` in the function parameters are the
-      same as the ones in ``parameters``. For a truncated normal distribution,
-      the bounds are part of the parameterization.
+    - ``lower_bound`` and ``upper_bound`` in the function parameters may not
+      be the same as the ones in ``parameters`` as the former are already
+      processed setting the numerical bounds when the given bounds are outside
+      them.
     """
     yy = np.empty(xx.shape)
     idx_lower = xx < lower_bound
@@ -249,14 +253,16 @@ def cdf(
         np.logical_not(idx_lower), np.logical_not(idx_upper)
     )
 
-    mu, sigma, lb_param, ub_param = _get_parameters(parameters)
+    # NOTE: Don't use the original bounds as "lower_bound" and "upper_bound"
+    # may have been further truncated for numerical reason.
+    mu, sigma, _, _ = _get_parameters(parameters)
 
     yy[idx_lower] = 0.0
     yy[idx_upper] = 1.0
     yy[idx_rest] = truncnorm.cdf(
         xx[idx_rest],
-        a=(lb_param - mu) / sigma,
-        b=(ub_param - mu) / sigma,
+        a=(lower_bound - mu) / sigma,
+        b=(upper_bound - mu) / sigma,
         loc=mu,
         scale=sigma,
     )
@@ -292,9 +298,10 @@ def icdf(
     -----
     - ICDF for sample with values of 0.0 and 1.0 are automatically set to the
       lower bound and upper bound, respectively.
-    - ``lower_bound`` and ``upper_bound`` in the function parameters are the
-      same as the ones in ``parameters``. For a truncated normal distribution,
-      the bounds are part of the parameterization.
+    - ``lower_bound`` and ``upper_bound`` in the function parameters may not
+      be the same as the ones in ``parameters`` as the former are already
+      processed setting the numerical bounds when the given bounds are outside
+      them.
     TODO: values outside [0, 1] must either be an error or NaN
     """
     yy = np.zeros(xx.shape)

--- a/tests/test_test_functions.py
+++ b/tests/test_test_functions.py
@@ -56,7 +56,7 @@ def test_call_instance(default_testfun):
 
     testfun, _ = default_testfun
 
-    xx = np.random.rand(10, testfun.spatial_dimension)
+    xx = testfun.input.get_sample(10)
 
     # Assertions
     assert_call(testfun, xx)

--- a/tests/test_univariate_gumbel.py
+++ b/tests/test_univariate_gumbel.py
@@ -107,7 +107,7 @@ def test_estimate_variance() -> None:
     )
 
     # Generate a sample
-    sample_size = 100000  # Should give 1e-2 accuracy
+    sample_size = 1000000  # Should give 1e-2 accuracy
     xx = my_univariate_input.get_sample(sample_size)
 
     # Estimated result

--- a/tests/test_univariate_trunc_gumbel.py
+++ b/tests/test_univariate_trunc_gumbel.py
@@ -152,3 +152,49 @@ def test_estimate_median() -> None:
 
     # Assertion
     assert np.isclose(median, median_ref, rtol=1e-2, atol=1e-2)
+
+
+def test_untruncated() -> None:
+    """When the bounds are set to inf, it must be the close to Gumbel one.
+
+    Notes
+    -----
+    - Strictly speaking, the values are not exactly the same because the
+      truncated distribution is rescaled to the numerical bounds while
+      the untruncated distribution is simply cut at the numerical bounds.
+      However, these values suppose to be close as the numerical bounds
+      are selected such that the cut probability is less than 1e-15.
+    """
+
+    # Create an instance of a truncated Gumbel distribution
+    distribution = DISTRIBUTION_NAME
+    parameters = [10, 2, -np.inf, np.inf]
+
+    my_univariate_input = UnivariateInput(
+        distribution=distribution, parameters=parameters
+    )
+
+    # Create a reference Gumbel distribution
+    my_univariate_input_ref = UnivariateInput(
+        distribution="gumbel", parameters=parameters[:2]
+    )
+
+    # Assertion
+    lb = my_univariate_input.lower
+    ub = my_univariate_input.upper
+    # PDF
+    xx = np.linspace(lb, ub, 100000)
+    yy = my_univariate_input.pdf(xx)
+    yy_ref = my_univariate_input_ref.pdf(xx)
+    assert np.allclose(yy, yy_ref)
+
+    # CDF
+    yy = my_univariate_input.cdf(xx)
+    yy_ref = my_univariate_input_ref.cdf(xx)
+    assert np.allclose(yy, yy_ref)
+
+    # ICDF
+    xx = np.linspace(0, 1, 100000)
+    quantiles = my_univariate_input.icdf(xx)
+    quantiles_ref = my_univariate_input_ref.icdf(xx)
+    assert np.allclose(quantiles, quantiles_ref, atol=1e-4, rtol=1e-4)

--- a/tests/test_univariate_trunc_normal.py
+++ b/tests/test_univariate_trunc_normal.py
@@ -157,7 +157,16 @@ def test_estimate_std() -> None:
 
 
 def test_untruncated() -> None:
-    """When the bounds are set to inf, it must be the same to normal one."""
+    """When the bounds are set to inf, it must be the same to normal one.
+
+    Notes
+    -----
+    - Strictly speaking, the values are not exactly the same because the
+      truncated distribution is rescaled to the numerical bounds while
+      the untruncated distribution is simply cut at the numerical bounds.
+      However, these values suppose to be close as the numerical bounds
+      are selected such that the cut probability is less than 1e-15.
+    """
 
     # Create an instance of a truncated normal UnivariateInput
     name = create_random_alphanumeric(10)
@@ -174,8 +183,10 @@ def test_untruncated() -> None:
     )
 
     # Assertion
+    lb = my_univariate_input.lower
+    ub = my_univariate_input.upper
     # PDF
-    xx = np.linspace(0, 20, 10000)
+    xx = np.linspace(ub, lb, 100000)
     yy = my_univariate_input.pdf(xx)
     yy_ref = my_univariate_input_ref.pdf(xx)
     assert np.allclose(yy, yy_ref)
@@ -186,7 +197,7 @@ def test_untruncated() -> None:
     assert np.allclose(yy, yy_ref)
 
     # ICDF
-    xx = np.linspace(0, 1, 10000)
+    xx = np.linspace(0, 1, 100000)
     quantiles = my_univariate_input.icdf(xx)
     quantiles_ref = my_univariate_input_ref.icdf(xx)
     assert np.allclose(quantiles, quantiles_ref)


### PR DESCRIPTION
- The values at the tails should be consistent with the numerical truncation value and accurate to at least 1e-15.
- Test test suite has been extended to check whether CDF/ICDF is monotonously increasing.

This PR should resolve Issues #92 and #90.