### PR TITLE
Dim-dependent param. must have keyword "spatial_dimension" to be called.

### DIFF
--- a/src/uqtestfuns/test_functions/sobol_g.py
+++ b/src/uqtestfuns/test_functions/sobol_g.py
@@ -133,8 +133,6 @@ def _get_params_saltelli_1995_2(spatial_dimension: int) -> np.ndarray:
       are used then the remaining dimension is also non-influential.
     """
     yy = np.zeros(spatial_dimension)
-    if spatial_dimension > 0:
-        yy[0] = 0
 
     if spatial_dimension > 1:
         yy[1] = 0

--- a/tests/builtin_test_functions/test_sobol_g.py
+++ b/tests/builtin_test_functions/test_sobol_g.py
@@ -9,7 +9,7 @@ Notes
 import numpy as np
 import pytest
 
-from uqtestfuns import SobolG
+from uqtestfuns.test_functions import SobolG
 
 available_parameters = list(SobolG.available_parameters.keys())
 
@@ -22,7 +22,7 @@ def test_wrong_param_selection():
 
 # ATTENTION: some parameters choice (e.g., "sobol-1")
 # can't be estimated properly with low N at high dimension
-@pytest.mark.parametrize("spatial_dimension", [1, 2, 10])
+@pytest.mark.parametrize("spatial_dimension", [1, 2, 3, 10])
 @pytest.mark.parametrize("params_selection", available_parameters)
 def test_compute_mean(spatial_dimension, params_selection):
     """Test the mean computation as the result is analytical."""
@@ -50,7 +50,7 @@ def test_compute_mean(spatial_dimension, params_selection):
 
 
 # ATTENTION: parameters with "Sobol-1" is unstable at large dimension >= 15
-@pytest.mark.parametrize("spatial_dimension", [1, 2, 10])
+@pytest.mark.parametrize("spatial_dimension", [1, 2, 3, 10])
 @pytest.mark.parametrize("params_selection", available_parameters)
 def test_compute_variance(spatial_dimension, params_selection):
     """Test the variance computation as the result is analytical."""

--- a/tests/builtin_test_functions/test_test_functions.py
+++ b/tests/builtin_test_functions/test_test_functions.py
@@ -12,16 +12,18 @@ import numpy as np
 import pytest
 import copy
 
+from typing import Type
+
 from conftest import assert_call
 
 from uqtestfuns.utils import get_available_classes
-from uqtestfuns import test_functions
+from uqtestfuns import test_functions, UQTestFunABC
 
 AVAILABLE_FUNCTION_CLASSES = get_available_classes(test_functions)
 
 
 @pytest.fixture(params=AVAILABLE_FUNCTION_CLASSES)
-def builtin_testfun(request):
+def builtin_testfun(request) -> Type[UQTestFunABC]:
     _, testfun = request.param
 
     return testfun
@@ -143,6 +145,21 @@ def test_call_instance(builtin_testfun):
 
     # Assertions
     assert_call(my_fun, xx)
+
+
+def test_str(builtin_testfun):
+    """Test the __str__() method of a test function instance."""
+
+    # Create an instance
+    my_fun = builtin_testfun()
+
+    str_ref = (
+        f"Name              : {my_fun.name}\n"
+        f"Spatial dimension : {my_fun.spatial_dimension}\n"
+        f"Description       : {my_fun.description}"
+    )
+
+    assert my_fun.__str__() == str_ref
 
 
 def test_transform_input(builtin_testfun):


### PR DESCRIPTION
- If a dimension-dependent function is used as parameters to a UQ test function then it must have keyword "spatial_dimension" for the function to be called with spatial_dimension during an object instantiation. Otherwise, the function is left as is (not called).
- Increase test coverage ratio for the Sobol-G function.

This PR should resolve Issue #204.