### PR TITLE
All class attributes are now lower case

### DIFF
--- a/docs/development/adding-test-function-implementation.md
+++ b/docs/development/adding-test-function-implementation.md
@@ -329,15 +329,15 @@ They are useful for the organization and bookkeeping of the test functions.
 ```python
 class Branin(UQTestFunABC):
     ...
-    _TAGS = ["optimization"]  # Application tags
+    _tags = ["optimization"]  # Application tags
 
-    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())  # Input selection keywords
+    _available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())  # Input selection keywords
 
-    _AVAILABLE_PARAMETERS = tuple(AVAILABLE_PARAMETERS.keys())  # Parameters selection keywords
+    _available_parameters = tuple(AVAILABLE_PARAMETERS.keys())  # Parameters selection keywords
 
-    _DEFAULT_SPATIAL_DIMENSION = 2  # Spatial dimension of the function
+    _default_spatial_dimension = 2  # Spatial dimension of the function
 
-    _DESCRIPTION = "Branin function from Dixon and Szegö (1978)"  # Short description
+    _description = "Branin function from Dixon and Szegö (1978)"  # Short description
     ...
 ```
 

--- a/src/uqtestfuns/core/uqtestfun.py
+++ b/src/uqtestfuns/core/uqtestfun.py
@@ -13,15 +13,15 @@ __all__ = ["UQTestFun"]
 class UQTestFun(UQTestFunABC):
     """Generic concrete class of UQ test function."""
 
-    _TAGS = None
+    _tags = None
 
-    _AVAILABLE_INPUTS = None
+    _available_inputs = None
 
-    _AVAILABLE_PARAMETERS = None
+    _available_parameters = None
 
-    _DEFAULT_SPATIAL_DIMENSION = None
+    _default_spatial_dimension = None
 
