### PR TITLE
A custom test function name can now be passed.

### DIFF
--- a/src/uqtestfuns/test_functions/ackley.py
+++ b/src/uqtestfuns/test_functions/ackley.py
@@ -113,6 +113,7 @@ class Ackley(UQTestFunABC):
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
         parameters_selection: Optional[str] = DEFAULT_PARAMETERS_SELECTION,
+        name: Optional[str] = None,
     ):
         # --- Arguments processing
         if not isinstance(spatial_dimension, int):
@@ -129,9 +130,12 @@ class Ackley(UQTestFunABC):
         parameters = create_parameters_from_available(
             parameters_selection, AVAILABLE_PARAMETERS, spatial_dimension
         )
+        # Process the default name
+        if name is None:
+            name = Ackley.__name__
 
         super().__init__(
-            prob_input=prob_input, parameters=parameters, name=Ackley.__name__
+            prob_input=prob_input, parameters=parameters, name=name
         )
 
     def evaluate(self, xx: np.ndarray):

--- a/src/uqtestfuns/test_functions/borehole.py
+++ b/src/uqtestfuns/test_functions/borehole.py
@@ -141,13 +141,17 @@ class Borehole(UQTestFunABC):
         self,
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
+        name: Optional[str] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
             prob_input_selection, AVAILABLE_INPUT_SPECS
         )
+        # Process the default name
+        if name is None:
+            name = Borehole.__name__
 
-        super().__init__(prob_input=prob_input, name=Borehole.__name__)
+        super().__init__(prob_input=prob_input, name=name)
 
     def evaluate(self, xx):
         """Evaluate the Borehole function on a set of input values.

--- a/src/uqtestfuns/test_functions/damped_oscillator.py
+++ b/src/uqtestfuns/test_functions/damped_oscillator.py
@@ -141,13 +141,17 @@ class DampedOscillator(UQTestFunABC):
         self,
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
+        name: Optional[str] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
             prob_input_selection, AVAILABLE_INPUT_SPECS
         )
+        # Process the default name
+        if name is None:
+            name = DampedOscillator.__name__
 
-        super().__init__(prob_input=prob_input, name=DampedOscillator.__name__)
+        super().__init__(prob_input=prob_input, name=name)
 
     def evaluate(self, xx: np.ndarray):
         """Evaluate the damped oscillator model on a set of input values.

--- a/src/uqtestfuns/test_functions/flood.py
+++ b/src/uqtestfuns/test_functions/flood.py
@@ -123,13 +123,17 @@ class Flood(UQTestFunABC):
         self,
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
+        name: Optional[str] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
             prob_input_selection, AVAILABLE_INPUT_SPECS
         )
+        # Process the default name
+        if name is None:
+            name = Flood.__name__
 
-        super().__init__(prob_input=prob_input, name=Flood.__name__)
+        super().__init__(prob_input=prob_input, name=name)
 
     def evaluate(self, xx):
         """Evaluate the flood model test function on a set of input values.

--- a/src/uqtestfuns/test_functions/ishigami.py
+++ b/src/uqtestfuns/test_functions/ishigami.py
@@ -102,6 +102,7 @@ class Ishigami(UQTestFunABC):
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
         parameters_selection: Optional[str] = DEFAULT_PARAMETERS_SELECTION,
+        name: Optional[str] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
@@ -111,11 +112,12 @@ class Ishigami(UQTestFunABC):
         parameters = create_parameters_from_available(
             parameters_selection, AVAILABLE_PARAMETERS
         )
+        # Process the default name
+        if name is None:
+            name = Ishigami.__name__
 
         super().__init__(
-            prob_input=prob_input,
-            parameters=parameters,
-            name=Ishigami.__name__,
+            prob_input=prob_input, parameters=parameters, name=name
         )
 
     def evaluate(self, xx):

--- a/src/uqtestfuns/test_functions/otl_circuit.py
+++ b/src/uqtestfuns/test_functions/otl_circuit.py
@@ -125,13 +125,17 @@ class OTLCircuit(UQTestFunABC):
         self,
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
+        name: Optional[str] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
             prob_input_selection, AVAILABLE_INPUT_SPECS
         )
+        # Process the default name
+        if name is None:
+            name = OTLCircuit.__name__
 
-        super().__init__(prob_input=prob_input, name=OTLCircuit.__name__)
+        super().__init__(prob_input=prob_input, name=name)
 
     def evaluate(self, xx: np.ndarray) -> np.ndarray:
         """Evaluate the OTL circuit test function on a set of input values.

