### PR TITLE
Dev 132: Sync between two repos

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,17 @@
+name: mirror
+
+on: [push, delete]
+
+jobs:
+  mirror-to-CASUS:
+    runs-on: ubuntu-22.04
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: mirror-repository
+      uses: spyoungtech/mirror-action@master
+      with:
+        REMOTE: 'https://github.com/casus/uqtestfuns.git'
+        GIT_USERNAME: damar-wicaksono
+        GIT_PASSWORD: ${{ secrets.GIT_PASSWORD }}

--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -12,6 +12,6 @@ jobs:
     - name: mirror-repository
       uses: spyoungtech/mirror-action@master
       with:
-        REMOTE: 'https://github.com/casus/uqtestfuns.git'
-        GIT_USERNAME: damar-wicaksono
-        GIT_PASSWORD: ${{ secrets.GIT_PASSWORD }}
+        REMOTE: 'ssh://git@github.com/casus/uqtestfuns.git'
+        GIT_SSH_PRIVATE_KEY: ${{ secrets.GIT_SSH_PRIVATE_KEY }}
+        GIT_SSH_NO_VERIFY_HOST: "true"


### PR DESCRIPTION
Using GitHub action, the current repo is sync with the one in the CASUS organization. The sync is a one-way street.

This PR should resolve Issue #132.