### PR TITLE
Use Python3.9 in RTD to build the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.9"
   jobs:
     pre_build:
       - "jupyter-book config sphinx docs/"

--- a/docs/getting-started/obtaining-and-installing.md
+++ b/docs/getting-started/obtaining-and-installing.md
@@ -15,7 +15,7 @@ pip install git+https://github.com/damar-wicaksono/uqtestfuns.git
 ```{important}
 UQTestFuns is currently a work in progress,
 therefore the interfaces are subject to change, at least until v1.0.0
-are finally released.
+is finally released.
 ```
 
 It's a good idea to install the package in an isolated virtual environment.


### PR DESCRIPTION
- It seems this may play a role whether the docs can be built successfully or not.

This PR should resolve Issue #109.