### PR TITLE
Probabilistic input specification is now stored as NamedTuple

### DIFF
--- a/src/uqtestfuns/core/prob_input/input_spec.py
+++ b/src/uqtestfuns/core/prob_input/input_spec.py
@@ -1,0 +1,63 @@
+"""
+Module with definition of data structure to hold information on prob. input.
+
+The probabilistic input specification should be stored in a built-in Python
+data type that contains the only information required to construct
+a ProbInput instance. The container type should be free of custom methods.
+"""
+from typing import Any, Callable, List, NamedTuple, Optional, Tuple, Union
+
+
+__all__ = ["MarginalSpec", "ProbInputSpec", "ProbInputSpecVarDim"]
+
+
+class MarginalSpec(NamedTuple):
+    """A univariate marginal distribution specification.
+
+    Parameters
+    ----------
+    name : str
+        The name of the univariate marginal.
+    distribution : str
+        The name of the distribution of the univariate marginal.
+    parameters : Union[List[Union[int, float]], Tuple[Union[int, float], ...]]
+        Parameter values of the distribution.
+    description : str
+        Short description of the univariate marginal.
+    """
+
+    name: str
+    distribution: str
+    parameters: Union[List[Union[int, float]], Tuple[Union[int, float], ...]]
+    description: str
+
+
+class ProbInputSpec(NamedTuple):
+    """All the information required for constructing a ProbInput instance.
+
+    Parameters
+    ----------
+    name : str
+        The name of the probabilistic input model.
+    description : str
+        A short description of the probabilistic input model.
+    marginals : Union[Callable, List[MarginalSpec]]
+        A list of univariate marginal specifications or a callable
+        to construct the list of marginal specifications.
+    copulas : Optional[Any]
+        The copula specification of the probabilistic input model.
+    """
+
+    name: str
+    description: str
+    marginals: List[MarginalSpec]
+    copulas: Optional[Any]
+
+
+class ProbInputSpecVarDim(NamedTuple):
+    """All the information to construct a ProbInput w/ variable dimension."""
+
+    name: str
+    description: str
+    marginals_generator: Callable[[int], List[MarginalSpec]]
+    copulas: Optional[Any]

--- a/src/uqtestfuns/core/prob_input/univariate_distribution.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distribution.py
@@ -21,6 +21,7 @@ from .utils import (
     get_cdf_values,
     get_icdf_values,
 )
+from .input_spec import MarginalSpec
 from ...global_settings import ARRAY_FLOAT
 
 __all__ = ["UnivDist"]
@@ -156,4 +157,26 @@ class UnivDist:
 
         return get_icdf_values(
             xx, self.distribution, self.parameters, self.lower, self.upper
+        )
+
+    @classmethod
+    def from_spec(
+        cls, marginal_spec: MarginalSpec, rng_seed: Optional[int] = None
+    ):
+        """Create an instance of UnivDist from a marginal specification.
+
+        Parameters
+        ----------
+        marginal_spec : MarginalSpec
+            The specification for the univariate marginal.
+        rng_seed : int, optional
+            The seed used to initialize the pseudo-random number generator.
+            If not specified, the value is taken from the system entropy.
+        """
+        return cls(
+            distribution=marginal_spec.distribution,
+            parameters=marginal_spec.parameters,
+            name=marginal_spec.name,
+            description=marginal_spec.description,
+            rng_seed=rng_seed,
         )

