### PR TITLE
Pseudo-RNG is now attached to the `UnivDist` and `ProbInput`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to the UQTestFuns project is documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.1.1] - 2023-07-03
+
+### Added
+
+- An instance of NumPy random number generator is now attached to instances of
+  `UnivDist` and `ProbInput`. The random seed
+  number may be passed to the corresponding constructor for reproducibility.
 
 ### Fixed
 
@@ -51,6 +59,7 @@ First public release of UQTestFuns.
 - CI/CD to build and serve the documentation on [ReadTheDocs](https://readthedocs.org/)
 - Mirror GitHub action to the [CASUS organization](https://github.com/casus)
 
+[Unreleased]: https://github.com/damar-wicaksono/uqtestfuns/compare/main...dev
 [0.1.1]: https://github.com/damar-wicaksono/uqtestfuns/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/damar-wicaksono/uqtestfuns/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/damar-wicaksono/uqtestfuns/releases/tag/v0.0.1

--- a/docs/getting-started/creating-a-built-in.md
+++ b/docs/getting-started/creating-a-built-in.md
@@ -47,7 +47,20 @@ in the context of metamodeling and sensitivity analysis.
 To instantiate a borehole test function, call the constructor as follows:
 
 ```{code-cell} ipython3
-my_testfun = uqtf.Borehole()
+my_testfun = uqtf.Borehole(rng_seed_prob_input=176326)
+```
+
+```{note}
+The parameter `rng_seed_prob_input` is optional; if not specified,
+the system entropy is used to initialized
+the [NumPy default random generator](https://numpy.org/doc/stable/reference/random/generator.html#numpy.random.default_rng).
+The number is given here such that the example is more or less reproducible.
+
+In UQTestFuns, each instance of test function carries its own pseudo-random
+number generator (RNG) for the corresponding probabilitic input model
+to avoid using the global NumPy random RNG.
+See this [blog post](https://albertcthomas.github.io/good-practices-random-number-generators/)
+regarding some good practices on using NumPy RNG.
 ```
 
 To verify whether the instance has been created,
@@ -81,7 +94,7 @@ my_testfun(xx)
 ```{note}
 Calling the function on a set of input values automatically
 verifies the correctness of the input (its dimensionality and bounds).
-Furthermore, the test function also accepts a vectorized input
+Moreover, the test function accepts a vectorized input
 (that is, an $N$-by-$M$ array where $N$ and $M$ are the number of points
 and dimensions, respectively)
 ```
@@ -153,8 +166,8 @@ For instance, suppose we have a sample of size $5$ in $[-1, 1]^8$
 for the borehole function:
 
 ```{code-cell} ipython3
-np.random.seed(42)
-xx_sample_dom_1 = -1 + 2 * np.random.rand(5, 8)
+rng_1 = np.random.default_rng(42)
+xx_sample_dom_1 = rng_1.uniform(low=-1, high=1, size=(5, 8))
 xx_sample_dom_1
 ```
 
@@ -172,15 +185,17 @@ It is possible to transform values defined in another uniform domain.
 For example, the sample values in $[0, 1]^8$ (a unit hypercube):
 
 ```{code-cell} ipython3
-np.random.seed(42)
-xx_sample_dom_2 = np.random.rand(5, 8)
+rng_2 = np.random.default_rng(42)
+xx_sample_dom_2 = rng_2.random((5, 8))
 xx_sample_dom_2
 ```
 
 can be transformed to the domain of the borehole function as follows:
 
 ```{code-cell} ipython3
-xx_sample_trans_2 = my_testfun.transform_sample(xx_sample_dom_2, min_value=0.0, max_value=1.0)
+xx_sample_trans_2 = my_testfun.transform_sample(
+    xx_sample_dom_2, min_value=0.0, max_value=1.0
+)
 xx_sample_trans_2
 ```
 
@@ -188,8 +203,8 @@ Note that for a given sample, the bounds of the hypercube domain must be
 the same in all dimensions.
 
 The two transformed values above should be the same since
-we reset the seed for the random number generator
-each time we call `np.random.rand()`.
+we use two instances of the default RNG with the same seed
+to generate the random sample.
 
 ```{code-cell} ipython3
 assert np.allclose(xx_sample_trans_1, xx_sample_trans_2)

--- a/src/uqtestfuns/core/prob_input/probabilistic_input.py
+++ b/src/uqtestfuns/core/prob_input/probabilistic_input.py
@@ -8,9 +8,11 @@ is defined by an instance of the ``UnivDist`` class.
 from __future__ import annotations
 
 import numpy as np
+
+from dataclasses import dataclass, field
+from numpy.random._generator import Generator
 from tabulate import tabulate
 from typing import Any, List, Optional, Union, Tuple
-from dataclasses import dataclass, field
 
 from .univariate_distribution import UnivDist, FIELD_NAMES
 
@@ -25,19 +27,26 @@ class ProbInput:
     Parameters
     ----------
     marginals : Union[List[UnivDist], Tuple[UnivDist, ...]]
-        A list of one-dimensional marginals (univariate random variables)
+        A list of one-dimensional marginals (univariate random variables).
     copulas : Any
         Copulas between univariate inputs that define dependence structure
-        (currently not used)
+        (currently not used).
     name : str, optional
-        The name of the probabilistic input model
+        The name of the probabilistic input model.
     description : str, optional
-        The short description regarding the input model
+        The short description regarding the input model.
+    rng_seed : int, optional.
+        The seed used to initialize the pseudo-random number generator.
+        If not specified, the value is taken from the system entropy.
 
     Attributes
     ----------
     spatial_dimension : int
         Number of constituents (random) input variables.
+    _rng : Generator
+        The default pseudo-random number generator of NumPy.
+        The generator is only created if or when needed (e.g., generating
+        a random sample from the distribution).
     """
 
     spatial_dimension: int = field(init=False)
@@ -45,6 +54,8 @@ class ProbInput:
     copulas: Any = None
     name: Optional[str] = None
     description: Optional[str] = None
+    rng_seed: Optional[int] = field(default=None, repr=False)
+    _rng: Optional[Generator] = field(init=False, default=None, repr=False)
 
     def __post_init__(self):
         self.spatial_dimension = len(self.marginals)
@@ -88,13 +99,15 @@ class ProbInput:
             where :math:`N` and :math:`M` are the sample size
             and the number of spatial dimensions, respectively.
         """
+        if self._rng is None:  # pragma: no cover
+            # Create a pseudo-random number generator (lazy evaluation)
+            self._rng = np.random.default_rng(self.rng_seed)
 
-        xx = np.empty((sample_size, self.spatial_dimension))
-        # Transform the sample in [0, 1] to the domain of the distribution
+        xx = self._rng.random((sample_size, self.spatial_dimension))
         if not self.copulas:
-            # Independent inputs generate sample marginal by marginal
+            # Transform the sample in [0, 1] to the domain of the distribution
             for idx_dim, marginal in enumerate(self.marginals):
-                xx[:, idx_dim] = marginal.get_sample(sample_size)
+                xx[:, idx_dim] = marginal.icdf(xx[:, idx_dim])
         else:
             raise ValueError("Copulas are not currently supported!")
 

--- a/src/uqtestfuns/test_functions/ackley.py
+++ b/src/uqtestfuns/test_functions/ackley.py
@@ -95,6 +95,14 @@ class Ackley(UQTestFunABC):
     parameters_selection : str, optional
         The selection of a parameters sets from a list of available
         parameter sets. This is a keyword only parameter.
+    name : str, optional
+        The name of the instance; if not given the default name is used.
+        This is a keyword only parameter.
+    rng_seed_prob_input : int, optional
+        The seed number for the pseudo-random number generator of the
+        corresponding `ProbInput`; if not given `None` is used
+        (taken from the system entropy).
+        This is a keyword only parameter.
     """
 
     _TAGS = ["optimization", "metamodeling"]
@@ -114,6 +122,7 @@ class Ackley(UQTestFunABC):
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
         parameters_selection: Optional[str] = DEFAULT_PARAMETERS_SELECTION,
         name: Optional[str] = None,
+        rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
         if not isinstance(spatial_dimension, int):
@@ -124,7 +133,10 @@ class Ackley(UQTestFunABC):
         # Ackley is an M-dimensional test function, either given / use default
         # Create the input according to spatial dimension
         prob_input = create_prob_input_from_available(
-            prob_input_selection, AVAILABLE_INPUT_SPECS, spatial_dimension
+            prob_input_selection,
+            AVAILABLE_INPUT_SPECS,
+            spatial_dimension,
+            rng_seed_prob_input,
         )
         # Create the parameters according to spatial dimension
         parameters = create_parameters_from_available(
@@ -135,7 +147,9 @@ class Ackley(UQTestFunABC):
             name = Ackley.__name__
 
         super().__init__(
-            prob_input=prob_input, parameters=parameters, name=name
+            prob_input=prob_input,
+            parameters=parameters,
+            name=name,
         )
 
     def evaluate(self, xx: np.ndarray):

--- a/src/uqtestfuns/test_functions/available.py
+++ b/src/uqtestfuns/test_functions/available.py
@@ -10,6 +10,7 @@ def create_prob_input_from_available(
     input_selection: Optional[str],
     available_input_specs: dict,
     spatial_dimension: Optional[int] = None,
+    rng_seed: Optional[int] = None,
 ) -> Optional[ProbInput]:
     """Construct a Multivariate input given available specifications.
 
@@ -22,6 +23,9 @@ def create_prob_input_from_available(
     spatial_dimension : int, optional
         The requested number of spatial dimensions, when applicable.
         Some specifications are functions of spatial dimension.
+    rng_seed : int, optional
+        The seed for the pseudo-random number generator; if not given then
+        the number is taken from the system entropy.
 
     Raises
     ------
@@ -41,9 +45,10 @@ def create_prob_input_from_available(
                 description=input_specs["description"],
                 marginals=marginals,
                 copulas=input_specs["copulas"],
+                rng_seed=rng_seed,
             )
         else:
-            prob_input = ProbInput(**input_specs)
+            prob_input = ProbInput(**input_specs, rng_seed=rng_seed)
     else:
         raise ValueError("Invalid selection!")
 

--- a/src/uqtestfuns/test_functions/borehole.py
+++ b/src/uqtestfuns/test_functions/borehole.py
@@ -142,10 +142,13 @@ class Borehole(UQTestFunABC):
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
         name: Optional[str] = None,
+        rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
-            prob_input_selection, AVAILABLE_INPUT_SPECS
+            prob_input_selection,
+            AVAILABLE_INPUT_SPECS,
+            rng_seed=rng_seed_prob_input,
         )
         # Process the default name
         if name is None:

--- a/src/uqtestfuns/test_functions/damped_oscillator.py
+++ b/src/uqtestfuns/test_functions/damped_oscillator.py
@@ -142,10 +142,13 @@ class DampedOscillator(UQTestFunABC):
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
         name: Optional[str] = None,
+        rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
-            prob_input_selection, AVAILABLE_INPUT_SPECS
+            prob_input_selection,
+            AVAILABLE_INPUT_SPECS,
+            rng_seed=rng_seed_prob_input,
         )
         # Process the default name
         if name is None:

--- a/src/uqtestfuns/test_functions/flood.py
+++ b/src/uqtestfuns/test_functions/flood.py
@@ -124,10 +124,13 @@ class Flood(UQTestFunABC):
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
         name: Optional[str] = None,
+        rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
-            prob_input_selection, AVAILABLE_INPUT_SPECS
+            prob_input_selection,
+            AVAILABLE_INPUT_SPECS,
+            rng_seed=rng_seed_prob_input,
         )
         # Process the default name
         if name is None:

--- a/src/uqtestfuns/test_functions/ishigami.py
+++ b/src/uqtestfuns/test_functions/ishigami.py
@@ -103,10 +103,13 @@ class Ishigami(UQTestFunABC):
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
         parameters_selection: Optional[str] = DEFAULT_PARAMETERS_SELECTION,
         name: Optional[str] = None,
+        rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
-            prob_input_selection, AVAILABLE_INPUT_SPECS
+            prob_input_selection,
+            AVAILABLE_INPUT_SPECS,
+            rng_seed=rng_seed_prob_input,
         )
         # Ishigami supports several different parameterizations
         parameters = create_parameters_from_available(

--- a/src/uqtestfuns/test_functions/oakley_ohagan_1d.py
+++ b/src/uqtestfuns/test_functions/oakley_ohagan_1d.py
@@ -64,10 +64,13 @@ class OakleyOHagan1D(UQTestFunABC):
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
         name: Optional[str] = None,
+        rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
-            prob_input_selection, AVAILABLE_INPUT_SPECS
+            prob_input_selection,
+            AVAILABLE_INPUT_SPECS,
+            rng_seed=rng_seed_prob_input,
         )
         # Process the default name
         if name is None:

--- a/src/uqtestfuns/test_functions/otl_circuit.py
+++ b/src/uqtestfuns/test_functions/otl_circuit.py
@@ -126,10 +126,13 @@ class OTLCircuit(UQTestFunABC):
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
         name: Optional[str] = None,
+        rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
-            prob_input_selection, AVAILABLE_INPUT_SPECS
+            prob_input_selection,
+            AVAILABLE_INPUT_SPECS,
+            rng_seed=rng_seed_prob_input,
         )
         # Process the default name
         if name is None:

--- a/src/uqtestfuns/test_functions/piston.py
+++ b/src/uqtestfuns/test_functions/piston.py
@@ -131,10 +131,13 @@ class Piston(UQTestFunABC):
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
         name: Optional[str] = None,
+        rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
-            prob_input_selection, AVAILABLE_INPUT_SPECS
+            prob_input_selection,
+            AVAILABLE_INPUT_SPECS,
+            rng_seed=rng_seed_prob_input,
         )
         # Process the default name
         if name is None:

--- a/src/uqtestfuns/test_functions/sobol_g.py
+++ b/src/uqtestfuns/test_functions/sobol_g.py
@@ -220,6 +220,7 @@ class SobolG(UQTestFunABC):
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
         parameters_selection: Optional[str] = DEFAULT_PARAMETERS_SELECTION,
         name: Optional[str] = None,
+        rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
         if not isinstance(spatial_dimension, int):
@@ -230,7 +231,10 @@ class SobolG(UQTestFunABC):
         # Sobol-G is an M-dimensional test function, either given / use default
         # Create the input according to spatial dimension
         prob_input = create_prob_input_from_available(
-            prob_input_selection, AVAILABLE_INPUT_SPECS, spatial_dimension
+            prob_input_selection,
+            AVAILABLE_INPUT_SPECS,
+            spatial_dimension,
+            rng_seed_prob_input,
         )
         # Create the parameters according to spatial dimension
         parameters = create_parameters_from_available(

--- a/src/uqtestfuns/test_functions/sulfur.py
+++ b/src/uqtestfuns/test_functions/sulfur.py
@@ -164,10 +164,13 @@ class Sulfur(UQTestFunABC):
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
         name: Optional[str] = None,
+        rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
-            prob_input_selection, AVAILABLE_INPUT_SPECS
+            prob_input_selection,
+            AVAILABLE_INPUT_SPECS,
+            rng_seed=rng_seed_prob_input,
         )
         # Process the default name
         if name is None:

--- a/src/uqtestfuns/test_functions/wing_weight.py
+++ b/src/uqtestfuns/test_functions/wing_weight.py
@@ -126,10 +126,13 @@ class WingWeight(UQTestFunABC):
         *,
         prob_input_selection: Optional[str] = DEFAULT_INPUT_SELECTION,
         name: Optional[str] = None,
+        rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
         prob_input = create_prob_input_from_available(
-            prob_input_selection, AVAILABLE_INPUT_SPECS
+            prob_input_selection,
+            AVAILABLE_INPUT_SPECS,
+            rng_seed=rng_seed_prob_input,
         )
         # Process the default name
         if name is None:

--- a/tests/builtin_test_functions/test_test_functions.py
+++ b/tests/builtin_test_functions/test_test_functions.py
@@ -154,26 +154,22 @@ def test_transform_input(builtin_testfun):
     """Test transforming a set of input values in the default unif. domain."""
 
     testfun = builtin_testfun
+    rng_seed = 32
 
     # Create an instance
-    my_fun = testfun()
+    my_fun = testfun(rng_seed_prob_input=rng_seed)
 
     sample_size = 100
 
     # Transformation from the default uniform domain to the input domain
-    np.random.seed(315)
-    # NOTE: Direct sample from the input property is done by column to column,
-    # for reproducibility using the same RNG seed the reference input must be
-    # filled in column by column as well with the. The call to NumPy random
-    # number generators below yields the same effect.
-    xx_1 = -1 + 2 * np.random.rand(my_fun.spatial_dimension, sample_size).T
+    rng = np.random.default_rng(rng_seed)
+    xx_1 = -1 + 2 * rng.random((sample_size, my_fun.spatial_dimension))
     xx_1 = my_fun.transform_sample(xx_1)
 
     # Directly sample from the input property
-    np.random.seed(315)
     xx_2 = my_fun.prob_input.get_sample(sample_size)
 
-    # Assertion: two sampled values are equal
+    # Assertion: Both samples are equal because the seed is identical
     assert np.allclose(xx_1, xx_2)
 
 
@@ -181,26 +177,22 @@ def test_transform_input_non_default(builtin_testfun):
     """Test transforming an input from non-default domain."""
 
     testfun = builtin_testfun
+    rng_seed = 1232
 
     # Create an instance
-    my_fun = testfun()
+    my_fun = testfun(rng_seed_prob_input=rng_seed)
 
     sample_size = 100
 
     # Transformation from non-default uniform domain to the input domain
-    np.random.seed(315)
-    # NOTE: Direct sample from the input property is done by column to column,
-    # for reproducibility using the same RNG seed the reference input must be
-    # filled in column by column as well with the. The call to NumPy random
-    # number generators below yields the same effect.
-    xx_1 = np.random.rand(my_fun.spatial_dimension, sample_size).T
+    rng = np.random.default_rng(rng_seed)
+    xx_1 = rng.random((sample_size, my_fun.spatial_dimension))
     xx_1 = my_fun.transform_sample(xx_1, min_value=0.0, max_value=1.0)
 
     # Directly sample from the input property
-    np.random.seed(315)
     xx_2 = my_fun.prob_input.get_sample(sample_size)
 
-    # Assertion: two sampled values are equal
+    # Assertion: Both samples are equal because the seed is identical
     assert np.allclose(xx_1, xx_2)
 
 

--- a/tests/core/prob_input/test_multivariate_input.py
+++ b/tests/core/prob_input/test_multivariate_input.py
@@ -217,6 +217,24 @@ def test_repr_html():
     assert my_multivariate_input._repr_html_() == str_ref
 
 
+@pytest.mark.parametrize("spatial_dimension", [1, 2, 10, 100])
+def test_pass_random_seed(spatial_dimension):
+    """Test passing random seed to the constructor."""
+    marginals = create_random_marginals(spatial_dimension)
+
+    # Create two instances with an identical seed number
+    rng_seed = 42
+    my_input_1 = ProbInput(marginals, rng_seed=rng_seed)
+    my_input_2 = ProbInput(marginals, rng_seed=rng_seed)
+
+    # Generate sample points
+    xx_1 = my_input_1.get_sample(1000)
+    xx_2 = my_input_2.get_sample(1000)
+
+    # Assertion: Both samples are identical because the seed is identical
+    assert np.allclose(xx_1, xx_2)
+
+
 #
 # def test_get_cdf_values():
 #     """Test the CDF values from an instance of UnivariateInput."""

--- a/tests/core/prob_input/test_univariate_input.py
+++ b/tests/core/prob_input/test_univariate_input.py
@@ -216,3 +216,19 @@ def test_cdf_monotonously_increasing(univariate_input: Any) -> None:
 
     # Assertion
     assert np.all(yy_diff >= 0.0)
+
+
+def test_pass_random_seed():
+    """Test passing random seed to the constructor."""
+
+    # Create two instances with an identical seed number
+    rng_seed = 42
+    my_input_1 = UnivDist("uniform", [0, 1], rng_seed=rng_seed)
+    my_input_2 = UnivDist("uniform", [0, 1], rng_seed=rng_seed)
+
+    # Generate sample points
+    xx_1 = my_input_1.get_sample(1000)
+    xx_2 = my_input_2.get_sample(1000)
+
+    # Assertion: Both samples are equal because the seed is identical
+    assert np.allclose(xx_1, xx_2)

--- a/tests/core/test_uqtestfun.py
+++ b/tests/core/test_uqtestfun.py
@@ -1,6 +1,7 @@
 """
 Test module for UQTestFun class, a generic class for generic UQ test function.
 """
+import numpy as np
 import pytest
 
 from uqtestfuns import UQTestFun, ProbInput
@@ -82,3 +83,12 @@ def test_invalid_input(uqtestfun):
 
     with pytest.raises(TypeError):
         UQTestFun(**uqtestfun_dict)
+
+
+def test_empty_uqtestfun():
+    """Test creation of an empty UQTestFun instance."""
+    my_fun = UQTestFun(lambda x: x)
+
+    with pytest.raises(ValueError):
+        xx = np.random.rand(10)
+        my_fun.transform_sample(xx)


### PR DESCRIPTION
- Following the best practice of using NumPy's pseudo-RNG, all instances of relevant classes (`UnivDist` and `ProbInput`) now include independent RNG to avoid using the global RNG. Seed number may be passed for reproducibility purposes.

This PR should resolve issue #182.