### PR TITLE
get_sample() of MultivariateInput uses the one from UnivariateInput

### DIFF
--- a/src/uqtestfuns/core/prob_input/multivariate_input.py
+++ b/src/uqtestfuns/core/prob_input/multivariate_input.py
@@ -66,19 +66,13 @@ class MultivariateInput:
 
     def get_sample(self, sample_size: int = 1):
         """Get a random sample from the distribution."""
-        # Create an instance univariate sample
-        univ_input = UnivariateInput(
-            name="X", distribution="uniform", parameters=[0, 1]
-        )
 
-        xx = np.random.rand(sample_size, self.spatial_dimension)
+        xx = np.empty((sample_size, self.spatial_dimension))
         # Transform the sample in [0, 1] to the domain of the distribution
         if not self.copulas:
             # Independent inputs generate sample marginal by marginal
             for idx_dim, marginal in enumerate(self.marginals):
-                xx[:, idx_dim] = univ_input.transform_sample(
-                    xx[:, idx_dim], marginal
-                )
+                xx[:, idx_dim] = marginal.get_sample(sample_size)
         else:
             raise ValueError("Copulas are not currently supported!")
 

--- a/tests/test_test_functions.py
+++ b/tests/test_test_functions.py
@@ -67,14 +67,20 @@ def test_transform_input(default_testfun):
 
     testfun, _ = default_testfun
 
+    sample_size = 100
+
     # Transformation from the default uniform domain to the input domain
     np.random.seed(315)
-    xx_1 = -1 + 2 * np.random.rand(100, testfun.spatial_dimension)
+    # NOTE: Direct sample from the input property is done by column to column,
+    # for reproducibility using the same RNG seed the reference input must be
+    # filled in column by column as well with the. The call to NumPy random
+    # number generators below yields the same effect.
+    xx_1 = -1 + 2 * np.random.rand(testfun.spatial_dimension, sample_size).T
     xx_1 = testfun.transform_inputs(xx_1)
 
     # Directly sample from the input property
     np.random.seed(315)
-    xx_2 = testfun.input.get_sample(100)
+    xx_2 = testfun.input.get_sample(sample_size)
 
     # Assertion: two sampled values are equal
     assert np.allclose(xx_1, xx_2)
@@ -85,14 +91,20 @@ def test_transform_input_non_default(default_testfun):
 
     testfun, _ = default_testfun
 
+    sample_size = 100
+
     # Transformation from non-default uniform domain to the input domain
     np.random.seed(315)
-    xx_1 = np.random.rand(100, testfun.spatial_dimension)
+    # NOTE: Direct sample from the input property is done by column to column,
+    # for reproducibility using the same RNG seed the reference input must be
+    # filled in column by column as well with the. The call to NumPy random
+    # number generators below yields the same effect.
+    xx_1 = np.random.rand(testfun.spatial_dimension, sample_size).T
     xx_1 = testfun.transform_inputs(xx_1, min_value=0.0, max_value=1.0)
 
     # Directly sample from the input property
     np.random.seed(315)
-    xx_2 = testfun.input.get_sample(100)
+    xx_2 = testfun.input.get_sample(sample_size)
 
     # Assertion: two sampled values are equal
     assert np.allclose(xx_1, xx_2)


### PR DESCRIPTION
- For consistency, when the multivariate input is independent, getting a sample now uses the get_sample() method of the underlying marginals (i.e., UnivariateInput instances).
- The test suite has been modified to accommodate the changes. In particular, comparing a sample with a transformed sample requires additional care because now the random number generation should be done column by column.

This PR should resolve Issue #103.