--- a/src/uqtestfuns/test_functions/available.py
+++ b/src/uqtestfuns/test_functions/available.py
@@ -2,57 +2,9 @@
 Helpers module to construct probabilistic input and parameters.
 """
 from types import FunctionType
-from typing import Any, Optional
+from typing import Any, Dict, Optional, Union
 from ..core import ProbInput
-
-
-def create_prob_input_from_available(
-    input_selection: Optional[str],
-    available_input_specs: dict,
-    spatial_dimension: Optional[int] = None,
-    rng_seed: Optional[int] = None,
-) -> Optional[ProbInput]:
-    """Construct a Multivariate input given available specifications.
-
-    Parameters
-    ----------
-    input_selection : str
-        Which available input specifications to construct.
-    available_input_specs : dict
-        Dictionary of available probabilistic input specifications.
-    spatial_dimension : int, optional
-        The requested number of spatial dimensions, when applicable.
-        Some specifications are functions of spatial dimension.
-    rng_seed : int, optional
-        The seed for the pseudo-random number generator; if not given then
-        the number is taken from the system entropy.
-
-    Raises
-    ------
-    ValueError
-        If the input selection keyword not in the list of available
-        specifications.
-    """
-    if input_selection is None:
-        return None
-
-    if input_selection in available_input_specs:
-        input_specs = available_input_specs[input_selection]
-        if isinstance(input_specs["marginals"], FunctionType):
-            marginals = input_specs["marginals"](spatial_dimension)
-            prob_input = ProbInput(
-                name=input_specs["name"],
-                description=input_specs["description"],
-                marginals=marginals,
-                copulas=input_specs["copulas"],
-                rng_seed=rng_seed,
-            )
-        else:
-            prob_input = ProbInput(**input_specs, rng_seed=rng_seed)
-    else:
-        raise ValueError("Invalid selection!")
-
-    return prob_input
+from ..core.prob_input.input_spec import ProbInputSpec, ProbInputSpecVarDim
 
 
 def create_parameters_from_available(
@@ -84,3 +36,51 @@ def create_parameters_from_available(
         raise ValueError("Invalid parameters selection!")
 
     return parameters
+
+
+def get_prob_input_spec(
+    prob_input_selection: Optional[str],
+    available_input_specs: Dict[str, ProbInputSpec],
+) -> Optional[ProbInputSpec]:
+    """Get ProbInputSpec from the available specifications.
+
+    Parameters
+    ----------
+    """
+    if prob_input_selection is None:
+        return None
+
+    if prob_input_selection in available_input_specs:
+        prob_input_spec = available_input_specs[prob_input_selection]
+    else:
+        raise KeyError("Invalid ProbInput selection!")
+
+    return prob_input_spec
+
+
+def create_prob_input_from_spec(
+    prob_input_spec: Optional[Union[ProbInputSpec, ProbInputSpecVarDim]],
+    spatial_dimension: Optional[int] = None,
+    rng_seed: Optional[int] = None,
+) -> Optional[ProbInput]:
+    """Construct a Multivariate input given available specifications.
+
+    Parameters
+    ----------
+    prob_input_spec : Union[ProbInputSpec, ProbInputSpecVarDim], optional
+        The specification of a probabilistic input model.
+    spatial_dimension : int, optional
+        The requested number of spatial dimensions, when applicable.
+        Some specifications are functions of spatial dimension.
+    rng_seed : int, optional
+        The seed for the pseudo-random number generator; if not given then
+        the number is taken from the system entropy.
+    """
+    if prob_input_spec is None:
+        return None
+
+    prob_input = ProbInput.from_spec(
+        prob_input_spec, spatial_dimension=spatial_dimension, rng_seed=rng_seed
+    )
+
+    return prob_input

--- a/src/uqtestfuns/test_functions/borehole.py
+++ b/src/uqtestfuns/test_functions/borehole.py
@@ -25,57 +25,57 @@ import numpy as np
 
 from typing import Optional
 
-from ..core.prob_input.univariate_distribution import UnivDist
 from ..core.uqtestfun_abc import UQTestFunABC
-from .available import create_prob_input_from_available
+from ..core.prob_input.input_spec import MarginalSpec, ProbInputSpec
+from .available import get_prob_input_spec, create_prob_input_from_spec
 
 __all__ = ["Borehole"]
 
 # From Ref. [1]
 INPUT_MARGINALS_HARPER1983 = [
-    UnivDist(
+    MarginalSpec(
         name="rw",
         distribution="normal",
         parameters=[0.10, 0.0161812],
         description="radius of the borehole [m]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="r",
         distribution="lognormal",
         parameters=[7.71, 1.0056],
         description="radius of influence [m]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Tu",
         distribution="uniform",
         parameters=[63070.0, 115600.0],
         description="transmissivity of upper aquifer [m^2/year]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Hu",
         distribution="uniform",
         parameters=[990.0, 1100.0],
         description="potentiometric head of upper aquifer [m]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Tl",
         distribution="uniform",
         parameters=[63.1, 116.0],
         description="transmissivity of lower aquifer [m^2/year]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Hl",
         distribution="uniform",
         parameters=[700.0, 820.0],
         description="potentiometric head of lower aquifer [m]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="L",
         distribution="uniform",
         parameters=[1120.0, 1680.0],
         description="length of the borehole [m]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Kw",
         distribution="uniform",
         parameters=[9985.0, 12045.0],
@@ -86,13 +86,13 @@ INPUT_MARGINALS_HARPER1983 = [
 # From Ref. [2]
 INPUT_MARGINALS_MORRIS1993 = list(INPUT_MARGINALS_HARPER1983)
 INPUT_MARGINALS_MORRIS1993[0:2] = [
-    UnivDist(
+    MarginalSpec(
         name="rw",
         distribution="uniform",
         parameters=[0.05, 0.15],
         description="radius of the borehole [m]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="r",
         distribution="uniform",
         parameters=[100, 50000],
@@ -101,24 +101,24 @@ INPUT_MARGINALS_MORRIS1993[0:2] = [
 ]
 
 AVAILABLE_INPUT_SPECS = {
-    "Harper1983": {
-        "name": "Borehole-Harper-1983",
-        "description": (
+    "Harper1983": ProbInputSpec(
+        name="Borehole-Harper-1983",
+        description=(
             "Probabilistic input model of the Borehole model "
             "from Harper and Gupta (1983)."
         ),
-        "marginals": INPUT_MARGINALS_HARPER1983,
-        "copulas": None,
-    },
-    "Morris1993": {
-        "name": "Borehole-Morris-1993",
-        "description": (
+        marginals=INPUT_MARGINALS_HARPER1983,
+        copulas=None,
+    ),
+    "Morris1993": ProbInputSpec(
+        name="Borehole-Morris-1993",
+        description=(
             "Probabilistic input model of the Borehole model "
             "from Morris et al. (1993)."
         ),
-        "marginals": INPUT_MARGINALS_MORRIS1993,
-        "copulas": None,
-    },
+        marginals=INPUT_MARGINALS_MORRIS1993,
+        copulas=None,
+    ),
 }
 
 DEFAULT_INPUT_SELECTION = "Harper1983"
@@ -145,10 +145,13 @@ class Borehole(UQTestFunABC):
         rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
-        prob_input = create_prob_input_from_available(
-            prob_input_selection,
-            AVAILABLE_INPUT_SPECS,
-            rng_seed=rng_seed_prob_input,
+        # Get the ProbInputSpec from available
+        prob_input_spec = get_prob_input_spec(
+            prob_input_selection, AVAILABLE_INPUT_SPECS
+        )
+        # Create a ProbInput
+        prob_input = create_prob_input_from_spec(
+            prob_input_spec, rng_seed=rng_seed_prob_input
         )
         # Process the default name
         if name is None:

--- a/src/uqtestfuns/test_functions/damped_oscillator.py
+++ b/src/uqtestfuns/test_functions/damped_oscillator.py
@@ -34,15 +34,15 @@ import numpy as np
 
 from typing import Optional
 
-from ..core.prob_input.univariate_distribution import UnivDist
+from ..core.prob_input.input_spec import MarginalSpec, ProbInputSpec
 from ..core.uqtestfun_abc import UQTestFunABC
 from .utils import lognorm2norm_mean, lognorm2norm_std
-from .available import create_prob_input_from_available
+from .available import get_prob_input_spec, create_prob_input_from_spec
 
 __all__ = ["DampedOscillator"]
 
 INPUT_MARGINALS_DERKIUREGHIAN1991 = [  # From [2]
-    UnivDist(
+    MarginalSpec(
         name="Mp",
         distribution="lognormal",
         parameters=[
@@ -51,7 +51,7 @@ INPUT_MARGINALS_DERKIUREGHIAN1991 = [  # From [2]
         ],
         description="Primary mass",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Ms",
         distribution="lognormal",
         parameters=[
@@ -60,7 +60,7 @@ INPUT_MARGINALS_DERKIUREGHIAN1991 = [  # From [2]
         ],
         description="Secondary mass",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Kp",
         distribution="lognormal",
         parameters=[
@@ -69,7 +69,7 @@ INPUT_MARGINALS_DERKIUREGHIAN1991 = [  # From [2]
         ],
         description="Primary spring stiffness",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Ks",
         distribution="lognormal",
         parameters=[
@@ -78,7 +78,7 @@ INPUT_MARGINALS_DERKIUREGHIAN1991 = [  # From [2]
         ],
         description="Secondary spring stiffness",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Zeta_p",
         distribution="lognormal",
         parameters=[
@@ -87,7 +87,7 @@ INPUT_MARGINALS_DERKIUREGHIAN1991 = [  # From [2]
         ],
         description="Primary damping ratio",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Zeta_s",
         distribution="lognormal",
         parameters=[
@@ -96,7 +96,7 @@ INPUT_MARGINALS_DERKIUREGHIAN1991 = [  # From [2]
         ],
         description="Secondary damping ratio",
     ),
-    UnivDist(
+    MarginalSpec(
         name="S0",
         distribution="lognormal",
         parameters=[
@@ -108,15 +108,15 @@ INPUT_MARGINALS_DERKIUREGHIAN1991 = [  # From [2]
 ]
 
 AVAILABLE_INPUT_SPECS = {
-    "DerKiureghian1991": {
-        "name": "Damped-Oscillator-Der-Kiureghian-1991",
-        "description": (
+    "DerKiureghian1991": ProbInputSpec(
+        name="Damped-Oscillator-Der-Kiureghian-1991",
+        description=(
             "Probabilistic input model for the Damped Oscillator model "
             "from Der Kiureghian and De Stefano (1991)."
         ),
-        "marginals": INPUT_MARGINALS_DERKIUREGHIAN1991,
-        "copulas": None,
-    },
+        marginals=INPUT_MARGINALS_DERKIUREGHIAN1991,
+        copulas=None,
+    ),
 }
 
 DEFAULT_INPUT_SELECTION = "DerKiureghian1991"
@@ -145,10 +145,13 @@ class DampedOscillator(UQTestFunABC):
         rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
-        prob_input = create_prob_input_from_available(
-            prob_input_selection,
-            AVAILABLE_INPUT_SPECS,
-            rng_seed=rng_seed_prob_input,
+        # Get the ProbInputSpec from available
+        prob_input_spec = get_prob_input_spec(
+            prob_input_selection, AVAILABLE_INPUT_SPECS
+        )
+        # Create a ProbInput
+        prob_input = create_prob_input_from_spec(
+            prob_input_spec, rng_seed=rng_seed_prob_input
         )
         # Process the default name
         if name is None:

--- a/src/uqtestfuns/test_functions/flood.py
+++ b/src/uqtestfuns/test_functions/flood.py
@@ -34,56 +34,56 @@ import numpy as np
 
 from typing import Optional
 
-from ..core.prob_input.univariate_distribution import UnivDist
+from ..core.prob_input.input_spec import MarginalSpec, ProbInputSpec
 from ..core.uqtestfun_abc import UQTestFunABC
-from .available import create_prob_input_from_available
+from .available import get_prob_input_spec, create_prob_input_from_spec
 
 __all__ = ["Flood"]
 
 INPUT_MARGINALS_IOOSS2015 = [  # From Ref. [1]
-    UnivDist(
+    MarginalSpec(
         name="Q",
         distribution="trunc-gumbel",
         parameters=[1013.0, 558.0, 500.0, 3000.0],
         description="Maximum annual flow rate [m^3/s]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Ks",
         distribution="trunc-normal",
         parameters=[30.0, 8.0, 15.0, np.inf],
         description="Strickler coefficient [m^(1/3)/s]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Zv",
         distribution="triangular",
         parameters=[49.0, 51.0, 50.0],
         description="River downstream level [m]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Zm",
         distribution="triangular",
         parameters=[54.0, 56.0, 55.0],
         description="River upstream level [m]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Hd",
         distribution="uniform",
         parameters=[7.0, 9.0],
         description="Dyke height [m]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Cb",
         distribution="triangular",
         parameters=[55.0, 56.0, 55.5],
         description="Bank level [m]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="L",
         distribution="triangular",
         parameters=[4990.0, 5010.0, 5000.0],
         description="Length of the river stretch [m]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="B",
         distribution="triangular",
         parameters=[295.0, 305.0, 300.0],
@@ -92,15 +92,15 @@ INPUT_MARGINALS_IOOSS2015 = [  # From Ref. [1]
 ]
 
 AVAILABLE_INPUT_SPECS = {
-    "Iooss2015": {
-        "name": "Flood-Iooss-2015",
-        "description": (
+    "Iooss2015": ProbInputSpec(
+        name="Flood-Iooss-2015",
+        description=(
             "Probabilistic input model for the Flood model "
             "from Iooss and Lemaître (2015)."
         ),
-        "marginals": INPUT_MARGINALS_IOOSS2015,
-        "copulas": None,
-    }
+        marginals=INPUT_MARGINALS_IOOSS2015,
+        copulas=None,
+    ),
 }
 
 DEFAULT_INPUT_SELECTION = "Iooss2015"
@@ -127,10 +127,13 @@ class Flood(UQTestFunABC):
         rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
-        prob_input = create_prob_input_from_available(
-            prob_input_selection,
-            AVAILABLE_INPUT_SPECS,
-            rng_seed=rng_seed_prob_input,
+        # Get the ProbInputSpec from available
+        prob_input_spec = get_prob_input_spec(
+            prob_input_selection, AVAILABLE_INPUT_SPECS
+        )
+        # Create a ProbInput
+        prob_input = create_prob_input_from_spec(
+            prob_input_spec, rng_seed=rng_seed_prob_input
         )
         # Process the default name
         if name is None:

--- a/src/uqtestfuns/test_functions/franke.py
+++ b/src/uqtestfuns/test_functions/franke.py
@@ -43,20 +43,20 @@ import numpy as np
 
 from typing import Optional
 
-from ..core.prob_input.univariate_distribution import UnivDist
+from ..core.prob_input.input_spec import MarginalSpec, ProbInputSpec
 from ..core.uqtestfun_abc import UQTestFunABC
-from .available import create_prob_input_from_available
+from .available import get_prob_input_spec, create_prob_input_from_spec
 
 __all__ = ["Franke1", "Franke2", "Franke3", "Franke4", "Franke5", "Franke6"]
 
 INPUT_MARGINALS_FRANKE1979 = [  # From Ref. [1]
-    UnivDist(
+    MarginalSpec(
         name="X1",
         distribution="uniform",
         parameters=[0.0, 1.0],
         description="None",
     ),
-    UnivDist(
+    MarginalSpec(
         name="X2",
         distribution="uniform",
         parameters=[0.0, 1.0],
@@ -65,15 +65,15 @@ INPUT_MARGINALS_FRANKE1979 = [  # From Ref. [1]
 ]
 
 AVAILABLE_INPUT_SPECS = {
-    "Franke1979": {
-        "name": "Franke-1979",
-        "description": (
+    "Franke1979": ProbInputSpec(
+        name="Franke-1979",
+        description=(
             "Input specification for the Franke's test functions "
             "from Franke (1979)."
         ),
-        "marginals": INPUT_MARGINALS_FRANKE1979,
-        "copulas": None,
-    }
+        marginals=INPUT_MARGINALS_FRANKE1979,
+        copulas=None,
+    ),
 }
 
 DEFAULT_INPUT_SELECTION = "Franke1979"
@@ -96,10 +96,13 @@ def _init(
 ) -> None:
     """A common __init__ for all Franke's test functions."""
     # --- Arguments processing
