### PR TITLE
One-dimensional test functions now return one-dimensional array

### DIFF
--- a/src/uqtestfuns/test_functions/forrester.py
+++ b/src/uqtestfuns/test_functions/forrester.py
@@ -47,7 +47,9 @@ def evaluate(xx: np.ndarray) -> np.ndarray:
     ----------
 
     """
-    return (6 * xx - 2) ** 2 * np.sin(12 * xx - 4)
+    yy = (6 * xx[:, 0] - 2) ** 2 * np.sin(12 * xx[:, 0] - 4)
+
+    return yy
 
 
 class Forrester2008(UQTestFunABC):

--- a/src/uqtestfuns/test_functions/oakley_ohagan_1d.py
+++ b/src/uqtestfuns/test_functions/oakley_ohagan_1d.py
@@ -56,7 +56,7 @@ def evaluate(xx: np.ndarray) -> np.ndarray:
         on the input values.
         The output is a 1-dimensional array of length N.
     """
-    yy = 5 + xx + np.cos(xx)
+    yy = 5 + xx[:, 0] + np.cos(xx[:, 0])
 
     return yy
 


### PR DESCRIPTION
- Previously, all one-dimensional test functions return two-dimensional arrays with a single column; this behavior is inconsistent with the other test functions.

This PR should resolve Issue #221.