### PR TITLE
Refactor each of the test function modules

### DIFF
--- a/docs/test-functions/borehole.md
+++ b/docs/test-functions/borehole.md
@@ -75,7 +75,7 @@ to the `input_selection` parameter.
 For example, to create a Borehole test function using the input specification by {cite:t}`Morris1993`:
 
 ```{code-cell} ipython3
-my_testfun_alt = uqtestfuns.create_from_default("borehole", input_selection="morris")
+my_testfun_alt = uqtestfuns.create_from_default("borehole", prob_input="morris")
 my_testfun_alt.prob_input
 ```
 

--- a/src/uqtestfuns/test_functions/ackley.py
+++ b/src/uqtestfuns/test_functions/ackley.py
@@ -13,9 +13,11 @@ References
 """
 import numpy as np
 
-from ..core import UnivariateInput, MultivariateInput
+from ..core import UnivariateInput
 
 DEFAULT_NAME = "Ackley"
+
+TAGS = ["metamodeling", "optimization"]
 
 
 def _ackley_input(spatial_dimension: int):
@@ -35,16 +37,24 @@ def _ackley_input(spatial_dimension: int):
             )
         )
 
-    return MultivariateInput(marginals)
+    return marginals
 
 
-DEFAULT_INPUTS = {
-    "ackley": _ackley_input,
+AVAILABLE_INPUT_SPECS = {
+    "ackley": {
+        "name": "Ackley",
+        "description": (
+            "Probabilistic input model for the Ackley function "
+            "from Ackley (1987)."
+        ),
+        "marginals": _ackley_input,
+        "copulas": None,
+    },
 }
 
 DEFAULT_INPUT_SELECTION = "ackley"
 
-DEFAULT_PARAMETERS = {"ackley": (20, 0.2, 2 * np.pi)}
+AVAILABLE_PARAMETERS = {"ackley": (20, 0.2, 2 * np.pi)}
 
 DEFAULT_PARAMETERS_SELECTION = "ackley"
 

--- a/src/uqtestfuns/test_functions/borehole.py
+++ b/src/uqtestfuns/test_functions/borehole.py
@@ -1,7 +1,7 @@
 """
 Module with an implementation of the Borehole function.
 
-The Borehole test function [1] is an 8-dimensional scalar-valued function
+The Borehole test function [1] is an eight-dimensional scalar-valued function
 that models water flow through a borehole that is drilled from
 the ground surface through two aquifers.
 
@@ -16,19 +16,24 @@ References
    Isolation, Battelle Memorial Institute, Columbus, Ohio,
    BMI/ONWI-516, 1983.
    URL: https://inldigitallibrary.inl.gov/PRR/84393.pdf
