### PR TITLE
Fix issue of ICDF values when input is outside [0, 1]

### DIFF
--- a/src/uqtestfuns/core/prob_input/univariate_distributions/gumbel.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/gumbel.py
@@ -14,6 +14,7 @@ import numpy as np
 
 from scipy.stats import gumbel_r
 
+from .utils import postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "gumbel"
@@ -228,8 +229,8 @@ def icdf(
 
     Notes
     -----
-    - ICDF for sample with values of 0.0 and 1.0 are automatically set to the
-      lower bound and upper bound, respectively.
+    - ICDF for sample values outside [0.0, 1.0] is set to NaN according to
+      the underlying SciPy implementation.
     """
     # Get the parameters
     mu = parameters[0]
@@ -239,13 +240,6 @@ def icdf(
     yy = gumbel_r.ppf(xx, loc=mu, scale=beta)
 
     # Check if values are within the set bounds
-    if yy.ndim != 0:
-        yy[yy < lower_bound] = lower_bound
-        yy[yy > upper_bound] = upper_bound
-    else:
-        if yy < lower_bound:
-            return np.asarray(lower_bound)
-        if yy > upper_bound:
-            return np.asarray(upper_bound)
+    yy = postprocess_icdf(yy, lower_bound, upper_bound)
 
     return yy

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/logitnormal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/logitnormal.py
@@ -18,6 +18,7 @@ from scipy.stats import norm
 from scipy.special import logit
 from scipy.special import expit as logistic
 
+from .utils import postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "logitnormal"
@@ -216,20 +217,14 @@ def icdf(
 
     Notes
     -----
-    - The ICDF for sample with values of 0.0 and 1.0 are automatically set
-      to the lower bound and upper bound, respectively.
+    - ICDF for sample values outside [0.0, 1.0] is set to NaN according to
+      the underlying SciPy implementation.
     """
-    yy = np.zeros(xx.shape)
-    idx_lower = xx == 0.0
-    idx_upper = xx == 1.0
-    idx_rest = np.logical_and(
-        np.logical_not(idx_lower), np.logical_not(idx_upper)
-    )
 
-    yy[idx_lower] = lower_bound
-    yy[idx_upper] = upper_bound
-    yy[idx_rest] = logistic(
-        norm.ppf(xx[idx_rest], loc=parameters[0], scale=parameters[1])
-    )
+    # Compute the ICDF
+    yy = logistic(norm.ppf(xx, loc=parameters[0], scale=parameters[1]))
+
+    # Check if values are within the set bounds
+    yy = postprocess_icdf(yy, lower_bound, upper_bound)
 
     return yy

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/lognormal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/lognormal.py
@@ -20,6 +20,7 @@ and SciPy is as follows:
 import numpy as np
 from scipy.stats import lognorm
 
+from .utils import postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "lognormal"
@@ -221,18 +222,14 @@ def icdf(
 
     Notes
     -----
-    - ICDF for sample with values of 0.0 and 1.0 are automatically set to the
-      lower bound and upper bound, respectively.
+    - ICDF for sample values outside [0.0, 1.0] is set to NaN according to
+      the underlying SciPy implementation.
     """
-    yy = np.zeros(xx.shape)
-    idx_lower = xx == 0.0
-    idx_upper = xx == 1.0
-    idx_rest = np.logical_not(idx_upper)
 
-    yy[idx_lower] = lower_bound
-    yy[idx_upper] = upper_bound
-    yy[idx_rest] = lognorm.ppf(
-        xx[idx_rest], s=parameters[1], scale=np.exp(parameters[0])
-    )
+    # Compute the ICDF
+    yy = lognorm.ppf(xx, s=parameters[1], scale=np.exp(parameters[0]))
+
+    # Check if values are within the set bounds
+    yy = postprocess_icdf(yy, lower_bound, upper_bound)
 
     return yy

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/normal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/normal.py
@@ -11,6 +11,7 @@ while the standard deviation (sigma) corresponds to the ``scale`` parameter.
 import numpy as np
 from scipy.stats import norm
 
+from .utils import postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "normal"
@@ -211,20 +212,14 @@ def icdf(
 
     Notes
     -----
-    - The ICDF for sample with values of 0.0 and 1.0 are automatically set
-      to the lower bound and upper bound, respectively.
+    - ICDF for sample values outside [0.0, 1.0] is set to NaN according to
+      the underlying SciPy implementation.
     """
-    yy = np.zeros(xx.shape)
-    idx_lower = xx == 0.0
-    idx_upper = xx == 1.0
-    idx_rest = np.logical_and(
-        np.logical_not(idx_lower), np.logical_not(idx_upper)
-    )
 
-    yy[idx_lower] = lower_bound
-    yy[idx_upper] = upper_bound
-    yy[idx_rest] = norm.ppf(
-        xx[idx_rest], loc=parameters[0], scale=parameters[1]
-    )
+    # Compute the ICDF
+    yy = norm.ppf(xx, loc=parameters[0], scale=parameters[1])
+
+    # Check if values are within the set bounds
+    yy = postprocess_icdf(yy, lower_bound, upper_bound)
 
     return yy

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/triangular.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/triangular.py
@@ -11,6 +11,7 @@ the distribution is 1.0.
 """
 import numpy as np
 
+from .utils import postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "triangular"
@@ -208,6 +209,10 @@ def icdf(
     -------
     ARRAY_FLOAT
         Transformed values in the domain of the triangular distribution.
+
+    Notes
+    -----
+    - ICDF for sample values outside [0.0, 1.0] is set to NaN.
     """
     mid_point = parameters[2]
     mid_point_quantile = (mid_point - lower_bound) / (
@@ -215,6 +220,7 @@ def icdf(
     )
     idx_below_mid = np.logical_and(xx >= 0.0, xx <= mid_point_quantile)
     idx_above_mid = np.logical_and(xx > mid_point_quantile, xx <= 1.0)
+    idx_nan = np.logical_not(np.logical_or(idx_below_mid, idx_above_mid))
 
     yy = np.empty(xx.shape)
     yy[idx_below_mid] = lower_bound + np.sqrt(
@@ -228,5 +234,10 @@ def icdf(
         * (upper_bound - lower_bound)
         * (upper_bound - mid_point)
     )
+
+    yy[idx_nan] = np.nan
+
+    # Check if values are within the set bounds
+    yy = postprocess_icdf(yy, lower_bound, upper_bound)
 
     return yy

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/uniform.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/uniform.py
@@ -6,6 +6,7 @@ the lower and upper bounds.
 """
 import numpy as np
 
+from .utils import postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "uniform"
@@ -189,7 +190,17 @@ def icdf(
     -------
     np.ndarray
         Transformed values in the domain of the uniform distribution.
+    Notes
+    -----
+    - ICDF for sample values outside [0.0, 1.0] is set to NaN.
     """
+    xx[xx < 0.0] = np.nan
+    xx[xx > 1.0] = np.nan
+
+    # Compute the ICDF
     yy = lower_bound + np.diff(parameters) * xx
+
+    # Check if values are within the set bounds
+    yy = postprocess_icdf(yy, lower_bound, upper_bound)
 
     return yy

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/utils.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/utils.py
@@ -1,0 +1,49 @@
+"""
+Utility module for univariate distribution calculations.
+"""
+import numpy as np
+
+from ....global_settings import ARRAY_FLOAT
+
+
+def postprocess_icdf(
+    xx: ARRAY_FLOAT,
+    lower_bound: float,
+    upper_bound: float,
+) -> ARRAY_FLOAT:
+    """Postprocess the computed ICDF values.
+
+    The postprocessing ensures that the output is an array and always
+    within the bounds of the distribution and
+
+    Parameters
+    ----------
+    xx : ARRAY_FLOAT
+        The raw ICDF values of a distribution computed either from a built-in
+        function or a re-parameterization of the SciPy implementation.
+    lower_bound : float
+        The lower bound of the distribution. All values below this value will
+        automatically be set to this value.
+    upper_bound : float
+        The upper bound of the distribution. All values above this value will
+        automatically be set to this value.
+
+    Return
+    ------
+    ARRAY_FLOAT
+        The post-processed ICDF values.
+    """
+    # A scalar output
+    if xx.ndim == 0:
+        if xx < lower_bound:
+            xx = lower_bound
+        if xx > upper_bound:
+            xx = upper_bound
+
+        xx = np.asarray(xx)
+
+    else:
+        xx[xx < lower_bound] = lower_bound
+        xx[xx > upper_bound] = upper_bound
+
+    return xx

--- a/tests/test_univariate_input.py
+++ b/tests/test_univariate_input.py
@@ -145,6 +145,10 @@ def test_get_icdf_values(univariate_input: Any) -> None:
     assert my_univariate_input.icdf(0.0 + 5e-16) >= lb
     assert my_univariate_input.icdf(1.0 - 5e-16) <= ub
 
+    # Values outside [0.0, 1.0] should return NaN
+    assert np.isnan(my_univariate_input.icdf(0.0 - 1e-15))
+    assert np.isnan(my_univariate_input.icdf(1.0 + 1e-15))
+
 
 def test_transform_sample() -> None:
     """Test the transformation of sample values from one dist. to another."""


### PR DESCRIPTION
- ICDF values of all univariate distributions for input outside [0.0, 1.0] are set to NaN.
- ICDF values outside the lower (resp. upper) bound of the distribution are set to the lower (resp. upper) bound.
- The test suite has been accordingly extended.

This PR should resolve Issue #57.