--- a/src/uqtestfuns/test_functions/piston.py
+++ b/src/uqtestfuns/test_functions/piston.py
@@ -130,13 +130,17 @@ class Piston(UQTestFunABC):
         self,
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
+        name: Optional[str] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
             prob_input_selection, AVAILABLE_INPUT_SPECS
         )
+        # Process the default name
+        if name is None:
+            name = Piston.__name__
 
-        super().__init__(prob_input=prob_input, name=Piston.__name__)
+        super().__init__(prob_input=prob_input, name=name)
 
     def evaluate(self, xx: np.ndarray) -> np.ndarray:
         """Evaluate the OTL circuit test function on a set of input values.

--- a/src/uqtestfuns/test_functions/sobol_g.py
+++ b/src/uqtestfuns/test_functions/sobol_g.py
@@ -219,6 +219,7 @@ class SobolG(UQTestFunABC):
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
         parameters_selection: Optional[str] = DEFAULT_PARAMETERS_SELECTION,
+        name: Optional[str] = None,
     ):
         # --- Arguments processing
         if not isinstance(spatial_dimension, int):
@@ -235,9 +236,12 @@ class SobolG(UQTestFunABC):
         parameters = create_parameters_from_available(
             parameters_selection, AVAILABLE_PARAMETERS, spatial_dimension
         )
+        # Process the default name
+        if name is None:
+            name = SobolG.__name__
 
         super().__init__(
-            prob_input=prob_input, parameters=parameters, name=SobolG.__name__
+            prob_input=prob_input, parameters=parameters, name=name
         )
 
     def evaluate(self, xx: np.ndarray):

--- a/src/uqtestfuns/test_functions/sulfur.py
+++ b/src/uqtestfuns/test_functions/sulfur.py
@@ -163,13 +163,17 @@ class Sulfur(UQTestFunABC):
         self,
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
+        name: Optional[str] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
             prob_input_selection, AVAILABLE_INPUT_SPECS
         )
+        # Process the default name
+        if name is None:
+            name = Sulfur.__name__
 
-        super().__init__(prob_input=prob_input, name=Sulfur.__name__)
+        super().__init__(prob_input=prob_input, name=name)
 
     def evaluate(self, xx):
         """Evaluate the Sulfur model test function on a set of input values.

--- a/src/uqtestfuns/test_functions/wing_weight.py
+++ b/src/uqtestfuns/test_functions/wing_weight.py
@@ -122,14 +122,20 @@ class WingWeight(UQTestFunABC):
     _DESCRIPTION = "Wing weight model from Forrester et al. (2008)"
 
     def __init__(
-        self, *, prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION
+        self,
+        *,
+        prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
+        name: Optional[str] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
             prob_input_selection, AVAILABLE_INPUT_SPECS
         )
+        # Process the default name
+        if name is None:
+            name = WingWeight.__name__
 
-        super().__init__(prob_input=prob_input, name=WingWeight.__name__)
+        super().__init__(prob_input=prob_input, name=name)
 
     def evaluate(self, xx):
         """Evaluate the Wing Weight function on a set of input values.

--- a/tests/test_test_functions.py
+++ b/tests/test_test_functions.py
@@ -22,7 +22,6 @@ AVAILABLE_FUNCTION_CLASSES = get_available_classes(test_functions)
 
 @pytest.fixture(params=AVAILABLE_FUNCTION_CLASSES)
 def builtin_testfun(request):
-    print(request.param)
     _, testfun = request.param
 
     return testfun
@@ -34,6 +33,24 @@ def test_create_instance(builtin_testfun):
 
     # Assertion
     assert_call(testfun)
+
+
+def test_create_instance_with_custom_name(builtin_testfun):
+    """Test the creation of an instance and passing the name argument."""
+    testfun_class = builtin_testfun
+
+    # Get the default name of the test function
+    name = testfun_class.__name__
+
+    # Create a default instance
+    my_fun = testfun_class()
+
+    # Assertion
+    assert my_fun.name == name
+
+    # Use custom name to create a test function
+    my_fun = testfun_class(name=name)
+    assert my_fun.name == name
 
 
 def test_create_instance_with_prob_input(builtin_testfun):


### PR DESCRIPTION
A custom name for a test function instance can now be passed via `__init__()`.
For example:

```python
import uqtestfuns as uqtf

my_fun = uqtf.Borehole(name="The Borehole function")
```

Note that the default name is the class name itself.

This PR should resolve Issue #125.