-2. M. D. Morris, T. J. Mitchell, and D. Ylvisaker, “Bayesian design and
+2. Max D. Morris, T. J. Mitchell, and D. Ylvisaker, “Bayesian design and
    analysis of computer experiments: Use of derivatives in surface
    prediction,” Technometrics, vol. 35, no. 3, pp. 243–255, 1993.
    DOI:10.1080/00401706.1993.10485320
 """
 import numpy as np
 
-from ..core import UnivariateInput, MultivariateInput
+from ..core import UnivariateInput
 
 DEFAULT_NAME = "Borehole"
 
-# From Ref. 1
-DEFAULT_INPUT_MARGINALS_1 = [
+TAGS = [
+    "metamodeling",
+    "sensitivity-analysis",
+]
+
+# From [1]
+INPUT_MARGINALS_HARPER = [
     UnivariateInput(
         name="rw",
         distribution="normal",
@@ -79,9 +84,9 @@ DEFAULT_INPUT_MARGINALS_1 = [
     ),
 ]
 
-# From Ref. 2
-DEFAULT_INPUT_MARGINALS_2 = list(DEFAULT_INPUT_MARGINALS_1)
-DEFAULT_INPUT_MARGINALS_2[0:2] = [
+# From [2]
+INPUT_MARGINALS_MORRIS = list(INPUT_MARGINALS_HARPER)
+INPUT_MARGINALS_MORRIS[0:2] = [
     UnivariateInput(
         name="rw",
         distribution="uniform",
@@ -96,14 +101,30 @@ DEFAULT_INPUT_MARGINALS_2[0:2] = [
     ),
 ]
 
-DEFAULT_INPUTS = {
-    "harper": MultivariateInput(DEFAULT_INPUT_MARGINALS_1),
-    "morris": MultivariateInput(DEFAULT_INPUT_MARGINALS_2),
+AVAILABLE_INPUT_SPECS = {
+    "harper": {
+        "name": "Borehole-Harper",
+        "description": (
+            "Probabilistic input model of the Borehole model "
+            "from Harper and Gupta (1983)."
+        ),
+        "marginals": INPUT_MARGINALS_HARPER,
+        "copulas": None,
+    },
+    "morris": {
+        "name": "Borehole-Morris",
+        "description": (
+            "Probabilistic input model of the Borehole model "
+            "from Morris et al. (1993)."
+        ),
+        "marginals": INPUT_MARGINALS_MORRIS,
+        "copulas": None,
+    },
 }
 
 DEFAULT_INPUT_SELECTION = "harper"
 
-DEFAULT_PARAMETERS = None
+AVAILABLE_PARAMETERS = None
 
 
 def evaluate(xx: np.ndarray) -> np.ndarray:

--- a/src/uqtestfuns/test_functions/damped_oscillator.py
+++ b/src/uqtestfuns/test_functions/damped_oscillator.py
@@ -33,12 +33,12 @@ References
 import numpy as np
 
 from .utils import lognorm2norm_mean, lognorm2norm_std
-from ..core import UnivariateInput, MultivariateInput
+from ..core import UnivariateInput
 
 
 DEFAULT_NAME = "Damped-Oscillator"
 
-DEFAULT_INPUT_MARGINALS_DE_KIUREGHIAN = [  # From [2]
+INPUT_MARGINALS_DE_KIUREGHIAN = [  # From [2]
     UnivariateInput(
         name="Mp",
         distribution="lognormal",
@@ -104,13 +104,21 @@ DEFAULT_INPUT_MARGINALS_DE_KIUREGHIAN = [  # From [2]
     ),
 ]
 
-DEFAULT_INPUTS = {
-    "de-kiureghian": MultivariateInput(DEFAULT_INPUT_MARGINALS_DE_KIUREGHIAN),
+AVAILABLE_INPUT_SPECS = {
+    "de-kiureghian": {
+        "name": "Damped-Oscillator-De-Kiureghian",
+        "description": (
+            "Probabilistic input model for the Damped Oscillator model "
+            "from De Kiureghian and De Stefano (1991)."
+        ),
+        "marginals": INPUT_MARGINALS_DE_KIUREGHIAN,
+        "copulas": None,
+    },
 }
 
 DEFAULT_INPUT_SELECTION = "de-kiureghian"
 
-DEFAULT_PARAMETERS = None
+AVAILABLE_PARAMETERS = None
 
 
 def evaluate(xx: np.ndarray) -> np.ndarray:

--- a/src/uqtestfuns/test_functions/flood.py
+++ b/src/uqtestfuns/test_functions/flood.py
@@ -30,12 +30,18 @@ References
 """
 import numpy as np
 
-from ..core import UnivariateInput, MultivariateInput
+from ..core import UnivariateInput
 
 
 DEFAULT_NAME = "Flood"
 