-    _DESCRIPTION = None
+    _description = None
 
     def __init__(
         self,

--- a/src/uqtestfuns/core/uqtestfun_abc.py
+++ b/src/uqtestfuns/core/uqtestfun_abc.py
@@ -12,11 +12,11 @@ from .utils import create_canonical_uniform_input
 __all__ = ["UQTestFunABC"]
 
 CLASS_HIDDEN_ATTRIBUTES = [
-    "_TAGS",
-    "_AVAILABLE_INPUTS",
-    "_AVAILABLE_PARAMETERS",
-    "_DEFAULT_SPATIAL_DIMENSION",
-    "_DESCRIPTION",
+    "_tags",
+    "_available_inputs",
+    "_available_parameters",
+    "_default_spatial_dimension",
+    "_description",
 ]
 
 
@@ -31,23 +31,7 @@ class classproperty(property):
 
 
 class UQTestFunABC(abc.ABC):
-    """An abstract class for UQ test functions.
-
-    Attributes
-    ----------
-    tags : List[str]
-        A List of tags to classify a test function given known field of
-        applications in the literature. This is an abstract class property.
-    available_inputs : Optional[Tuple[str, ...]]
-        A tuple of available probabilistic input model specification in the
-        literature. This is an abstract class property.
-    available_parameters : Optional[Tuple[str, ...]]
-        A tuple of available set of parameter values in the literature.
-        This is an abstract class property.
-    default_spatial_dimension : Optional[int]
-        The default spatial dimension of a UQ test function. If 'None' then
-        the function is a variable dimensional test function.
-    """
+    """An abstract class for UQ test functions."""
 
     def __init__(
         self,
@@ -89,29 +73,29 @@ class UQTestFunABC(abc.ABC):
                 )
 
     @classproperty
-    def TAGS(cls) -> Optional[List[str]]:
+    def tags(cls) -> Optional[List[str]]:
         """Tags to classify different UQ test functions."""
-        return cls._TAGS  # type: ignore
+        return cls._tags  # type: ignore
 
     @classproperty
-    def AVAILABLE_INPUTS(cls) -> Optional[Tuple[str, ...]]:
+    def available_inputs(cls) -> Optional[Tuple[str, ...]]:
         """All the keys to the available probabilistic input specifications."""
-        return cls._AVAILABLE_INPUTS  # type: ignore
+        return cls._available_inputs  # type: ignore
 
     @classproperty
-    def AVAILABLE_PARAMETERS(cls) -> Optional[Tuple[str, ...]]:
+    def available_parameters(cls) -> Optional[Tuple[str, ...]]:
         """All the keys to the available set of parameter values."""
-        return cls._AVAILABLE_PARAMETERS  # type: ignore
+        return cls._available_parameters  # type: ignore
 
     @classproperty
-    def DEFAULT_SPATIAL_DIMENSION(cls) -> Optional[int]:
+    def default_spatial_dimension(cls) -> Optional[int]:
         """To store the default dimension of a test function."""
-        return cls._DEFAULT_SPATIAL_DIMENSION  # type: ignore
+        return cls._default_spatial_dimension  # type: ignore
 
     @classproperty
-    def DESCRIPTION(cls) -> Optional[str]:
+    def description(cls) -> Optional[str]:
         """Short description of the UQ test function."""
-        return cls._DESCRIPTION  # type: ignore
+        return cls._description  # type: ignore
 
     @property
     def prob_input(self) -> Optional[ProbInput]:
@@ -145,7 +129,7 @@ class UQTestFunABC(abc.ABC):
         if self._prob_input is not None:
             return self._prob_input.spatial_dimension
         else:
-            return self.DEFAULT_SPATIAL_DIMENSION
+            return self.default_spatial_dimension
 
     @property
     def name(self) -> Optional[str]:
@@ -227,7 +211,7 @@ class UQTestFunABC(abc.ABC):
         out = (
             f"Name              : {self.name}\n"
             f"Spatial dimension : {self.spatial_dimension}\n"
-            f"Description       : {self.DESCRIPTION}"
+            f"Description       : {self.description}"
         )
 
         return out

--- a/src/uqtestfuns/helpers.py
+++ b/src/uqtestfuns/helpers.py
@@ -108,13 +108,13 @@ def list_functions(
     ):
         available_class = available_classes_dict[available_class_name]
 
-        default_spatial_dimension = available_class.DEFAULT_SPATIAL_DIMENSION
+        default_spatial_dimension = available_class.default_spatial_dimension
         if not default_spatial_dimension:
             default_spatial_dimension = "M"
 
-        tags = ", ".join(available_class.TAGS)
+        tags = ", ".join(available_class.tags)
 
-        description = available_class.DESCRIPTION
+        description = available_class.description
 
         value = [
             idx + 1,
@@ -227,7 +227,7 @@ def _get_functions_from_dimension(
         available_class_path,
     ) in available_classes.items():
         default_spatial_dimension = (
-            available_class_path.DEFAULT_SPATIAL_DIMENSION
+            available_class_path.default_spatial_dimension
         )
         if not default_spatial_dimension:
             default_spatial_dimension = "m"
@@ -248,7 +248,7 @@ def _get_functions_from_tag(
         available_class_name,
         available_class_path,
     ) in available_classes.items():
-        tags = available_class_path.TAGS
+        tags = available_class_path.tags
 
         if tag in tags:
             values.append(available_class_name)

--- a/src/uqtestfuns/test_functions/ackley.py
+++ b/src/uqtestfuns/test_functions/ackley.py
@@ -105,15 +105,15 @@ class Ackley(UQTestFunABC):
         This is a keyword only parameter.
     """
 
-    _TAGS = ["optimization", "metamodeling"]
+    _tags = ["optimization", "metamodeling"]
 
-    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    _AVAILABLE_PARAMETERS = tuple(AVAILABLE_PARAMETERS.keys())
+    _available_parameters = tuple(AVAILABLE_PARAMETERS.keys())
 
-    _DEFAULT_SPATIAL_DIMENSION = None
+    _default_spatial_dimension = None
 
-    _DESCRIPTION = "Ackley function from Ackley (1987)"
+    _description = "Ackley function from Ackley (1987)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/borehole.py
+++ b/src/uqtestfuns/test_functions/borehole.py
@@ -127,15 +127,15 @@ DEFAULT_INPUT_SELECTION = "Harper1983"
 class Borehole(UQTestFunABC):
     """A concrete implementation of the Borehole function."""
 
-    _TAGS = ["metamodeling", "sensitivity"]
+    _tags = ["metamodeling", "sensitivity"]
 
-    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    _AVAILABLE_PARAMETERS = None
+    _available_parameters = None
 
-    _DEFAULT_SPATIAL_DIMENSION = 8
+    _default_spatial_dimension = 8
 
-    _DESCRIPTION = "Borehole function from Harper and Gupta (1983)"
+    _description = "Borehole function from Harper and Gupta (1983)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/bratley1992.py
+++ b/src/uqtestfuns/test_functions/bratley1992.py
@@ -86,11 +86,11 @@ DEFAULT_DIMENSION_SELECTION = 2
 
 # Common metadata used in each class definition of Bratley test functions
 COMMON_METADATA = dict(
-    _TAGS=["integration", "sensitivity"],
-    _AVAILABLE_INPUTS=tuple(AVAILABLE_INPUT_SPECS.keys()),
-    _AVAILABLE_PARAMETERS=None,
-    _DEFAULT_SPATIAL_DIMENSION=None,
-    _DESCRIPTION="from Bratley et al. (1992)",
+    _tags=["integration", "sensitivity"],
+    _available_inputs=tuple(AVAILABLE_INPUT_SPECS.keys()),
+    _available_parameters=None,
+    _default_spatial_dimension=None,
+    _description="from Bratley et al. (1992)",
 )
 
 
@@ -145,12 +145,12 @@ class Bratley1992d(UQTestFunABC):
         This is a keyword only parameter.
     """
 
-    _TAGS = COMMON_METADATA["_TAGS"]
-    _AVAILABLE_INPUTS = COMMON_METADATA["_AVAILABLE_INPUTS"]
-    _AVAILABLE_PARAMETERS = COMMON_METADATA["_AVAILABLE_PARAMETERS"]
-    _DEFAULT_SPATIAL_DIMENSION = COMMON_METADATA["_DEFAULT_SPATIAL_DIMENSION"]
-    _DESCRIPTION = (
-        f"Integration test function #4 {COMMON_METADATA['_DESCRIPTION']}"
+    _tags = COMMON_METADATA["_tags"]
+    _available_inputs = COMMON_METADATA["_available_inputs"]
+    _available_parameters = COMMON_METADATA["_available_parameters"]
+    _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
+    _description = (
+        f"Integration test function #4 {COMMON_METADATA['_description']}"
     )
 
     __init__ = _init  # type: ignore

--- a/src/uqtestfuns/test_functions/damped_oscillator.py
+++ b/src/uqtestfuns/test_functions/damped_oscillator.py
@@ -125,15 +125,15 @@ DEFAULT_INPUT_SELECTION = "DerKiureghian1991"
 class DampedOscillator(UQTestFunABC):
     """A concrete implementation of the Damped oscillator test function."""
 
-    _TAGS = ["metamodeling", "sensitivity"]
+    _tags = ["metamodeling", "sensitivity"]
 
-    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    _AVAILABLE_PARAMETERS = None
+    _available_parameters = None
 
-    _DEFAULT_SPATIAL_DIMENSION = 8
+    _default_spatial_dimension = 8
 
-    _DESCRIPTION = (
+    _description = (
         "Damped oscillator model from Igusa and Der Kiureghian (1985)"
     )
 

--- a/src/uqtestfuns/test_functions/flood.py
+++ b/src/uqtestfuns/test_functions/flood.py
@@ -109,15 +109,15 @@ DEFAULT_INPUT_SELECTION = "Iooss2015"
 class Flood(UQTestFunABC):
     """Concrete implementation of the Flood model test function."""
 
-    _TAGS = ["metamodeling", "sensitivity"]
+    _tags = ["metamodeling", "sensitivity"]
 
-    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    _AVAILABLE_PARAMETERS = None
+    _available_parameters = None
 
-    _DEFAULT_SPATIAL_DIMENSION = 8
+    _default_spatial_dimension = 8
 
-    _DESCRIPTION = "Flood model from Iooss and Lemaître (2015)"
+    _description = "Flood model from Iooss and Lemaître (2015)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/franke.py
+++ b/src/uqtestfuns/test_functions/franke.py
@@ -79,11 +79,11 @@ AVAILABLE_INPUT_SPECS = {
 DEFAULT_INPUT_SELECTION = "Franke1979"
 
 COMMON_METADATA = dict(
-    _TAGS=["metamodeling"],
-    _AVAILABLE_INPUTS=tuple(AVAILABLE_INPUT_SPECS.keys()),
-    _AVAILABLE_PARAMETERS=None,
-    _DEFAULT_SPATIAL_DIMENSION=2,
-    _DESCRIPTION="from Franke (1979)",
+    _tags=["metamodeling"],
+    _available_inputs=tuple(AVAILABLE_INPUT_SPECS.keys()),
+    _available_parameters=None,
+    _default_spatial_dimension=2,
+    _description="from Franke (1979)",
 )
 
 
@@ -114,11 +114,11 @@ class Franke1(UQTestFunABC):
     The function features two Gaussian peaks and a Gaussian dip.
     """
 
-    _TAGS = COMMON_METADATA["_TAGS"]
-    _AVAILABLE_INPUTS = COMMON_METADATA["_AVAILABLE_INPUTS"]
-    _AVAILABLE_PARAMETERS = COMMON_METADATA["_AVAILABLE_PARAMETERS"]
-    _DEFAULT_SPATIAL_DIMENSION = COMMON_METADATA["_DEFAULT_SPATIAL_DIMENSION"]
-    _DESCRIPTION = f"(1st) Franke function {COMMON_METADATA['_DESCRIPTION']}"
+    _tags = COMMON_METADATA["_tags"]
+    _available_inputs = COMMON_METADATA["_available_inputs"]
+    _available_parameters = COMMON_METADATA["_available_parameters"]
+    _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
+    _description = f"(1st) Franke function {COMMON_METADATA['_description']}"
 
     __init__ = _init  # type: ignore
 
@@ -161,11 +161,11 @@ class Franke2(UQTestFunABC):
     The function features two plateaus joined by a steep hill.
     """
 
-    _TAGS = COMMON_METADATA["_TAGS"]
-    _AVAILABLE_INPUTS = COMMON_METADATA["_AVAILABLE_INPUTS"]
-    _AVAILABLE_PARAMETERS = COMMON_METADATA["_AVAILABLE_PARAMETERS"]
-    _DEFAULT_SPATIAL_DIMENSION = COMMON_METADATA["_DEFAULT_SPATIAL_DIMENSION"]
-    _DESCRIPTION = f"(2nd) Franke function {COMMON_METADATA['_DESCRIPTION']}"
+    _tags = COMMON_METADATA["_tags"]
+    _available_inputs = COMMON_METADATA["_available_inputs"]
+    _available_parameters = COMMON_METADATA["_available_parameters"]
+    _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
+    _description = f"(2nd) Franke function {COMMON_METADATA['_description']}"
 
     __init__ = _init  # type: ignore
 
@@ -196,11 +196,11 @@ class Franke3(UQTestFunABC):
     The function features a saddle shaped surface.
     """
 
-    _TAGS = COMMON_METADATA["_TAGS"]
-    _AVAILABLE_INPUTS = COMMON_METADATA["_AVAILABLE_INPUTS"]
-    _AVAILABLE_PARAMETERS = COMMON_METADATA["_AVAILABLE_PARAMETERS"]
-    _DEFAULT_SPATIAL_DIMENSION = COMMON_METADATA["_DEFAULT_SPATIAL_DIMENSION"]
-    _DESCRIPTION = f"(3rd) Franke function {COMMON_METADATA['_DESCRIPTION']}"
+    _tags = COMMON_METADATA["_tags"]
+    _available_inputs = COMMON_METADATA["_available_inputs"]
+    _available_parameters = COMMON_METADATA["_available_parameters"]
+    _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
+    _description = f"(3rd) Franke function {COMMON_METADATA['_description']}"
 
     __init__ = _init  # type: ignore
 
@@ -234,11 +234,11 @@ class Franke4(UQTestFunABC):
     The function features a gentle Gaussian hill.
     """
 
-    _TAGS = COMMON_METADATA["_TAGS"]
-    _AVAILABLE_INPUTS = COMMON_METADATA["_AVAILABLE_INPUTS"]
-    _AVAILABLE_PARAMETERS = COMMON_METADATA["_AVAILABLE_PARAMETERS"]
-    _DEFAULT_SPATIAL_DIMENSION = COMMON_METADATA["_DEFAULT_SPATIAL_DIMENSION"]
-    _DESCRIPTION = f"(4th) Franke function {COMMON_METADATA['_DESCRIPTION']}"
+    _tags = COMMON_METADATA["_tags"]
+    _available_inputs = COMMON_METADATA["_available_inputs"]
+    _available_parameters = COMMON_METADATA["_available_parameters"]
+    _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
+    _description = f"(4th) Franke function {COMMON_METADATA['_description']}"
 
     __init__ = _init  # type: ignore
 
@@ -274,11 +274,11 @@ class Franke5(UQTestFunABC):
     The function features a steep Gaussian hill.
     """
 
-    _TAGS = COMMON_METADATA["_TAGS"]
-    _AVAILABLE_INPUTS = COMMON_METADATA["_AVAILABLE_INPUTS"]
-    _AVAILABLE_PARAMETERS = COMMON_METADATA["_AVAILABLE_PARAMETERS"]
-    _DEFAULT_SPATIAL_DIMENSION = COMMON_METADATA["_DEFAULT_SPATIAL_DIMENSION"]
-    _DESCRIPTION = f"(5th) Franke function {COMMON_METADATA['_DESCRIPTION']}"
+    _tags = COMMON_METADATA["_tags"]
+    _available_inputs = COMMON_METADATA["_available_inputs"]
+    _available_parameters = COMMON_METADATA["_available_parameters"]
+    _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
+    _description = f"(5th) Franke function {COMMON_METADATA['_description']}"
 
     __init__ = _init  # type: ignore
 
@@ -314,11 +314,11 @@ class Franke6(UQTestFunABC):
     The function features a part of a sphere.
     """
 
-    _TAGS = COMMON_METADATA["_TAGS"]
-    _AVAILABLE_INPUTS = COMMON_METADATA["_AVAILABLE_INPUTS"]
-    _AVAILABLE_PARAMETERS = COMMON_METADATA["_AVAILABLE_PARAMETERS"]
-    _DEFAULT_SPATIAL_DIMENSION = COMMON_METADATA["_DEFAULT_SPATIAL_DIMENSION"]
-    _DESCRIPTION = f"(6th) Franke function {COMMON_METADATA['_DESCRIPTION']}"
+    _tags = COMMON_METADATA["_tags"]
+    _available_inputs = COMMON_METADATA["_available_inputs"]
+    _available_parameters = COMMON_METADATA["_available_parameters"]
+    _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
+    _description = f"(6th) Franke function {COMMON_METADATA['_description']}"
 
     __init__ = _init  # type: ignore
 

--- a/src/uqtestfuns/test_functions/ishigami.py
+++ b/src/uqtestfuns/test_functions/ishigami.py
@@ -87,15 +87,15 @@ DEFAULT_PARAMETERS_SELECTION = "Ishigami1991"
 class Ishigami(UQTestFunABC):
     """A concrete implementation of the Ishigami function."""
 
-    _TAGS = ["sensitivity"]
+    _tags = ["sensitivity"]
 
-    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    _AVAILABLE_PARAMETERS = tuple(AVAILABLE_PARAMETERS.keys())
+    _available_parameters = tuple(AVAILABLE_PARAMETERS.keys())
 
-    _DEFAULT_SPATIAL_DIMENSION = 3
+    _default_spatial_dimension = 3
 
-    _DESCRIPTION = "Ishigami function from Ishigami and Homma (1991)"
+    _description = "Ishigami function from Ishigami and Homma (1991)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/mclain.py
+++ b/src/uqtestfuns/test_functions/mclain.py
@@ -67,11 +67,11 @@ AVAILABLE_INPUT_SPECS = {
 DEFAULT_INPUT_SELECTION = "McLain1974"
 
 COMMON_METADATA = dict(
-    _TAGS=["metamodeling"],
-    _AVAILABLE_INPUTS=tuple(AVAILABLE_INPUT_SPECS.keys()),
-    _AVAILABLE_PARAMETERS=None,
-    _DEFAULT_SPATIAL_DIMENSION=2,
-    _DESCRIPTION="from McLain (1974)",
+    _tags=["metamodeling"],
+    _available_inputs=tuple(AVAILABLE_INPUT_SPECS.keys()),
+    _available_parameters=None,
+    _default_spatial_dimension=2,
+    _description="from McLain (1974)",
 )
 
 
@@ -102,11 +102,11 @@ class McLainS1(UQTestFunABC):
     The function features a part of a sphere.
     """
 
-    _TAGS = COMMON_METADATA["_TAGS"]
-    _AVAILABLE_INPUTS = COMMON_METADATA["_AVAILABLE_INPUTS"]
-    _AVAILABLE_PARAMETERS = COMMON_METADATA["_AVAILABLE_PARAMETERS"]
-    _DEFAULT_SPATIAL_DIMENSION = COMMON_METADATA["_DEFAULT_SPATIAL_DIMENSION"]
-    _DESCRIPTION = f"McLain S1 function {COMMON_METADATA['_DESCRIPTION']}"
+    _tags = COMMON_METADATA["_tags"]
+    _available_inputs = COMMON_METADATA["_available_inputs"]
+    _available_parameters = COMMON_METADATA["_available_parameters"]
+    _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
+    _description = f"McLain S1 function {COMMON_METADATA['_description']}"
 
     __init__ = _init  # type: ignore
 
@@ -137,11 +137,11 @@ class McLainS2(UQTestFunABC):
     The function features a steep hill rising from a plain.
     """
 
-    _TAGS = COMMON_METADATA["_TAGS"]
-    _AVAILABLE_INPUTS = COMMON_METADATA["_AVAILABLE_INPUTS"]
-    _AVAILABLE_PARAMETERS = COMMON_METADATA["_AVAILABLE_PARAMETERS"]
-    _DEFAULT_SPATIAL_DIMENSION = COMMON_METADATA["_DEFAULT_SPATIAL_DIMENSION"]
-    _DESCRIPTION = f"McLain S2 function {COMMON_METADATA['_DESCRIPTION']}"
+    _tags = COMMON_METADATA["_tags"]
+    _available_inputs = COMMON_METADATA["_available_inputs"]
+    _available_parameters = COMMON_METADATA["_available_parameters"]
+    _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
+    _description = f"McLain S2 function {COMMON_METADATA['_description']}"
 
     __init__ = _init  # type: ignore
 
@@ -171,11 +171,11 @@ class McLainS3(UQTestFunABC):
     The function features a less steep hill (compared to S2).
     """
 
-    _TAGS = COMMON_METADATA["_TAGS"]
-    _AVAILABLE_INPUTS = COMMON_METADATA["_AVAILABLE_INPUTS"]
-    _AVAILABLE_PARAMETERS = COMMON_METADATA["_AVAILABLE_PARAMETERS"]
-    _DEFAULT_SPATIAL_DIMENSION = COMMON_METADATA["_DEFAULT_SPATIAL_DIMENSION"]
-    _DESCRIPTION = f"McLain S3 function {COMMON_METADATA['_DESCRIPTION']}"
+    _tags = COMMON_METADATA["_tags"]
+    _available_inputs = COMMON_METADATA["_available_inputs"]
+    _available_parameters = COMMON_METADATA["_available_parameters"]
+    _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
+    _description = f"McLain S3 function {COMMON_METADATA['_description']}"
 
     __init__ = _init  # type: ignore
 
@@ -205,11 +205,11 @@ class McLainS4(UQTestFunABC):
     The function features a long narrow hill.
     """
 
-    _TAGS = COMMON_METADATA["_TAGS"]
-    _AVAILABLE_INPUTS = COMMON_METADATA["_AVAILABLE_INPUTS"]
-    _AVAILABLE_PARAMETERS = COMMON_METADATA["_AVAILABLE_PARAMETERS"]
-    _DEFAULT_SPATIAL_DIMENSION = COMMON_METADATA["_DEFAULT_SPATIAL_DIMENSION"]
-    _DESCRIPTION = f"McLain S4 function {COMMON_METADATA['_DESCRIPTION']}"
+    _tags = COMMON_METADATA["_tags"]
+    _available_inputs = COMMON_METADATA["_available_inputs"]
+    _available_parameters = COMMON_METADATA["_available_parameters"]
+    _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
+    _description = f"McLain S4 function {COMMON_METADATA['_description']}"
 
     __init__ = _init  # type: ignore
 
@@ -245,11 +245,11 @@ class McLainS5(UQTestFunABC):
     The function features two plateaus separated by a steep cliff.
     """
 
-    _TAGS = COMMON_METADATA["_TAGS"]
-    _AVAILABLE_INPUTS = COMMON_METADATA["_AVAILABLE_INPUTS"]
-    _AVAILABLE_PARAMETERS = COMMON_METADATA["_AVAILABLE_PARAMETERS"]
-    _DEFAULT_SPATIAL_DIMENSION = COMMON_METADATA["_DEFAULT_SPATIAL_DIMENSION"]
-    _DESCRIPTION = f"McLain S5 function {COMMON_METADATA['_DESCRIPTION']}"
+    _tags = COMMON_METADATA["_tags"]
+    _available_inputs = COMMON_METADATA["_available_inputs"]
+    _available_parameters = COMMON_METADATA["_available_parameters"]
+    _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
+    _description = f"McLain S5 function {COMMON_METADATA['_description']}"
 
     __init__ = _init  # type: ignore
 

--- a/src/uqtestfuns/test_functions/oakley_ohagan_1d.py
+++ b/src/uqtestfuns/test_functions/oakley_ohagan_1d.py
@@ -49,15 +49,15 @@ DEFAULT_INPUT_SELECTION = "Oakley2002"
 class OakleyOHagan1D(UQTestFunABC):
     """A concrete implementation of the 1D Oakley-O'Hagan test function."""
 
-    _TAGS = ["metamodeling"]
+    _tags = ["metamodeling"]
 
-    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    _AVAILABLE_PARAMETERS = None
+    _available_parameters = None
 
-    _DEFAULT_SPATIAL_DIMENSION = 1
+    _default_spatial_dimension = 1
 
-    _DESCRIPTION = "One-dimensional function from Oakley and O'Hagan (2002)"
+    _description = "One-dimensional function from Oakley and O'Hagan (2002)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/otl_circuit.py
+++ b/src/uqtestfuns/test_functions/otl_circuit.py
@@ -108,15 +108,15 @@ DEFAULT_INPUT_SELECTION = "BenAri2007"
 class OTLCircuit(UQTestFunABC):
     """A concrete implementation of the OTL circuit test function."""
 
-    _TAGS = ["metamodeling", "sensitivity"]
+    _tags = ["metamodeling", "sensitivity"]
 
-    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    _AVAILABLE_PARAMETERS = None
+    _available_parameters = None
 
-    _DEFAULT_SPATIAL_DIMENSION = 6
+    _default_spatial_dimension = 6
 
-    _DESCRIPTION = (
+    _description = (
         "Output transformerless (OTL) circuit model "
         "from Ben-Ari and Steinberg (2007)"
     )

--- a/src/uqtestfuns/test_functions/piston.py
+++ b/src/uqtestfuns/test_functions/piston.py
@@ -116,15 +116,15 @@ DEFAULT_INPUT_SELECTION = "BenAri2007"
 class Piston(UQTestFunABC):
     """A concrete implementation of the Piston simulation test function."""
 
-    _TAGS = ["metamodeling", "sensitivity"]
+    _tags = ["metamodeling", "sensitivity"]
 
-    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    _AVAILABLE_PARAMETERS = None
+    _available_parameters = None
 
-    _DEFAULT_SPATIAL_DIMENSION = 7
+    _default_spatial_dimension = 7
 
-    _DESCRIPTION = "Piston simulation model from Ben-Ari and Steinberg (2007)"
+    _description = "Piston simulation model from Ben-Ari and Steinberg (2007)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/sobol_g.py
+++ b/src/uqtestfuns/test_functions/sobol_g.py
@@ -203,15 +203,15 @@ DEFAULT_DIMENSION_SELECTION = 2
 class SobolG(UQTestFunABC):
     """A concrete implementation of the M-dimensional Sobol'-G function."""
 
-    _TAGS = ["sensitivity", "integration"]
+    _tags = ["sensitivity", "integration"]
 
-    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    _AVAILABLE_PARAMETERS = tuple(AVAILABLE_PARAMETERS.keys())
+    _available_parameters = tuple(AVAILABLE_PARAMETERS.keys())
 
-    _DEFAULT_SPATIAL_DIMENSION = None
+    _default_spatial_dimension = None
 
-    _DESCRIPTION = "Sobol'-G function from Radović et al. (1996)"
+    _description = "Sobol'-G function from Radović et al. (1996)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/sulfur.py
+++ b/src/uqtestfuns/test_functions/sulfur.py
@@ -149,15 +149,15 @@ DAYS_IN_YEAR = 365  # [days]
 class Sulfur(UQTestFunABC):
     """A concrete implementation of the Sulfur model test function."""
 
-    _TAGS = ["metamodeling", "sensitivity"]
+    _tags = ["metamodeling", "sensitivity"]
 
-    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    _AVAILABLE_PARAMETERS = None
+    _available_parameters = None
 
-    _DEFAULT_SPATIAL_DIMENSION = 9
+    _default_spatial_dimension = 9
 
-    _DESCRIPTION = "Sulfur model from Charlson et al. (1992)"
+    _description = "Sulfur model from Charlson et al. (1992)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/welch1992.py
+++ b/src/uqtestfuns/test_functions/welch1992.py
@@ -55,15 +55,15 @@ DEFAULT_INPUT_SELECTION = "Welch1992"
 class Welch1992(UQTestFunABC):
     """A concrete implementation of the Welch et al. (1992) test function."""
 
-    _TAGS = ["metamodeling", "sensitivity", "integration"]
+    _tags = ["metamodeling", "sensitivity", "integration"]
 
-    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    _AVAILABLE_PARAMETERS = None
+    _available_parameters = None
 
-    _DEFAULT_SPATIAL_DIMENSION = 20
+    _default_spatial_dimension = 20
 
-    _DESCRIPTION = "20-Dimensional function from Welch et al. (1992)"
+    _description = "20-Dimensional function from Welch et al. (1992)"
 
     def __init__(
         self,

--- a/src/uqtestfuns/test_functions/wing_weight.py
+++ b/src/uqtestfuns/test_functions/wing_weight.py
@@ -111,15 +111,15 @@ DEFAULT_INPUT_SELECTION = "Forrester2008"
 class WingWeight(UQTestFunABC):
     """A concrete implementation of the wing weight test function."""
 
-    _TAGS = ["metamodeling", "sensitivity"]
+    _tags = ["metamodeling", "sensitivity"]
 
-    _AVAILABLE_INPUTS = tuple(AVAILABLE_INPUT_SPECS.keys())
+    _available_inputs = tuple(AVAILABLE_INPUT_SPECS.keys())
 
-    _AVAILABLE_PARAMETERS = None
+    _available_parameters = None
 
-    _DEFAULT_SPATIAL_DIMENSION = 10
+    _default_spatial_dimension = 10
 
-    _DESCRIPTION = "Wing weight model from Forrester et al. (2008)"
+    _description = "Wing weight model from Forrester et al. (2008)"
 
     def __init__(
         self,

--- a/tests/builtin_test_functions/test_ishigami.py
+++ b/tests/builtin_test_functions/test_ishigami.py
@@ -13,7 +13,7 @@ from uqtestfuns import Ishigami
 import uqtestfuns.test_functions.ishigami as ishigami_mod
 
 # Test for different parameters to the Ishigami function
-available_parameters = Ishigami.AVAILABLE_PARAMETERS
+available_parameters = Ishigami.available_parameters
 
 
 @pytest.fixture(params=available_parameters)

--- a/tests/builtin_test_functions/test_sobol_g.py
+++ b/tests/builtin_test_functions/test_sobol_g.py
@@ -11,7 +11,7 @@ import pytest
 
 from uqtestfuns import SobolG
 
-available_parameters = SobolG.AVAILABLE_PARAMETERS
+available_parameters = SobolG.available_parameters
 
 
 def test_wrong_param_selection():

--- a/tests/builtin_test_functions/test_test_functions.py
+++ b/tests/builtin_test_functions/test_test_functions.py
@@ -13,8 +13,8 @@ import pytest
 import copy
 
 from conftest import assert_call
-from uqtestfuns.utils import get_available_classes
 
+from uqtestfuns.utils import get_available_classes
 from uqtestfuns import test_functions
 
 AVAILABLE_FUNCTION_CLASSES = get_available_classes(test_functions)
@@ -71,11 +71,11 @@ def test_create_instance_with_prob_input(builtin_testfun):
     my_prob_input = copy.copy(my_fun.prob_input)
 
     # Create an instance without probabilistic input
-    if testfun_class.AVAILABLE_INPUTS is not None:
+    if testfun_class.available_inputs is not None:
         my_fun_2 = testfun_class(prob_input_selection=None)
         assert my_fun_2.prob_input is None
         assert my_fun_2.spatial_dimension == (
-            testfun_class.DEFAULT_SPATIAL_DIMENSION
+            testfun_class.default_spatial_dimension
         )
 
         # Assign the probabilistic input
@@ -102,7 +102,7 @@ def test_create_instance_with_parameters(builtin_testfun):
     my_fun = testfun_class()
     parameters = my_fun.parameters
 
-    if testfun_class.AVAILABLE_PARAMETERS is not None:
+    if testfun_class.available_parameters is not None:
         my_fun_2 = testfun_class(parameters_selection=None)
         assert my_fun_2.parameters is None
         my_fun_2.parameters = parameters
@@ -116,7 +116,7 @@ def test_available_inputs(builtin_testfun):
 
     testfun_class = builtin_testfun
 
-    available_inputs = testfun_class.AVAILABLE_INPUTS
+    available_inputs = testfun_class.available_inputs
 
     for available_input in available_inputs:
         assert_call(testfun_class, prob_input_selection=available_input)
@@ -127,7 +127,7 @@ def test_available_parameters(builtin_testfun):
 
     testfun_class = builtin_testfun
 
-    available_parameters = testfun_class.AVAILABLE_PARAMETERS
+    available_parameters = testfun_class.available_parameters
 
     if available_parameters is not None:
         for available_parameter in available_parameters:
@@ -234,7 +234,7 @@ def test_evaluate_wrong_input_domain(builtin_testfun):
 def test_evaluate_invalid_spatial_dim(builtin_testfun):
     """Test if an exception is raised if invalid spatial dimension is given."""
 
-    if builtin_testfun.DEFAULT_SPATIAL_DIMENSION is None:
+    if builtin_testfun.default_spatial_dimension is None:
         with pytest.raises(TypeError):
             builtin_testfun(spatial_dimension="10")
 

--- a/tests/core/test_uqtestfun.py
+++ b/tests/core/test_uqtestfun.py
@@ -68,7 +68,7 @@ def test_str(uqtestfun):
     str_ref = (
         f"Name              : {uqtestfun_instance.name}\n"
         f"Spatial dimension : {uqtestfun_instance.spatial_dimension}\n"
-        f"Description       : {uqtestfun_instance.DESCRIPTION}"
+        f"Description       : {uqtestfun_instance.description}"
     )
 
     assert uqtestfun_instance.__str__() == str_ref


### PR DESCRIPTION
- The  class attributes of UQTestFunABC are now written in lower case letters to conform with Python convention. These attributes may still be read-only but there is already a mechanism to prevent rewriting the value (no setter).

This PR should resolve Issue #213.