### PR TITLE
Fix issue with class-level attributes

### DIFF
--- a/src/uqtestfuns/core/uqtestfun.py
+++ b/src/uqtestfuns/core/uqtestfun.py
@@ -15,15 +15,15 @@ __all__ = ["UQTestFun"]
 class UQTestFun(UQTestFunABC):
     """Generic concrete class of UQ test function."""
 
-    tags = None
+    _TAGS = None
 
-    available_inputs = None
+    _AVAILABLE_INPUTS = None
 
-    available_parameters = None
+    _AVAILABLE_PARAMETERS = None
 
-    default_dimension = None
+    _DEFAULT_SPATIAL_DIMENSION = None
 
-    description = None
+    _DESCRIPTION = None
 
     def __init__(
         self,

--- a/src/uqtestfuns/helpers.py
+++ b/src/uqtestfuns/helpers.py
@@ -107,18 +107,18 @@ def list_functions(
     ):
         available_class = available_classes_dict[available_class_name]
 
-        default_dimension = available_class.default_dimension
-        if not default_dimension:
-            default_dimension = "M"
+        default_spatial_dimension = available_class.DEFAULT_SPATIAL_DIMENSION
+        if not default_spatial_dimension:
+            default_spatial_dimension = "M"
 
-        tags = ", ".join(available_class.tags)
+        tags = ", ".join(available_class.TAGS)
 
-        description = available_class.description
+        description = available_class.DESCRIPTION
 
         value = [
             idx + 1,
             f"{available_class_name}()",
-            f"{default_dimension}",
+            f"{default_spatial_dimension}",
             tags,
             f"{description}",
         ]
@@ -223,11 +223,13 @@ def _get_functions_from_dimension(
         available_class_name,
         available_class_path,
     ) in available_classes.items():
-        default_dimension = available_class_path.default_dimension
-        if not default_dimension:
-            default_dimension = "m"
+        default_spatial_dimension = (
+            available_class_path.DEFAULT_SPATIAL_DIMENSION
+        )
+        if not default_spatial_dimension:
+            default_spatial_dimension = "m"
 
-        if default_dimension == spatial_dimension:
+        if default_spatial_dimension == spatial_dimension:
             values.append(available_class_name)
 
     return values
@@ -243,7 +245,7 @@ def _get_functions_from_tag(
         available_class_name,
         available_class_path,
     ) in available_classes.items():
-        tags = available_class_path.tags
+        tags = available_class_path.TAGS
 
         if tag in tags:
             values.append(available_class_name)

--- a/src/uqtestfuns/test_functions/ackley.py
+++ b/src/uqtestfuns/test_functions/ackley.py
@@ -90,15 +90,15 @@ class Ackley(UQTestFunABC):
         parameter sets. This is a keyword only parameter.
     """
 
-    tags = ["optimization"]
+    _TAGS = ["optimization"]
 
-    available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    available_parameters = tuple(AVAILABLE_PARAMETERS.keys())
+    _AVAILABLE_PARAMETERS = tuple(AVAILABLE_PARAMETERS.keys())
 
-    default_dimension = None
+    _DEFAULT_SPATIAL_DIMENSION = None
 
-    description = "Ackley function from Ackley (1987)"
+    _DESCRIPTION = "Ackley function from Ackley (1987)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/borehole.py
+++ b/src/uqtestfuns/test_functions/borehole.py
@@ -127,15 +127,15 @@ DEFAULT_INPUT_SELECTION = "harper"
 class Borehole(UQTestFunABC):
     """A concrete implementation of the Borehole function."""
 
-    tags = ["metamodeling", "sensitivity"]
+    _TAGS = ["metamodeling", "sensitivity"]
 
-    available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    available_parameters = None
+    _AVAILABLE_PARAMETERS = None
 
-    default_dimension = 8
+    _DEFAULT_SPATIAL_DIMENSION = 8
 
-    description = "Borehole function from Harper and Gupta (1983)"
+    _DESCRIPTION = "Borehole function from Harper and Gupta (1983)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/damped_oscillator.py
+++ b/src/uqtestfuns/test_functions/damped_oscillator.py
@@ -125,15 +125,15 @@ DEFAULT_INPUT_SELECTION = "de-kiureghian"
 class DampedOscillator(UQTestFunABC):
     """A concrete implementation of the Damped oscillator test function."""
 
-    tags = ["metamodeling", "sensitivity"]
+    _TAGS = ["metamodeling", "sensitivity"]
 
-    available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    available_parameters = None
+    _AVAILABLE_PARAMETERS = None
 
-    default_dimension = 8
+    _DEFAULT_SPATIAL_DIMENSION = 8
 
-    description = (
+    _DESCRIPTION = (
         "Damped oscillator model from Igusa and Der Kiureghian (1985)"
     )
 

--- a/src/uqtestfuns/test_functions/flood.py
+++ b/src/uqtestfuns/test_functions/flood.py
@@ -107,15 +107,15 @@ DEFAULT_INPUT_SELECTION = "iooss"
 class Flood(UQTestFunABC):
     """Concrete implementation of the Flood model test function."""
 
-    tags = ["metamodeling", "sensitivity"]
+    _TAGS = ["metamodeling", "sensitivity"]
 
-    available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    available_parameters = None
+    _AVAILABLE_PARAMETERS = None
 
-    default_dimension = 8
+    _DEFAULT_SPATIAL_DIMENSION = 8
 
-    description = "Flood model from Iooss and Lemaître (2015)"
+    _DESCRIPTION = "Flood model from Iooss and Lemaître (2015)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/ishigami.py
+++ b/src/uqtestfuns/test_functions/ishigami.py
@@ -81,15 +81,15 @@ DEFAULT_PARAMETERS_SELECTION = "ishigami"
 class Ishigami(UQTestFunABC):
     """A concrete implementation of the Ishigami function."""
 
-    tags = ["metamodeling", "sensitivity"]
+    _TAGS = ["metamodeling", "sensitivity"]
 
-    available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    available_parameters = tuple(AVAILABLE_PARAMETERS.keys())
+    _AVAILABLE_PARAMETERS = tuple(AVAILABLE_PARAMETERS.keys())
 
-    default_dimension = 3
+    _DEFAULT_SPATIAL_DIMENSION = 3
 
-    description = "Ishigami function from Ishigami and Homma (1991)"
+    _DESCRIPTION = "Ishigami function from Ishigami and Homma (1991)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/otl_circuit.py
+++ b/src/uqtestfuns/test_functions/otl_circuit.py
@@ -108,15 +108,15 @@ DEFAULT_INPUT_SELECTION = "ben-ari"
 class OTLCircuit(UQTestFunABC):
     """A concrete implementation of the OTL circuit test function."""
 
-    tags = ["metamodeling", "sensitivity"]
+    _TAGS = ["metamodeling", "sensitivity"]
 
-    available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    available_parameters = None
+    _AVAILABLE_PARAMETERS = None
 
-    default_dimension = 6
+    _DEFAULT_SPATIAL_DIMENSION = 6
 
-    description = (
+    _DESCRIPTION = (
         "Output transformerless (OTL) circuit model "
         "from Ben-Ari and Steinberg (2007)"
     )

--- a/src/uqtestfuns/test_functions/piston.py
+++ b/src/uqtestfuns/test_functions/piston.py
@@ -116,15 +116,15 @@ DEFAULT_INPUT_SELECTION = "ben-ari"
 class Piston(UQTestFunABC):
     """A concrete implementation of the Piston simulation test function."""
 
-    tags = ["metamodeling", "sensitivity"]
+    _TAGS = ["metamodeling", "sensitivity"]
 
-    available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    available_parameters = None
+    _AVAILABLE_PARAMETERS = None
 
-    default_dimension = 7
+    _DEFAULT_SPATIAL_DIMENSION = 7
 
-    description = "Piston simulation model from Ben-Ari and Steinberg (2007)"
+    _DESCRIPTION = "Piston simulation model from Ben-Ari and Steinberg (2007)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/sobol_g.py
+++ b/src/uqtestfuns/test_functions/sobol_g.py
@@ -200,15 +200,15 @@ DEFAULT_DIMENSION_SELECTION = 2
 class SobolG(UQTestFunABC):
     """A concrete implementation of the M-dimensional Sobol'-G function."""
 
-    tags = ["sensitivity"]
+    _TAGS = ["sensitivity"]
 
-    available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    available_parameters = tuple(AVAILABLE_PARAMETERS.keys())
+    _AVAILABLE_PARAMETERS = tuple(AVAILABLE_PARAMETERS.keys())
 
-    default_dimension = None
+    _DEFAULT_SPATIAL_DIMENSION = None
 
-    description = "Sobol-G function from Sobol' (1998)"
+    _DESCRIPTION = "Sobol-G function from Sobol' (1998)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/sulfur.py
+++ b/src/uqtestfuns/test_functions/sulfur.py
@@ -147,15 +147,15 @@ DAYS_IN_YEAR = 365  # [days]
 class Sulfur(UQTestFunABC):
     """A concrete implementation of the Sulfur model test function."""
 
-    tags = ["metamodeling", "sensitivity"]
+    _TAGS = ["metamodeling", "sensitivity"]
 
-    available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    available_parameters = None
+    _AVAILABLE_PARAMETERS = None
 
-    default_dimension = 9
+    _DEFAULT_SPATIAL_DIMENSION = 9
 
-    description = "Sulfur model from Charlson et al. (1992)"
+    _DESCRIPTION = "Sulfur model from Charlson et al. (1992)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/wing_weight.py
+++ b/src/uqtestfuns/test_functions/wing_weight.py
@@ -103,15 +103,15 @@ DEFAULT_INPUT_SELECTION = "forrester"
 class WingWeight(UQTestFunABC):
     """A concrete implementation of the wing weight test function."""
 
-    tags = ["metamodeling", "sensitivity"]
+    _TAGS = ["metamodeling", "sensitivity"]
 
-    available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    available_parameters = None
+    _AVAILABLE_PARAMETERS = None
 
-    default_dimension = 10
+    _DEFAULT_SPATIAL_DIMENSION = 10
 
-    description = "Wing weight model from Forrester et al. (2008)"
+    _DESCRIPTION = "Wing weight model from Forrester et al. (2008)"
 
     def __init__(
         self, *, prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION

--- a/tests/test_ishigami.py
+++ b/tests/test_ishigami.py
@@ -13,7 +13,7 @@ from uqtestfuns import Ishigami
 import uqtestfuns.test_functions.ishigami as ishigami_mod
 
 # Test for different parameters to the Ishigami function
-available_parameters = Ishigami.available_parameters
+available_parameters = Ishigami.AVAILABLE_PARAMETERS
 
 
 @pytest.fixture(params=available_parameters)

--- a/tests/test_sobol_g.py
+++ b/tests/test_sobol_g.py
@@ -11,7 +11,7 @@ import pytest
 
 from uqtestfuns import SobolG
 
-available_parameters = SobolG.available_parameters
+available_parameters = SobolG.AVAILABLE_PARAMETERS
 
 
 def test_wrong_param_selection():

--- a/tests/test_test_functions.py
+++ b/tests/test_test_functions.py
@@ -54,10 +54,12 @@ def test_create_instance_with_prob_input(builtin_testfun):
     my_prob_input = copy.copy(my_fun.prob_input)
 
     # Create an instance without probabilistic input
-    if testfun_class.available_inputs is not None:
+    if testfun_class.AVAILABLE_INPUTS is not None:
         my_fun_2 = testfun_class(prob_input_selection=None)
         assert my_fun_2.prob_input is None
-        assert my_fun_2.spatial_dimension == testfun_class.default_dimension
+        assert my_fun_2.spatial_dimension == (
+            testfun_class.DEFAULT_SPATIAL_DIMENSION
+        )
 
         # Assign the probabilistic input
         my_fun_2.prob_input = my_prob_input
@@ -83,7 +85,7 @@ def test_create_instance_with_parameters(builtin_testfun):
     my_fun = testfun_class()
     parameters = my_fun.parameters
 
-    if testfun_class.available_parameters is not None:
+    if testfun_class.AVAILABLE_PARAMETERS is not None:
         my_fun_2 = testfun_class(parameters_selection=None)
         assert my_fun_2.parameters is None
         my_fun_2.parameters = parameters
@@ -97,7 +99,7 @@ def test_available_inputs(builtin_testfun):
 
     testfun_class = builtin_testfun
 
-    available_inputs = testfun_class.available_inputs
+    available_inputs = testfun_class.AVAILABLE_INPUTS
 
     for available_input in available_inputs:
         assert_call(testfun_class, prob_input_selection=available_input)
@@ -108,7 +110,7 @@ def test_available_parameters(builtin_testfun):
 
     testfun_class = builtin_testfun
 
-    available_parameters = testfun_class.available_parameters
+    available_parameters = testfun_class.AVAILABLE_PARAMETERS
 
     if available_parameters is not None:
         for available_parameter in available_parameters:
@@ -223,7 +225,7 @@ def test_evaluate_wrong_input_domain(builtin_testfun):
 def test_evaluate_invalid_spatial_dim(builtin_testfun):
     """Test if an exception is raised if invalid spatial dimension is given."""
 
-    if builtin_testfun.default_dimension is None:
+    if builtin_testfun.DEFAULT_SPATIAL_DIMENSION is None:
         with pytest.raises(TypeError):
             builtin_testfun(spatial_dimension="10")
 

--- a/tests/test_uqtestfun.py
+++ b/tests/test_uqtestfun.py
@@ -67,7 +67,7 @@ def test_str(uqtestfun):
     str_ref = (
         f"Name              : {uqtestfun_instance.name}\n"
         f"Spatial dimension : {uqtestfun_instance.spatial_dimension}\n"
-        f"Description       : {uqtestfun_instance.description}"
+        f"Description       : {uqtestfun_instance.DESCRIPTION}"
     )
 
     assert uqtestfun_instance.__str__() == str_ref


### PR DESCRIPTION
- Mandatory class-level attributes defined in the abstract class are now verified when the concrete class is defined not when an instance is create.
- Class-level attributes cannot be modified via the instance.
- It is still possible though to modify the attributes directly from the class. But the attributes are, by convention, hidden (preceding underscore) and capitalize (a constant).

This is additional PR to resolve Issue #114.