-DEFAULT_INPUT_MARGINALS_IOOSS = [
+TAGS = [
+    "metamodeling",
+    "sensitivity-analysis",
+]
+
+
+INPUT_MARGINALS_IOOSS = [  # From Ref. [1]
     UnivariateInput(
         name="Q",
         distribution="trunc-gumbel",
@@ -86,13 +92,21 @@ DEFAULT_INPUT_MARGINALS_IOOSS = [
     ),
 ]
 
-DEFAULT_INPUTS = {
-    "iooss": MultivariateInput(DEFAULT_INPUT_MARGINALS_IOOSS),
+AVAILABLE_INPUT_SPECS = {
+    "iooss": {
+        "name": "Flood-Iooss",
+        "description": (
+            "Probabilistic input model for the Flood model "
+            "from Iooss and Lemaître (2015)."
+        ),
+        "marginals": INPUT_MARGINALS_IOOSS,
+        "copulas": None,
+    }
 }
 
 DEFAULT_INPUT_SELECTION = "iooss"
 
-DEFAULT_PARAMETERS = None
+AVAILABLE_PARAMETERS = None
 
 
 def evaluate(xx: np.ndarray) -> np.ndarray:

--- a/src/uqtestfuns/test_functions/ishigami.py
+++ b/src/uqtestfuns/test_functions/ishigami.py
@@ -23,11 +23,16 @@ References
 """
 import numpy as np
 
-from ..core import UnivariateInput, MultivariateInput
+from ..core import UnivariateInput
 
 DEFAULT_NAME = "Ishigami"
 
-DEFAULT_INPUT_MARGINALS = [
+TAGS = [
+    "metamodeling",
+    "sensitivity-analysis",
+]
+
+INPUT_MARGINALS_ISHIGAMI = [
     UnivariateInput(
         name="X1",
         distribution="uniform",
@@ -48,13 +53,21 @@ DEFAULT_INPUT_MARGINALS = [
     ),
 ]
 
-DEFAULT_INPUTS = {
-    "ishigami": MultivariateInput(DEFAULT_INPUT_MARGINALS),
+AVAILABLE_INPUT_SPECS = {
+    "ishigami": {
+        "name": "Ishigami",
+        "description": (
+            "Probabilistic input model for the Ishigami function "
+            "from Ishigami and Homma (1991)."
+        ),
+        "marginals": INPUT_MARGINALS_ISHIGAMI,
+        "copulas": None,
+    }
 }
 
 DEFAULT_INPUT_SELECTION = "ishigami"
 
-DEFAULT_PARAMETERS = {
+AVAILABLE_PARAMETERS = {
     "sobol-levitan": (7, 0.05),  # from [2].
     "marrel": (7, 0.1),  # from [3].
 }

--- a/src/uqtestfuns/test_functions/otl_circuit.py
+++ b/src/uqtestfuns/test_functions/otl_circuit.py
@@ -24,12 +24,17 @@ import numpy as np
 
 from copy import copy
 
-from ..core import UnivariateInput, MultivariateInput
+from ..core import UnivariateInput
 
 
 DEFAULT_NAME = "OTL"
 
-DEFAULT_INPUT_MARGINALS_BEN_ARI = [
+TAGS = [
+    "metamodeling",
+    "sensitivity-analysis",
+]
+
+INPUT_MARGINALS_BEN_ARI = [
     UnivariateInput(
         name="Rb1",
         distribution="uniform",
@@ -68,11 +73,9 @@ DEFAULT_INPUT_MARGINALS_BEN_ARI = [
     ),
 ]
 
-DEFAULT_INPUT_MARGINALS_MOON = [
-    copy(_) for _ in DEFAULT_INPUT_MARGINALS_BEN_ARI
-]
+INPUT_MARGINALS_MOON = [copy(_) for _ in INPUT_MARGINALS_BEN_ARI]
 for i in range(14):
-    DEFAULT_INPUT_MARGINALS_MOON.append(
+    INPUT_MARGINALS_MOON.append(
         UnivariateInput(
             name=f"Inert {i+1}",
             distribution="uniform",
@@ -81,14 +84,30 @@ for i in range(14):
         )
     )
 
-DEFAULT_INPUTS = {
-    "ben-ari": MultivariateInput(DEFAULT_INPUT_MARGINALS_BEN_ARI),
-    "moon": MultivariateInput(DEFAULT_INPUT_MARGINALS_MOON),
+AVAILABLE_INPUT_SPECS = {
+    "ben-ari": {
+        "name": "OTL-Circuit-Ben-Ari",
+        "description": (
+            "Probabilistic input model for the OTL Circuit function "
+            "from Ben-Ari and Steinberg (2007)."
+        ),
+        "marginals": INPUT_MARGINALS_BEN_ARI,
+        "copulas": None,
+    },
+    "moon": {
+        "name": "OTL-Circuit-Moon",
+        "description": (
+            "Probabilistic input model for the OTL Circuit function "
+            "from Moon (2010)."
+        ),
+        "marginals": INPUT_MARGINALS_MOON,
+        "copulas": None,
+    },
 }
 
 DEFAULT_INPUT_SELECTION = "ben-ari"
 
-DEFAULT_PARAMETERS = None
+AVAILABLE_PARAMETERS = None
 
 
 def evaluate(xx: np.ndarray) -> np.ndarray:

--- a/src/uqtestfuns/test_functions/piston.py
+++ b/src/uqtestfuns/test_functions/piston.py
@@ -24,13 +24,18 @@ import numpy as np
 
 from copy import copy
 
-from ..core import UnivariateInput, MultivariateInput
+from ..core import UnivariateInput
 
 
 DEFAULT_NAME = "Piston"
 
-# Input specification from [1]
-DEFAULT_INPUT_MARGINALS_BEN_ARI = [
+TAGS = [
+    "metamodeling",
+    "sensitivity-analysis",
+]
+
+# Marginals specification from [1]
+INPUT_MARGINALS_BEN_ARI = [
     UnivariateInput(
         name="M",
         distribution="uniform",
@@ -75,12 +80,10 @@ DEFAULT_INPUT_MARGINALS_BEN_ARI = [
     ),
 ]
 
-# Input specification from [2]
-DEFAULT_INPUT_MARGINALS_MOON = [
-    copy(_) for _ in DEFAULT_INPUT_MARGINALS_BEN_ARI
-]
+# Marginals specification from [2]
+INPUT_MARGINALS_MOON = [copy(_) for _ in INPUT_MARGINALS_BEN_ARI]
 for i in range(13):
-    DEFAULT_INPUT_MARGINALS_MOON.append(
+    INPUT_MARGINALS_MOON.append(
         UnivariateInput(
             name=f"Inert {i+1}",
             distribution="uniform",
@@ -89,14 +92,30 @@ for i in range(13):
         )
     )
 
-DEFAULT_INPUTS = {
-    "ben-ari": MultivariateInput(DEFAULT_INPUT_MARGINALS_BEN_ARI),
-    "moon": MultivariateInput(DEFAULT_INPUT_MARGINALS_MOON),
+AVAILABLE_INPUT_SPECS = {
+    "ben-ari": {
+        "name": "Piston-Ben-Ari",
+        "description": (
+            "Probabilistic input model for the Piston simulation model "
+            "from Ben-Ari and Steinberg (2007)."
+        ),
+        "marginals": INPUT_MARGINALS_BEN_ARI,
+        "copulas": None,
+    },
+    "moon": {
+        "name": "Piston-Moon",
+        "description": (
+            "Probabilistic input model for the Piston simulation model "
+            "from Moon (2010)."
+        ),
+        "marginals": INPUT_MARGINALS_MOON,
+        "copulas": None,
+    },
 }
 
 DEFAULT_INPUT_SELECTION = "ben-ari"
 
-DEFAULT_PARAMETERS = None
+AVAILABLE_PARAMETERS = None
 
 
 def evaluate(xx: np.ndarray) -> np.ndarray:

--- a/src/uqtestfuns/test_functions/sobol_g.py
+++ b/src/uqtestfuns/test_functions/sobol_g.py
@@ -44,23 +44,28 @@ References
 """
 import numpy as np
 
-from ..core import UnivariateInput, MultivariateInput
+from typing import List
+
+from ..core import UnivariateInput
 
 DEFAULT_NAME = "Sobol-G"
 
+TAGS = ["sensitivity-analysis"]
 
-def _create_sobol_input(spatial_dimension: int) -> MultivariateInput:
+
+def _create_sobol_input(spatial_dimension: int) -> List[UnivariateInput]:
     """Construct an input instance for a given dimension according to [1].
 
     Parameters
     ----------
     spatial_dimension : int
-        The number of spatial dimension of the MultivariateInput.
+        The number of marginals to be created.
 
     Returns
     -------
-    MultivariateInput
-        M-dimensional MultivariateInput instance for the Sobol-G function.
+    List[UnivariateInput]
+        A list of M marginals as UnivariateInput instances to construct
+        the MultivariateInput.
     """
     marginals = []
     for i in range(spatial_dimension):
@@ -73,11 +78,19 @@ def _create_sobol_input(spatial_dimension: int) -> MultivariateInput:
             )
         )
 
-    return MultivariateInput(marginals)
+    return marginals
 
 
-DEFAULT_INPUTS = {
-    "sobol": _create_sobol_input,
+AVAILABLE_INPUT_SPECS = {
+    "sobol": {
+        "name": "Sobol-G",
+        "description": (
+            "Probabilistic input model for the Sobol'-G function "
+            "from Sobol' (1998)."
+        ),
+        "marginals": _create_sobol_input,
+        "copulas": None,
+    },
 }
 
 DEFAULT_INPUT_SELECTION = "sobol"
@@ -138,11 +151,9 @@ def _get_params_sobol_4(spatial_dimension: int) -> np.ndarray:
 
 def _get_params_kucherenko_2a(spatial_dimension: int) -> np.ndarray:
     """Construct a param. array for Sobol-G according to problem 2A in [2]."""
-    yy = 6.52 * np.ones(spatial_dimension)
-    if spatial_dimension >= 1:
-        yy[0] = 0.0
+    yy = np.zeros(spatial_dimension)
     if spatial_dimension >= 2:
-        yy[1] = 0.0
+        yy[2:] = 6.52
 
     return yy
 
@@ -167,7 +178,7 @@ def _get_params_crestaux_2007(spatial_dimension: int) -> np.ndarray:
     return yy
 
 
-DEFAULT_PARAMETERS = {
+AVAILABLE_PARAMETERS = {
     "sobol-1": _get_params_sobol_1,
     "sobol-2": _get_params_sobol_2,
     "sobol-3": _get_params_sobol_3,

--- a/src/uqtestfuns/test_functions/sulfur.py
+++ b/src/uqtestfuns/test_functions/sulfur.py
@@ -58,12 +58,17 @@ References
 """
 import numpy as np
 
-from ..core import UnivariateInput, MultivariateInput
+from ..core import UnivariateInput
 
 
 DEFAULT_NAME = "Sulfur"
 
-DEFAULT_INPUT_MARGINALS_PENNER = [  # From [3] (Table 2)
+TAGS = [
+    "metamodeling",
+    "sensitivity-analysis",
+]
+
+INPUT_MARGINALS_PENNER = [  # From [3] (Table 2)
     UnivariateInput(
         name="Q",
         distribution="lognormal",
@@ -122,11 +127,21 @@ DEFAULT_INPUT_MARGINALS_PENNER = [  # From [3] (Table 2)
     ),
 ]
 
-DEFAULT_INPUTS = {"penner": MultivariateInput(DEFAULT_INPUT_MARGINALS_PENNER)}
+AVAILABLE_INPUT_SPECS = {
+    "penner": {
+        "name": "Sulfur-Penner",
+        "description": (
+            "Probabilistic input model for the Sulfur model "
+            "from Penner et al. (1994)."
+        ),
+        "marginals": INPUT_MARGINALS_PENNER,
+        "copulas": None,
+    }
+}
 
 DEFAULT_INPUT_SELECTION = "penner"
 
-DEFAULT_PARAMETERS = None
+AVAILABLE_PARAMETERS = None
 
 SOLAR_CONSTANT = 1361  # [W/m^2] from [4]
 EARTH_AREA = 5.1e14  # [m^2] from [5]

--- a/src/uqtestfuns/test_functions/wing_weight.py
+++ b/src/uqtestfuns/test_functions/wing_weight.py
@@ -14,11 +14,14 @@ References
 import numpy as np
 
 from .utils import deg2rad
-from ..core import UnivariateInput, MultivariateInput
+from ..core import UnivariateInput
 
 DEFAULT_NAME = "Wing-Weight"
 
-DEFAULT_INPUT_MARGINALS = [
+TAGS = ["metamodeling", "sensitivity-analysis"]
+
+
+INPUT_MARGINALS_FORRESTER = [
     UnivariateInput(
         name="Sw",
         distribution="uniform",
@@ -81,13 +84,21 @@ DEFAULT_INPUT_MARGINALS = [
     ),
 ]
 
-DEFAULT_INPUTS = {
-    "forrester": MultivariateInput(DEFAULT_INPUT_MARGINALS),
+AVAILABLE_INPUT_SPECS = {
+    "forrester": {
+        "name": "Wing-Weight-Forrester",
+        "description": (
+            "Probabilistic input model for the Wing Weight model "
+            "from Forrester et al. (2008)."
+        ),
+        "marginals": INPUT_MARGINALS_FORRESTER,
+        "copulas": None,
+    }
 }
 
 DEFAULT_INPUT_SELECTION = "forrester"
 
-DEFAULT_PARAMETERS = None
+AVAILABLE_PARAMETERS = None
 
 
 def evaluate(xx: np.ndarray) -> np.ndarray:

--- a/tests/test_ishigami.py
+++ b/tests/test_ishigami.py
@@ -15,7 +15,7 @@ from uqtestfuns.test_functions import ishigami as ishigami_mod
 
 
 # Test for different parameters to the Ishigami function
-parameters = list(ishigami_mod.DEFAULT_PARAMETERS.values()) + [(7.0, 0.05)]
+parameters = list(ishigami_mod.AVAILABLE_PARAMETERS.values()) + [(7.0, 0.05)]
 
 
 @pytest.fixture(params=parameters)
@@ -70,13 +70,13 @@ def test_different_parameters(param_selection):
 
     # Create an instance of Ishigami function with a specified param. selection
     my_testfun = uqtestfuns.create_from_default(
-        "ishigami", param_selection=param_selection
+        "ishigami", parameters=param_selection
     )
 
     # Assertion
     assert (
         my_testfun.parameters
-        == ishigami_mod.DEFAULT_PARAMETERS[param_selection]
+        == ishigami_mod.AVAILABLE_PARAMETERS[param_selection]
     )
 
 
@@ -89,4 +89,4 @@ def test_wrong_dimension():
 def test_wrong_param_selection():
     """Test a wrong selection of the parameters."""
     with pytest.raises(ValueError):
-        uqtestfuns.create_from_default("ishigami", param_selection="marelli1")
+        uqtestfuns.create_from_default("ishigami", parameters="marelli1")

--- a/tests/test_otl_circuit.py
+++ b/tests/test_otl_circuit.py
@@ -13,8 +13,8 @@ from uqtestfuns import create_from_default
 
 def test_inert_inputs():
     """Test whether the inputs from 'Moon' specification are indeed inert."""
-    otl_ben_ari = create_from_default("otl", input_selection="ben-ari")
-    otl_moon = create_from_default("otl", input_selection="moon")
+    otl_ben_ari = create_from_default("otl", prob_input="ben-ari")
+    otl_moon = create_from_default("otl", prob_input="moon")
 
     # Generate sample and compare both
     num_sample = 1000000

--- a/tests/test_piston.py
+++ b/tests/test_piston.py
@@ -13,8 +13,8 @@ from uqtestfuns import create_from_default
 
 def test_inert_inputs():
     """Test whether the inputs from 'Moon' specification are indeed inert."""
-    otl_ben_ari = create_from_default("piston", input_selection="ben-ari")
-    otl_moon = create_from_default("piston", input_selection="moon")
+    otl_ben_ari = create_from_default("piston", prob_input="ben-ari")
+    otl_moon = create_from_default("piston", prob_input="moon")
 
     # Generate sample and compare both
     num_sample = 1000000

--- a/tests/test_sobol_g.py
+++ b/tests/test_sobol_g.py
@@ -14,41 +14,39 @@ from uqtestfuns.test_functions import sobol_g as sobol_g_mod
 
 
 @pytest.mark.parametrize(
-    "parameter", [None] + list(sobol_g_mod.DEFAULT_PARAMETERS.keys())
+    "parameter", [None] + list(sobol_g_mod.AVAILABLE_PARAMETERS.keys())
 )
 def test_different_parameters(parameter):
     """Test selecting different built-in parameters."""
 
     # Create an instance of a test function with a specified param. selection
-    my_fun = uqtestfuns.create_from_default(
-        "sobol-g", param_selection=parameter
-    )
+    my_fun = uqtestfuns.create_from_default("sobol-g", parameters=parameter)
 
     # Assertion
     if parameter:
-        stored_parameters = sobol_g_mod.DEFAULT_PARAMETERS[parameter](
+        stored_parameters = sobol_g_mod.AVAILABLE_PARAMETERS[parameter](
             my_fun.spatial_dimension
         )
         assert np.allclose(my_fun.parameters, stored_parameters)
     else:
         default_selection = sobol_g_mod.DEFAULT_PARAMETERS_SELECTION
-        stored_parameters = sobol_g_mod.DEFAULT_PARAMETERS[default_selection](
-            sobol_g_mod.DEFAULT_DIMENSION
-        )
+        stored_parameters = sobol_g_mod.AVAILABLE_PARAMETERS[
+            default_selection
+        ](sobol_g_mod.DEFAULT_DIMENSION)
         assert np.allclose(my_fun.parameters, stored_parameters)
 
 
 def test_wrong_param_selection():
     """Test a wrong selection of the parameters."""
     with pytest.raises(ValueError):
-        uqtestfuns.create_from_default("sobol-g", param_selection="marelli1")
+        uqtestfuns.create_from_default("sobol-g", parameters="marelli1")
 
 
 # ATTENTION: some parameters choice (e.g., "sobol-1")
 # can't be estimated properly with low N at high dimension
 @pytest.mark.parametrize("spatial_dimension", [None, 1, 2, 10])
 @pytest.mark.parametrize(
-    "parameter", [None] + list(sobol_g_mod.DEFAULT_PARAMETERS.keys())
+    "parameter", [None] + list(sobol_g_mod.AVAILABLE_PARAMETERS.keys())
 )
 def test_compute_mean(spatial_dimension, parameter):
     """Test the mean computation as the result is analytical."""
@@ -57,7 +55,7 @@ def test_compute_mean(spatial_dimension, parameter):
     my_fun = uqtestfuns.create_from_default(
         "sobol-g",
         spatial_dimension=spatial_dimension,
-        param_selection=parameter,
+        parameters=parameter,
     )
 
     # Compute mean via Monte Carlo
@@ -76,7 +74,7 @@ def test_compute_mean(spatial_dimension, parameter):
 # ATTENTION: parameters with "Sobol-1" is unstable at large dimension >= 15
 @pytest.mark.parametrize("spatial_dimension", [None, 1, 2, 10])
 @pytest.mark.parametrize(
-    "parameter", [None] + list(sobol_g_mod.DEFAULT_PARAMETERS.keys())
+    "parameter", [None] + list(sobol_g_mod.AVAILABLE_PARAMETERS.keys())
 )
 def test_compute_variance(spatial_dimension, parameter):
     """Test the variance computation as the result is analytical."""
@@ -85,7 +83,7 @@ def test_compute_variance(spatial_dimension, parameter):
     my_fun = uqtestfuns.create_from_default(
         "sobol-g",
         spatial_dimension=spatial_dimension,
-        param_selection=parameter,
+        parameters=parameter,
     )
 
     # Compute the variance via Monte Carlo

--- a/tests/test_univariate_logitnormal.py
+++ b/tests/test_univariate_logitnormal.py
@@ -77,4 +77,4 @@ def test_median() -> None:
     # Reference median is the logistic of the mean
     median_ref = logistic(parameters[0])
 
-    assert np.isclose(median, median_ref, rtol=1e-03, atol=1e-04)
+    assert np.isclose(median, median_ref, rtol=1e-03, atol=1e-03)

--- a/tests/test_wing_weight.py
+++ b/tests/test_wing_weight.py
@@ -16,5 +16,5 @@ def test_wrong_param_selection():
     with pytest.raises(ValueError):
         uqtestfuns.create_from_default(
             "wing-weight",
-            param_selection="marrei1",
+            parameters="marrei1",
         )


### PR DESCRIPTION
- Some attributes have been renamed, e.g., `DEFAULT_INPUTS` becomes `AVAILABLE_INPUT_SPECS`.
- Because 'MultivariateInput' object is not frozen, it would be better to store the probabilistic input specification instead of `MultivariateInput` instance such that when`'create_from_default()` function is called a new instance of `MultivariateInput` will be created.
- `create_from_default()` parameter names have been renamed.

This PR should resolve Issue #100.