### PR TITLE
Bibliography style in the docs is now 'unsrtalpha'.

### DIFF
--- a/docs/test-functions/ackley.md
+++ b/docs/test-functions/ackley.md
@@ -176,7 +176,7 @@ $\mathcal{M}(\boldsymbol{x}^*) = 0$ at $x_m^* = 0,\, m = 1, \ldots, M$.
 ## References
 
 ```{bibliography}
-:style: unsrt
+:style: unsrtalpha
 :filter: docname in docnames
 ```
 

--- a/docs/test-functions/borehole.md
+++ b/docs/test-functions/borehole.md
@@ -224,6 +224,6 @@ tabulate(
 ## References
 
 ```{bibliography}
-:style: unsrt
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/damped-oscillator.md
+++ b/docs/test-functions/damped-oscillator.md
@@ -221,6 +221,6 @@ tabulate(
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/flood.md
+++ b/docs/test-functions/flood.md
@@ -210,6 +210,6 @@ tabulate(
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/franke-1.md
+++ b/docs/test-functions/franke-1.md
@@ -162,6 +162,5 @@ plt.gcf().set_dpi(150);
 ## References
 
 ```{bibliography}
-:style: plain
 :filter: docname in docnames
 ```

--- a/docs/test-functions/franke-2.md
+++ b/docs/test-functions/franke-2.md
@@ -165,6 +165,6 @@ plt.gcf().set_dpi(150);
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/franke-3.md
+++ b/docs/test-functions/franke-3.md
@@ -153,6 +153,6 @@ plt.gcf().set_dpi(150);
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/franke-4.md
+++ b/docs/test-functions/franke-4.md
@@ -164,6 +164,6 @@ plt.gcf().set_dpi(150);
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/franke-5.md
+++ b/docs/test-functions/franke-5.md
@@ -164,6 +164,6 @@ plt.gcf().set_dpi(150);
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/franke-6.md
+++ b/docs/test-functions/franke-6.md
@@ -165,6 +165,6 @@ plt.gcf().set_dpi(150);
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/ishigami.md
+++ b/docs/test-functions/ishigami.md
@@ -312,6 +312,6 @@ the same.
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/mclain-s1.md
+++ b/docs/test-functions/mclain-s1.md
@@ -156,6 +156,6 @@ plt.gcf().set_dpi(150);
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/mclain-s2.md
+++ b/docs/test-functions/mclain-s2.md
@@ -156,6 +156,6 @@ plt.gcf().set_dpi(150);
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/mclain-s3.md
+++ b/docs/test-functions/mclain-s3.md
@@ -159,6 +159,6 @@ plt.gcf().set_dpi(150);
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/mclain-s4.md
+++ b/docs/test-functions/mclain-s4.md
@@ -147,6 +147,6 @@ plt.gcf().set_dpi(150);
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/mclain-s5.md
+++ b/docs/test-functions/mclain-s5.md
@@ -158,6 +158,6 @@ plt.gcf().set_dpi(150);
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/oakley-ohagan-1d.md
+++ b/docs/test-functions/oakley-ohagan-1d.md
@@ -219,6 +219,6 @@ tabulate(
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/otl-circuit.md
+++ b/docs/test-functions/otl-circuit.md
@@ -225,6 +225,6 @@ tabulate(
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/piston.md
+++ b/docs/test-functions/piston.md
@@ -228,6 +228,6 @@ tabulate(
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/sulfur.md
+++ b/docs/test-functions/sulfur.md
@@ -457,6 +457,6 @@ tabulate(
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/docs/test-functions/wing-weight.md
+++ b/docs/test-functions/wing-weight.md
@@ -197,6 +197,6 @@ tabulate(
 ## References
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```


### PR DESCRIPTION
- It means, the style uses alphanumeric reference labels, and citations are sorted by the order of appearance in a single page.

This PR should resolve Issue #207.