### PR TITLE
Rename 'input' property of UQTestFun to 'prob_input'

### DIFF
--- a/docs/test-functions/borehole.md
+++ b/docs/test-functions/borehole.md
@@ -49,14 +49,14 @@ where $\boldsymbol{x} = \{ r_w, r, T_u, H_u, T_l, H_l, L, K_w\}$ is the vector o
 
 +++
 
-## Inputs
+## Probabilistic input
 
 The original eight input variables of the Borehole function
 (from {cite}`Harper1983`) are modeled as independent random variables
 whose marginals shown in the table below.
 
 ```{code-cell} ipython3
-my_testfun.input
+my_testfun.prob_input
 ```
 
 There is another input specification from the literature listed in the table below.
@@ -76,7 +76,7 @@ For example, to create a Borehole test function using the input specification by
 
 ```{code-cell} ipython3
 my_testfun_alt = uqtestfuns.create_from_default("borehole", input_selection="morris")
-my_testfun_alt.input
+my_testfun_alt.prob_input
 ```
 
 ## Reference Results
@@ -86,7 +86,7 @@ my_testfun_alt.input
 Generate a random sample of input/output pairs:
 
 ```{code-cell} ipython3
-xx_test = my_testfun.input.get_sample(10000)
+xx_test = my_testfun.prob_input.get_sample(10000)
 yy_test = my_testfun(xx_test)
 ```
 

--- a/docs/test-functions/ishigami.md
+++ b/docs/test-functions/ishigami.md
@@ -50,14 +50,14 @@ both are given below.
 
 +++
 
-## Inputs
+## Probabilistic input
 
 The 3 input variables of the wing weight function are modeled
 as independent uniform random variables
 with specified ranges shown in the table below.
 
 ```{code-cell} ipython3
-my_testfun.input
+my_testfun.prob_input
 ```
 
 The parameters of the Ishigami function are two real-valued numbers.
@@ -86,7 +86,7 @@ uqtestfuns.create_from_default("ishigami", param_selection="marrel")
 Generate a random sample of input/output pairs:
 
 ```{code-cell} ipython3
-xx_test = my_testfun.input.get_sample(1000000)
+xx_test = my_testfun.prob_input.get_sample(1000000)
 yy_test = my_testfun(xx_test)
 ```
 

