### PR TITLE
The output of list_functions() now appears w/ scroll in the docs

### DIFF
--- a/docs/fundamentals/integration.md
+++ b/docs/fundamentals/integration.md
@@ -31,6 +31,8 @@ for metamodeling applications using ``list_functions()`` and filter the results
 using the ``tag`` parameter:
 
 ```{code-cell} ipython3
+:tags: ["output_scroll"]
+
 import uqtestfuns as uqtf
 
 uqtf.list_functions(tag="integration")

--- a/docs/fundamentals/metamodeling.md
+++ b/docs/fundamentals/metamodeling.md
@@ -47,6 +47,8 @@ for metamodeling applications using ``list_functions()`` and filter the results
 using the ``tag`` parameter:
 
 ```{code-cell} ipython3
+:tags: ["output_scroll"]
+
 import uqtestfuns as uqtf
 
 uqtf.list_functions(tag="metamodeling")

--- a/docs/fundamentals/optimization.md
+++ b/docs/fundamentals/optimization.md
@@ -27,6 +27,8 @@ for optimization applications using ``list_functions()`` and filter the results
 using the ``tag`` parameter:
 
 ```{code-cell} ipython3
+:tags: ["output_scroll"]
+
 import uqtestfuns as uqtf
 
 uqtf.list_functions(tag="optimization")

--- a/docs/fundamentals/sensitivity.md
+++ b/docs/fundamentals/sensitivity.md
@@ -36,6 +36,8 @@ for metamodeling applications using ``list_functions()`` and filter the results
 using the ``tag`` parameter:
 
 ```{code-cell} ipython3
+:tags: ["output_scroll"]
+
 import uqtestfuns as uqtf
 
 uqtf.list_functions(tag="sensitivity")

--- a/docs/test-functions/available.md
+++ b/docs/test-functions/available.md
@@ -53,6 +53,8 @@ In a Python terminal, you can list all the available functions
 along with the corresponding constructor using ``list_functions()``:
 
 ```{code-cell} ipython3
+:tags: ["output_scroll"]
+
 import uqtestfuns as uqtf
 
 uqtf.list_functions()


### PR DESCRIPTION
- To limit the length of the page in the docs when the output of `list_functions()` is rendered, the output is now scrollable.

This PR should resolve Issue #208.