-    prob_input = create_prob_input_from_available(
-        prob_input_selection,
-        AVAILABLE_INPUT_SPECS,
-        rng_seed=rng_seed_prob_input,
+    # Get the ProbInputSpec from available
+    prob_input_spec = get_prob_input_spec(
+        prob_input_selection, AVAILABLE_INPUT_SPECS
+    )
+    # Create a ProbInput
+    prob_input = create_prob_input_from_spec(
+        prob_input_spec, rng_seed=rng_seed_prob_input
     )
     # Process the default name
     if name is None:

--- a/src/uqtestfuns/test_functions/ishigami.py
+++ b/src/uqtestfuns/test_functions/ishigami.py
@@ -31,10 +31,11 @@ import numpy as np
 
 from typing import Optional
 
-from ..core.prob_input.univariate_distribution import UnivDist
+from ..core.prob_input.input_spec import MarginalSpec, ProbInputSpec
 from ..core.uqtestfun_abc import UQTestFunABC
 from .available import (
-    create_prob_input_from_available,
+    get_prob_input_spec,
+    create_prob_input_from_spec,
     create_parameters_from_available,
 )
 
@@ -42,19 +43,19 @@ __all__ = ["Ishigami"]
 
 
 INPUT_MARGINALS_ISHIGAMI1991 = [
-    UnivDist(
+    MarginalSpec(
         name="X1",
         distribution="uniform",
         parameters=[-np.pi, np.pi],
         description="None",
     ),
-    UnivDist(
+    MarginalSpec(
         name="X2",
         distribution="uniform",
         parameters=[-np.pi, np.pi],
         description="None",
     ),
-    UnivDist(
+    MarginalSpec(
         name="X3",
         distribution="uniform",
         parameters=[-np.pi, np.pi],
@@ -63,15 +64,15 @@ INPUT_MARGINALS_ISHIGAMI1991 = [
 ]
 
 AVAILABLE_INPUT_SPECS = {
-    "Ishigami1991": {
-        "name": "Ishigami-1991",
-        "description": (
+    "Ishigami1991": ProbInputSpec(
+        name="Ishigami-1991",
+        description=(
             "Probabilistic input model for the Ishigami function "
             "from Ishigami and Homma (1991)."
         ),
-        "marginals": INPUT_MARGINALS_ISHIGAMI1991,
-        "copulas": None,
-    }
+        marginals=INPUT_MARGINALS_ISHIGAMI1991,
+        copulas=None,
+    ),
 }
 
 DEFAULT_INPUT_SELECTION = "Ishigami1991"
@@ -106,10 +107,13 @@ class Ishigami(UQTestFunABC):
         rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
-        prob_input = create_prob_input_from_available(
-            prob_input_selection,
-            AVAILABLE_INPUT_SPECS,
-            rng_seed=rng_seed_prob_input,
+        # Get the ProbInputSpec from available
+        prob_input_spec = get_prob_input_spec(
+            prob_input_selection, AVAILABLE_INPUT_SPECS
+        )
+        # Create a ProbInput
+        prob_input = create_prob_input_from_spec(
+            prob_input_spec, rng_seed=rng_seed_prob_input
         )
         # Ishigami supports several different parameterizations
         parameters = create_parameters_from_available(

--- a/src/uqtestfuns/test_functions/mclain.py
+++ b/src/uqtestfuns/test_functions/mclain.py
@@ -31,20 +31,20 @@ import numpy as np
 
 from typing import Optional
 
-from ..core.prob_input.univariate_distribution import UnivDist
+from ..core.prob_input.input_spec import MarginalSpec, ProbInputSpec
 from ..core.uqtestfun_abc import UQTestFunABC
-from .available import create_prob_input_from_available
+from .available import get_prob_input_spec, create_prob_input_from_spec
 
 __all__ = ["McLainS1", "McLainS2", "McLainS3", "McLainS4", "McLainS5"]
 
 INPUT_MARGINALS_MCLAIN1974 = [  # From Ref. [1]
-    UnivDist(
+    MarginalSpec(
         name="X1",
         distribution="uniform",
         parameters=[1.0, 10.0],
         description="None",
     ),
-    UnivDist(
+    MarginalSpec(
         name="X2",
         distribution="uniform",
         parameters=[1.0, 10.0],
@@ -53,15 +53,15 @@ INPUT_MARGINALS_MCLAIN1974 = [  # From Ref. [1]
 ]
 
 AVAILABLE_INPUT_SPECS = {
-    "McLain1974": {
-        "name": "McLain-1974",
-        "description": (
+    "McLain1974": ProbInputSpec(
+        name="McLain-1974",
+        description=(
             "Input specification for the McLain's test functions "
             "from McLain (1974)."
         ),
-        "marginals": INPUT_MARGINALS_MCLAIN1974,
-        "copulas": None,
-    }
+        marginals=INPUT_MARGINALS_MCLAIN1974,
+        copulas=None,
+    ),
 }
 
 DEFAULT_INPUT_SELECTION = "McLain1974"
@@ -84,10 +84,13 @@ def _init(
 ) -> None:
     """A common __init__ for all McLain's test functions."""
     # --- Arguments processing
-    prob_input = create_prob_input_from_available(
-        prob_input_selection,
-        AVAILABLE_INPUT_SPECS,
-        rng_seed=rng_seed_prob_input,
+    # Get the ProbInputSpec from available
+    prob_input_spec = get_prob_input_spec(
+        prob_input_selection, AVAILABLE_INPUT_SPECS
+    )
+    # Create a ProbInput
+    prob_input = create_prob_input_from_spec(
+        prob_input_spec, rng_seed=rng_seed_prob_input
     )
     # Process the default name
     if name is None:

--- a/src/uqtestfuns/test_functions/oakley_ohagan_1d.py
+++ b/src/uqtestfuns/test_functions/oakley_ohagan_1d.py
@@ -17,14 +17,14 @@ import numpy as np
 
 from typing import Optional
 
-from ..core.prob_input.univariate_distribution import UnivDist
+from ..core.prob_input.input_spec import MarginalSpec, ProbInputSpec
 from ..core.uqtestfun_abc import UQTestFunABC
-from .available import create_prob_input_from_available
+from .available import get_prob_input_spec, create_prob_input_from_spec
 
 __all__ = ["OakleyOHagan1D"]
 
 INPUT_MARGINALS_OAKLEY2002 = [
-    UnivDist(
+    MarginalSpec(
         name="x",
         distribution="normal",
         parameters=[0.0, 4.0],
@@ -33,14 +33,15 @@ INPUT_MARGINALS_OAKLEY2002 = [
 ]
 
 AVAILABLE_INPUT_SPECS = {
-    "Oakley2002": {
-        "name": "Oakley-OHagan-2002",
-        "description": (
+    "Oakley2002": ProbInputSpec(
+        name="Oakley-OHagan-2002",
+        description=(
             "Probabilistic input model for the one-dimensional function "
             "from Oakley-O'Hagan function (2002)"
         ),
-        "marginals": INPUT_MARGINALS_OAKLEY2002,
-    }
+        marginals=INPUT_MARGINALS_OAKLEY2002,
+        copulas=None,
+    ),
 }
 
 DEFAULT_INPUT_SELECTION = "Oakley2002"
@@ -67,10 +68,13 @@ class OakleyOHagan1D(UQTestFunABC):
         rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
-        prob_input = create_prob_input_from_available(
-            prob_input_selection,
-            AVAILABLE_INPUT_SPECS,
-            rng_seed=rng_seed_prob_input,
+        # Get the ProbInputSpec from available
+        prob_input_spec = get_prob_input_spec(
+            prob_input_selection, AVAILABLE_INPUT_SPECS
+        )
+        # Create a ProbInput
+        prob_input = create_prob_input_from_spec(
+            prob_input_spec, rng_seed=rng_seed_prob_input
         )
         # Process the default name
         if name is None:

--- a/src/uqtestfuns/test_functions/otl_circuit.py
+++ b/src/uqtestfuns/test_functions/otl_circuit.py
@@ -25,44 +25,44 @@ import numpy as np
 from copy import copy
 from typing import Optional
 
-from ..core.prob_input.univariate_distribution import UnivDist
+from ..core.prob_input.input_spec import MarginalSpec, ProbInputSpec
 from ..core.uqtestfun_abc import UQTestFunABC
-from .available import create_prob_input_from_available
+from .available import get_prob_input_spec, create_prob_input_from_spec
 
 __all__ = ["OTLCircuit"]
 
 INPUT_MARGINALS_BENARI2007 = [
-    UnivDist(
+    MarginalSpec(
         name="Rb1",
         distribution="uniform",
         parameters=[50.0, 150.0],
         description="Resistance b1 [kOhm]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Rb2",
         distribution="uniform",
         parameters=[25.0, 70.0],
         description="Resistance b2 [kOhm]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Rf",
         distribution="uniform",
         parameters=[0.5, 3.0],
         description="Resistance f [kOhm]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Rc1",
         distribution="uniform",
         parameters=[1.2, 2.5],
         description="Resistance c1 [kOhm]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Rc2",
         distribution="uniform",
         parameters=[0.25, 1.20],
         description="Resistance c2 [kOhm]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="beta",
         distribution="uniform",
         parameters=[50.0, 300.0],
@@ -73,7 +73,7 @@ INPUT_MARGINALS_BENARI2007 = [
 INPUT_MARGINALS_MOON2010 = [copy(_) for _ in INPUT_MARGINALS_BENARI2007]
 for i in range(14):
     INPUT_MARGINALS_MOON2010.append(
-        UnivDist(
+        MarginalSpec(
             name=f"Inert {i+1}",
             distribution="uniform",
             parameters=[100.0, 200.0],
@@ -82,24 +82,24 @@ for i in range(14):
     )
 
 AVAILABLE_INPUT_SPECS = {
-    "BenAri2007": {
-        "name": "OTL-Circuit-Ben-Ari-2007",
-        "description": (
+    "BenAri2007": ProbInputSpec(
+        name="OTL-Circuit-Ben-Ari-2007",
+        description=(
             "Probabilistic input model for the OTL Circuit function "
             "from Ben-Ari and Steinberg (2007)."
         ),
-        "marginals": INPUT_MARGINALS_BENARI2007,
-        "copulas": None,
-    },
-    "Moon2010": {
-        "name": "OTL-Circuit-Moon-2010",
-        "description": (
+        marginals=INPUT_MARGINALS_BENARI2007,
+        copulas=None,
+    ),
+    "Moon2010": ProbInputSpec(
+        name="OTL-Circuit-Moon-2010",
+        description=(
             "Probabilistic input model for the OTL Circuit function "
             "from Moon (2010)."
         ),
-        "marginals": INPUT_MARGINALS_MOON2010,
-        "copulas": None,
-    },
+        marginals=INPUT_MARGINALS_MOON2010,
+        copulas=None,
+    ),
 }
 
 DEFAULT_INPUT_SELECTION = "BenAri2007"
@@ -129,10 +129,13 @@ class OTLCircuit(UQTestFunABC):
         rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
-        prob_input = create_prob_input_from_available(
-            prob_input_selection,
-            AVAILABLE_INPUT_SPECS,
-            rng_seed=rng_seed_prob_input,
+        # Get the ProbInputSpec from available
+        prob_input_spec = get_prob_input_spec(
+            prob_input_selection, AVAILABLE_INPUT_SPECS
+        )
+        # Create a ProbInput
+        prob_input = create_prob_input_from_spec(
+            prob_input_spec, rng_seed=rng_seed_prob_input
         )
         # Process the default name
         if name is None:

--- a/src/uqtestfuns/test_functions/piston.py
+++ b/src/uqtestfuns/test_functions/piston.py
@@ -25,51 +25,51 @@ import numpy as np
 from copy import copy
 from typing import Optional
 
-from ..core.prob_input.univariate_distribution import UnivDist
+from ..core.prob_input.input_spec import MarginalSpec, ProbInputSpec
 from ..core.uqtestfun_abc import UQTestFunABC
-from .available import create_prob_input_from_available
+from .available import get_prob_input_spec, create_prob_input_from_spec
 
 __all__ = ["Piston"]
 
 # Marginals specification from [1]
 INPUT_MARGINALS_BENARI2007 = [
-    UnivDist(
+    MarginalSpec(
         name="M",
         distribution="uniform",
         parameters=[30.0, 60.0],
         description="Piston weight [kg]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="S",
         distribution="uniform",
         parameters=[0.005, 0.020],
         description="Piston surface area [m^2]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="V0",
         distribution="uniform",
         parameters=[0.002, 0.010],
         description="Initial gas volume [m^3]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="k",
         distribution="uniform",
         parameters=[1000.0, 5000.0],
         description="Spring coefficient [N/m]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="P0",
         distribution="uniform",
         parameters=[90000.0, 110000.0],
         description="Atmospheric pressure [N/m^2]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Ta",
         distribution="uniform",
         parameters=[290.0, 296.0],
         description="Ambient temperature [K]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="T0",
         distribution="uniform",
         parameters=[340.0, 360.0],
@@ -81,7 +81,7 @@ INPUT_MARGINALS_BENARI2007 = [
 INPUT_MARGINALS_MOON2010 = [copy(_) for _ in INPUT_MARGINALS_BENARI2007]
 for i in range(13):
     INPUT_MARGINALS_MOON2010.append(
-        UnivDist(
+        MarginalSpec(
             name=f"Inert {i+1}",
             distribution="uniform",
             parameters=[100.0, 200.0],
@@ -90,24 +90,24 @@ for i in range(13):
     )
 
 AVAILABLE_INPUT_SPECS = {
-    "BenAri2007": {
-        "name": "Piston-Ben-Ari-2007",
-        "description": (
+    "BenAri2007": ProbInputSpec(
+        name="Piston-Ben-Ari-2007",
+        description=(
             "Probabilistic input model for the Piston simulation model "
             "from Ben-Ari and Steinberg (2007)."
         ),
-        "marginals": INPUT_MARGINALS_BENARI2007,
-        "copulas": None,
-    },
-    "Moon2010": {
-        "name": "Piston-Moon-2010",
-        "description": (
+        marginals=INPUT_MARGINALS_BENARI2007,
+        copulas=None,
+    ),
+    "Moon2010": ProbInputSpec(
+        name="Piston-Moon-2010",
+        description=(
             "Probabilistic input model for the Piston simulation model "
             "from Moon (2010)."
         ),
-        "marginals": INPUT_MARGINALS_MOON2010,
-        "copulas": None,
-    },
+        marginals=INPUT_MARGINALS_MOON2010,
+        copulas=None,
+    ),
 }
 
 DEFAULT_INPUT_SELECTION = "BenAri2007"
@@ -134,10 +134,13 @@ class Piston(UQTestFunABC):
         rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
-        prob_input = create_prob_input_from_available(
-            prob_input_selection,
-            AVAILABLE_INPUT_SPECS,
-            rng_seed=rng_seed_prob_input,
+        # Get the ProbInputSpec from available
+        prob_input_spec = get_prob_input_spec(
+            prob_input_selection, AVAILABLE_INPUT_SPECS
+        )
+        # Create a ProbInput
+        prob_input = create_prob_input_from_spec(
+            prob_input_spec, rng_seed=rng_seed_prob_input
         )
         # Process the default name
         if name is None:

--- a/src/uqtestfuns/test_functions/sulfur.py
+++ b/src/uqtestfuns/test_functions/sulfur.py
@@ -62,64 +62,64 @@ import numpy as np
 
 from typing import Optional
 
-from ..core.prob_input.univariate_distribution import UnivDist
+from ..core.prob_input.input_spec import MarginalSpec, ProbInputSpec
 from ..core.uqtestfun_abc import UQTestFunABC
-from .available import create_prob_input_from_available
+from .available import get_prob_input_spec, create_prob_input_from_spec
 
 __all__ = ["Sulfur"]
 
 INPUT_MARGINALS_PENNER1994 = [  # From [3] (Table 2)
-    UnivDist(
+    MarginalSpec(
         name="Q",
         distribution="lognormal",
         parameters=[np.log(71.0), np.log(1.15)],
         description="Source strength of anthropogenic Sulfur [10^12 g/year]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Y",
         distribution="lognormal",
         parameters=[np.log(0.5), np.log(1.5)],
         description="Fraction of SO2 oxidized to SO4(2-) aerosol [-]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="L",
         distribution="lognormal",
         parameters=[np.log(5.5), np.log(1.5)],
         description="Average lifetime of atmospheric SO4(2-) [days]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Psi_e",
         distribution="lognormal",
         parameters=[np.log(5.0), np.log(1.4)],
         description="Aerosol mass scattering efficiency [m^2/g]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="beta",
         distribution="lognormal",
         parameters=[np.log(0.3), np.log(1.3)],
         description="Fraction of light scattered upward hemisphere [-]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="f_Psi_e",
         distribution="lognormal",
         parameters=[np.log(1.7), np.log(1.2)],
         description="Fractional increase in aerosol scattering efficiency "
         "due to hygroscopic growth [-]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="T^2",
         distribution="lognormal",
         parameters=[np.log(0.58), np.log(1.4)],
         description="Square of atmospheric "
         "transmittance above aerosol layer [-]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="(1-Ac)",
         distribution="lognormal",
         parameters=[np.log(0.39), np.log(1.1)],
         description="Fraction of earth not covered by cloud [-]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="(1-Rs)^2",
         distribution="lognormal",
         parameters=[np.log(0.72), np.log(1.2)],
@@ -128,15 +128,15 @@ INPUT_MARGINALS_PENNER1994 = [  # From [3] (Table 2)
 ]
 
 AVAILABLE_INPUT_SPECS = {
-    "Penner1994": {
-        "name": "Sulfur-Penner-1994",
-        "description": (
+    "Penner1994": ProbInputSpec(
+        name="Sulfur-Penner-1994",
+        description=(
             "Probabilistic input model for the Sulfur model "
             "from Penner et al. (1994)."
         ),
-        "marginals": INPUT_MARGINALS_PENNER1994,
-        "copulas": None,
-    }
+        marginals=INPUT_MARGINALS_PENNER1994,
+        copulas=None,
+    ),
 }
 
 DEFAULT_INPUT_SELECTION = "Penner1994"
@@ -167,10 +167,13 @@ class Sulfur(UQTestFunABC):
         rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
-        prob_input = create_prob_input_from_available(
-            prob_input_selection,
-            AVAILABLE_INPUT_SPECS,
-            rng_seed=rng_seed_prob_input,
+        # Get the ProbInputSpec from available
+        prob_input_spec = get_prob_input_spec(
+            prob_input_selection, AVAILABLE_INPUT_SPECS
+        )
+        # Create a ProbInput
+        prob_input = create_prob_input_from_spec(
+            prob_input_spec, rng_seed=rng_seed_prob_input
         )
         # Process the default name
         if name is None:

--- a/src/uqtestfuns/test_functions/welch1992.py
+++ b/src/uqtestfuns/test_functions/welch1992.py
@@ -22,14 +22,15 @@ import numpy as np
 
 from typing import Optional
 
-from ..core.prob_input.univariate_distribution import UnivDist
+from ..core.prob_input.input_spec import MarginalSpec, ProbInputSpec
 from ..core.uqtestfun_abc import UQTestFunABC
-from .available import create_prob_input_from_available
+from .available import get_prob_input_spec, create_prob_input_from_spec
 
 __all__ = ["Welch1992"]
 
+
 INPUT_MARGINALS_WELCH1992 = [
-    UnivDist(
+    MarginalSpec(
         name=f"x{i}",
         distribution="uniform",
         parameters=[-0.5, 0.5],
@@ -39,14 +40,15 @@ INPUT_MARGINALS_WELCH1992 = [
 ]
 
 AVAILABLE_INPUT_SPECS = {
-    "Welch1992": {
-        "name": "Welch1992",
-        "description": (
+    "Welch1992": ProbInputSpec(
+        name="Welch1992",
+        description=(
             "Input specification for the test function "
             "from Welch et al. (1992)"
         ),
-        "marginals": INPUT_MARGINALS_WELCH1992,
-    }
+        marginals=INPUT_MARGINALS_WELCH1992,
+        copulas=None,
+    ),
 }
 
 DEFAULT_INPUT_SELECTION = "Welch1992"
@@ -73,10 +75,13 @@ class Welch1992(UQTestFunABC):
         rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
-        prob_input = create_prob_input_from_available(
-            prob_input_selection,
-            AVAILABLE_INPUT_SPECS,
-            rng_seed=rng_seed_prob_input,
+        # Get the ProbInputSpec from available
+        prob_input_spec = get_prob_input_spec(
+            prob_input_selection, AVAILABLE_INPUT_SPECS
+        )
+        # Create a ProbInput
+        prob_input = create_prob_input_from_spec(
+            prob_input_spec, rng_seed=rng_seed_prob_input
         )
         # Process the default name
         if name is None:

--- a/src/uqtestfuns/test_functions/wing_weight.py
+++ b/src/uqtestfuns/test_functions/wing_weight.py
@@ -23,69 +23,69 @@ import numpy as np
 
 from typing import Optional
 
-from ..core.prob_input.univariate_distribution import UnivDist
+from ..core.prob_input.input_spec import MarginalSpec, ProbInputSpec
 from ..core.uqtestfun_abc import UQTestFunABC
-from .available import create_prob_input_from_available
+from .available import get_prob_input_spec, create_prob_input_from_spec
 from .utils import deg2rad
 
 __all__ = ["WingWeight"]
 
 INPUT_MARGINALS_FORRESTER2008 = [
-    UnivDist(
+    MarginalSpec(
         name="Sw",
         distribution="uniform",
         parameters=[150.0, 200.0],
         description="wing area [ft^2]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Wfw",
         distribution="uniform",
         parameters=[220.0, 300.0],
         description="weight of fuel in the wing [lb]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="A",
         distribution="uniform",
         parameters=[6.0, 10.0],
         description="aspect ratio [-]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Lambda",
         distribution="uniform",
         parameters=[-10.0, 10.0],
         description="quarter-chord sweep [degrees]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="q",
         distribution="uniform",
         parameters=[16.0, 45.0],
         description="dynamic pressure at cruise [lb/ft^2]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="lambda",
         distribution="uniform",
         parameters=[0.5, 1.0],
         description="taper ratio [-]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="tc",
         distribution="uniform",
         parameters=[0.08, 0.18],
         description="aerofoil thickness to chord ratio [-]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Nz",
         distribution="uniform",
         parameters=[2.5, 6.0],
         description="ultimate load factor [-]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Wdg",
         distribution="uniform",
         parameters=[1700, 2500],
         description="flight design gross weight [lb]",
     ),
-    UnivDist(
+    MarginalSpec(
         name="Wp",
         distribution="uniform",
         parameters=[0.025, 0.08],
@@ -94,15 +94,15 @@ INPUT_MARGINALS_FORRESTER2008 = [
 ]
 
 AVAILABLE_INPUT_SPECS = {
-    "Forrester2008": {
-        "name": "Wing-Weight-Forrester-2008",
-        "description": (
+    "Forrester2008": ProbInputSpec(
+        name="Wing-Weight-Forrester-2008",
+        description=(
             "Probabilistic input model for the Wing Weight model "
             "from Forrester et al. (2008)."
         ),
-        "marginals": INPUT_MARGINALS_FORRESTER2008,
-        "copulas": None,
-    }
+        marginals=INPUT_MARGINALS_FORRESTER2008,
+        copulas=None,
+    ),
 }
 
 DEFAULT_INPUT_SELECTION = "Forrester2008"
@@ -129,14 +129,17 @@ class WingWeight(UQTestFunABC):
         rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Arguments processing
-        prob_input = create_prob_input_from_available(
-            prob_input_selection,
-            AVAILABLE_INPUT_SPECS,
-            rng_seed=rng_seed_prob_input,
+        # Get the ProbInputSpec from available
+        prob_input_spec = get_prob_input_spec(
+            prob_input_selection, AVAILABLE_INPUT_SPECS
+        )
+        # Create a ProbInput
+        prob_input = create_prob_input_from_spec(
+            prob_input_spec, rng_seed=rng_seed_prob_input
         )
         # Process the default name
         if name is None:
-            name = WingWeight.__name__
+            name = self.__class__.__name__
 
         super().__init__(prob_input=prob_input, name=name)
 

--- a/tests/builtin_test_functions/test_test_functions.py
+++ b/tests/builtin_test_functions/test_test_functions.py
@@ -241,5 +241,5 @@ def test_evaluate_invalid_spatial_dim(builtin_testfun):
 
 def test_evaluate_invalid_input_selection(builtin_testfun):
     """Test if an exception is raised if invalid input selection is given."""
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         builtin_testfun(prob_input_selection=100)

--- a/tests/core/test_input_spec.py
+++ b/tests/core/test_input_spec.py
@@ -1,0 +1,94 @@
+"""
+Test module for the prob. input specification class.
+"""
+from typing import List
+
+from uqtestfuns.core.prob_input.input_spec import (
+    MarginalSpec,
+    ProbInputSpec,
+    ProbInputSpecVarDim,
+)
+
+
+def test_marginalspec():
+    """Test the creation of MarginalSpec NamedTuple."""
+
+    name = "T0"
+    distribution = "uniform"
+    parameters = [340.0, 360.0]
+    description = "Filling gas temperature"
+
+    # Create a MarginalSpec
+    my_marginalspec = MarginalSpec(
+        name=name,
+        distribution=distribution,
+        parameters=parameters,
+        description=description,
+    )
+
+    # Assertions
+    assert my_marginalspec.name == name
+    assert my_marginalspec.distribution == distribution
+    assert my_marginalspec.parameters == parameters
+    assert my_marginalspec.description == description
+
+
+def test_probinputspec_list():
+    """Test the creation of ProbInputSpec NamedTuple w/ list of marginals."""
+
+    # Create a list of marginals
+    marginals = _create_marginals(10)
+
+    # Create a ProbInputSpec
+    name = "Some input"
+    description = "Probabilistic input model from somewhere"
+    copulas = None
+    my_probinputspec = ProbInputSpec(
+        name=name,
+        description=description,
+        marginals=marginals,
+        copulas=copulas,
+    )
+
+    # Assertions
+    assert my_probinputspec.name == name
+    assert my_probinputspec.description == description
+    assert my_probinputspec.copulas == copulas
+    assert my_probinputspec.marginals == marginals
+
+
+def test_probinputspec_vardim():
+    """Test the creation of ProbInputSpec w/ a callable as marginal."""
+
+    # Create a list of marginals
+    marginals_gen = _create_marginals
+
+    # Create a ProbInputSpec
+    name = "Some input"
+    description = "Probabilistic input model from somewhere"
+    copulas = None
+    my_probinputspec = ProbInputSpecVarDim(
+        name=name,
+        description=description,
+        marginals_generator=marginals_gen,
+        copulas=copulas,
+    )
+
+    # Assertions
+    assert my_probinputspec.name == name
+    assert my_probinputspec.description == description
+    assert my_probinputspec.copulas == copulas
+    assert my_probinputspec.marginals_generator == marginals_gen
+
+
+def _create_marginals(spatial_dimension: int) -> List[MarginalSpec]:
+    """Create a list of test marginals."""
+    return [
+        MarginalSpec(
+            name=f"x{i + 1}",
+            distribution="uniform",
+            parameters=[0.0, 1.0],
+            description="None",
+        )
+        for i in range(spatial_dimension)
+    ]


### PR DESCRIPTION
- For a lightweight data storage (free of methods), NamedTuple has been adopted to store the specifications of univariate marginals and probabilistic input models.

This PR should resolve Issue #214.