--- a/docs/test-functions/wing-weight.md
+++ b/docs/test-functions/wing-weight.md
@@ -49,12 +49,12 @@ where $\boldsymbol{x} = \{ S_w, W_{fw}, A, \Lambda, q, \lambda, t_c, N_z, W_{dg}
 
 +++
 
-## Inputs
+## Probabilistic input
 
 The ten input variables of the wing weight function are modeled as independent uniform random variables with specified ranges shown in the table below.
 
 ```{code-cell} ipython3
-my_testfun.input
+my_testfun.prob_input
 ```
 
 ## Reference Results
@@ -64,7 +64,7 @@ my_testfun.input
 Generate a random sample of input/output pairs:
 
 ```{code-cell} ipython3
-xx_test = my_testfun.input.get_sample(10000)
+xx_test = my_testfun.prob_input.get_sample(10000)
 yy_test = my_testfun(xx_test)
 ```
 

--- a/src/uqtestfuns/core/uqtestfun.py
+++ b/src/uqtestfuns/core/uqtestfun.py
@@ -23,7 +23,7 @@ class UQTestFun:
     ----------
     evaluate : Callable
         Implementation of the a test function as a Callable.
-    input : MultivariateInput
+    prob_input : MultivariateInput
         Multivariate probabilistic input model.
     name : str, optional
         Name of the instance.
@@ -43,20 +43,20 @@ class UQTestFun:
     """
 
     evaluate: Callable
-    input: MultivariateInput
+    prob_input: MultivariateInput
     spatial_dimension: int = field(init=False)
     name: Optional[str] = None
     parameters: Any = None
 
     def __post_init__(self):
 
-        if not isinstance(self.input, MultivariateInput):
+        if not isinstance(self.prob_input, MultivariateInput):
             raise TypeError(
                 f"Input must be of 'MultivariateInput' type, "
-                f"instead of {type(self.input)}!"
+                f"instead of {type(self.prob_input)}!"
             )
 
-        self.spatial_dimension = self.input.spatial_dimension
+        self.spatial_dimension = self.prob_input.spatial_dimension
 
     def __call__(self, xx: np.ndarray):
         """Evaluation of the test function by calling the instance."""
@@ -65,8 +65,8 @@ class UQTestFun:
         _verify_sample_shape(xx, self.spatial_dimension)
         # Verify the domain of the input
         for dim_idx in range(self.spatial_dimension):
-            lb = self.input.marginals[dim_idx].lower
-            ub = self.input.marginals[dim_idx].upper
+            lb = self.prob_input.marginals[dim_idx].lower
+            ub = self.prob_input.marginals[dim_idx].upper
             _verify_sample_domain(xx[:, dim_idx], min_value=lb, max_value=ub)
 
         if self.parameters is None:
@@ -109,7 +109,7 @@ class UQTestFun:
         )
 
         # Transform the sampled value to the function domain
-        xx_trans = uniform_input.transform_sample(xx, other=self.input)
+        xx_trans = uniform_input.transform_sample(xx, other=self.prob_input)
 
         return xx_trans
 

--- a/src/uqtestfuns/test_functions/default.py
+++ b/src/uqtestfuns/test_functions/default.py
@@ -89,7 +89,7 @@ def get_default_args(
     default_args = {
         "name": fun_mod.DEFAULT_NAME,
         "evaluate": fun_mod.evaluate,
-        "input": _get_default_input(
+        "prob_input": _get_default_input(
             fun_mod, input_selection, spatial_dimension
         ),
         "parameters": _get_default_parameters(

--- a/tests/test_ishigami.py
+++ b/tests/test_ishigami.py
@@ -24,7 +24,7 @@ def ishigami_fun(request):
     ishigami = UQTestFun(
         name=default_args["name"],
         evaluate=default_args["evaluate"],
-        input=default_args["input"],
+        prob_input=default_args["prob_input"],
         parameters=request.param,
     )
 
@@ -35,7 +35,7 @@ def test_compute_mean(ishigami_fun):
     """Test the mean computation as the result is analytical."""
 
     # Compute mean via Monte Carlo
-    xx = ishigami_fun.input.get_sample(1000000)
+    xx = ishigami_fun.prob_input.get_sample(1000000)
     yy = ishigami_fun(xx)
 
     mean_mc = np.mean(yy)
@@ -51,7 +51,7 @@ def test_compute_variance(ishigami_fun):
     """Test the variance computation as the result is analytical."""
 
     # Compute variance via Monte Carlo
-    xx = ishigami_fun.input.get_sample(1000000)
+    xx = ishigami_fun.prob_input.get_sample(1000000)
     yy = ishigami_fun(xx)
 
     var_mc = np.var(yy)

--- a/tests/test_otl_circuit.py
+++ b/tests/test_otl_circuit.py
@@ -18,8 +18,8 @@ def test_inert_inputs():
 
     # Generate sample and compare both
     num_sample = 1000000
-    xx_otl_ben_ari = otl_ben_ari.input.get_sample(num_sample)
-    xx_otl_moon = otl_moon.input.get_sample(num_sample)
+    xx_otl_ben_ari = otl_ben_ari.prob_input.get_sample(num_sample)
+    xx_otl_moon = otl_moon.prob_input.get_sample(num_sample)
 
     yy_otl_ben_ari = otl_ben_ari(xx_otl_ben_ari)
     yy_otl_moon = otl_moon(xx_otl_moon)

--- a/tests/test_piston.py
+++ b/tests/test_piston.py
@@ -18,8 +18,8 @@ def test_inert_inputs():
 
     # Generate sample and compare both
     num_sample = 1000000
-    xx_otl_ben_ari = otl_ben_ari.input.get_sample(num_sample)
-    xx_otl_moon = otl_moon.input.get_sample(num_sample)
+    xx_otl_ben_ari = otl_ben_ari.prob_input.get_sample(num_sample)
+    xx_otl_moon = otl_moon.prob_input.get_sample(num_sample)
 
     yy_otl_ben_ari = otl_ben_ari(xx_otl_ben_ari)
     yy_otl_moon = otl_moon(xx_otl_moon)

--- a/tests/test_sobol_g.py
+++ b/tests/test_sobol_g.py
@@ -61,7 +61,7 @@ def test_compute_mean(spatial_dimension, parameter):
     )
 
     # Compute mean via Monte Carlo
-    xx = my_fun.input.get_sample(500000)
+    xx = my_fun.prob_input.get_sample(500000)
     yy = my_fun(xx)
 
     mean_mc = np.mean(yy)
@@ -89,7 +89,7 @@ def test_compute_variance(spatial_dimension, parameter):
     )
 
     # Compute the variance via Monte Carlo
-    xx = my_fun.input.get_sample(500000)
+    xx = my_fun.prob_input.get_sample(500000)
     yy = my_fun(xx)
 
     var_mc = np.var(yy)

--- a/tests/test_sulfur.py
+++ b/tests/test_sulfur.py
@@ -48,13 +48,13 @@ def test_compute_mean():
     my_fun = uqtestfuns.create_from_default("sulfur")
 
     # Compute mean via Monte Carlo
-    xx = my_fun.input.get_sample(1000000)
+    xx = my_fun.prob_input.get_sample(1000000)
     yy = my_fun(xx)
 
     mean_mc = np.mean(np.log(-1 * yy))
 
     # Analytical mean
-    marginals = my_fun.input.marginals
+    marginals = my_fun.prob_input.marginals
     mean_ref = _compute_sqrt_geometric_mean_std(marginals)[0]
 
     # Assertion
@@ -68,13 +68,13 @@ def test_compute_std():
     my_fun = uqtestfuns.create_from_default("sulfur")
 
     # Compute mean via Monte Carlo
-    xx = my_fun.input.get_sample(1000000)
+    xx = my_fun.prob_input.get_sample(1000000)
     yy = my_fun(xx)
 
     std_mc = np.std(np.log(-1 * yy))
 
     # Analytical standard deviation
-    marginals = my_fun.input.marginals
+    marginals = my_fun.prob_input.marginals
     std_ref = _compute_sqrt_geometric_mean_std(marginals)[1]
 
     # Assertion

--- a/tests/test_test_functions.py
+++ b/tests/test_test_functions.py
@@ -56,7 +56,7 @@ def test_call_instance(default_testfun):
 
     testfun, _ = default_testfun
 
-    xx = testfun.input.get_sample(10)
+    xx = testfun.prob_input.get_sample(10)
 
     # Assertions
     assert_call(testfun, xx)
@@ -80,7 +80,7 @@ def test_transform_input(default_testfun):
 
     # Directly sample from the input property
     np.random.seed(315)
-    xx_2 = testfun.input.get_sample(sample_size)
+    xx_2 = testfun.prob_input.get_sample(sample_size)
 
     # Assertion: two sampled values are equal
     assert np.allclose(xx_1, xx_2)
@@ -104,7 +104,7 @@ def test_transform_input_non_default(default_testfun):
 
     # Directly sample from the input property
     np.random.seed(315)
-    xx_2 = testfun.input.get_sample(sample_size)
+    xx_2 = testfun.prob_input.get_sample(sample_size)
 
     # Assertion: two sampled values are equal
     assert np.allclose(xx_1, xx_2)
@@ -135,7 +135,7 @@ def test_wrong_input_domain(default_testfun):
 
     # Create sampled input values from the default and perturb them
     xx = np.empty((100, testfun.spatial_dimension))
-    for i, marginal in enumerate(testfun.input.marginals):
+    for i, marginal in enumerate(testfun.prob_input.marginals):
         lb = marginal.lower + 1000
         ub = marginal.upper - 1000
         xx[:, i] = lb + (ub - lb) * np.random.rand(100)

--- a/tests/test_uqmetatestfun.py
+++ b/tests/test_uqmetatestfun.py
@@ -177,9 +177,9 @@ def test_get_sample(spatial_dimension):
     # Assertion
     assert isinstance(my_testfun, UQTestFun)
     assert my_testfun.spatial_dimension == spatial_dimension
-    assert my_testfun.input.spatial_dimension == spatial_dimension
+    assert my_testfun.prob_input.spatial_dimension == spatial_dimension
     assert isinstance(my_testfun.parameters, UQTestFunSpec)
-    assert_call(my_testfun, my_testfun.input.get_sample(100))
+    assert_call(my_testfun, my_testfun.prob_input.get_sample(100))
 
     # Get sample > 1
     sample_size = 100
@@ -221,7 +221,7 @@ def test_evaluate_sample(spatial_dimension):
     assert isinstance(my_testfun, UQTestFun)
 
     sample_size = 1000
-    xx = my_testfun.input.get_sample(sample_size)
+    xx = my_testfun.prob_input.get_sample(sample_size)
     yy = my_testfun(xx)
 
     yy_ref = _create_reference_evaluate(xx, my_testfun.parameters)

--- a/tests/test_uqtestfun.py
+++ b/tests/test_uqtestfun.py
@@ -27,7 +27,7 @@ def uqtestfun():
     uqtestfun_instance = UQTestFun(
         name="Test function",
         evaluate=evaluate,
-        input=MultivariateInput(input_marginals),
+        prob_input=MultivariateInput(input_marginals),
         parameters=10,
     )
 
@@ -53,7 +53,7 @@ def test_call_instance(uqtestfun):
     """Test calling an instance of UQTestFun."""
     uqtestfun_instance, _ = uqtestfun
 
-    xx = uqtestfun_instance.input.get_sample(1000)
+    xx = uqtestfun_instance.prob_input.get_sample(1000)
 
     # Assertions
     assert_call(uqtestfun_instance, xx)


### PR DESCRIPTION
- 'input' is a built-in function in Python, so it might be a good idea not to use the same name of a property in a high-level class.

This PR should resolve Issue #105.