### PR TITLE
When list_functions() is called with "tag", it is no longer displayed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ISO format YYYY-MM-DD.
 - The bibliography style in the docs has been changed to 'unsrtalpha'
   (alphanumeric labels, sorted by order of appearance).
+- When `list_functions()` is called with a `tag` argument,
+  then the application tags are no longer displayed to save terminal spaces.
 
 ### Fixed
 

--- a/docs/getting-started/about-uq-test-functions.md
+++ b/docs/getting-started/about-uq-test-functions.md
@@ -212,6 +212,6 @@ Satisfying all the above requirements is exactly the goal
 of the UQTestFuns package.
 
 ```{bibliography}
-:style: plain
+:style: unsrtalpha
 :filter: docname in docnames
 ```

--- a/src/uqtestfuns/helpers.py
+++ b/src/uqtestfuns/helpers.py
@@ -92,13 +92,21 @@ def list_functions(
         return constructors
 
     # --- Create a tabulated view of the list
-    header_names = [
-        "No.",
-        "Constructor",
-        "Spatial Dimension",
-        "Application",
-        "Description",
-    ]
+    if tag is None:
+        header_names = [
+            "No.",
+            "Constructor",
+            "Dimension",
+            "Application",
+            "Description",
+        ]
+    else:
+        header_names = [
+            "No.",
+            "Constructor",
+            "Dimension",
+            "Description",
+        ]
 
     values = []
     for idx, available_class_name in enumerate(
@@ -113,26 +121,41 @@ def list_functions(
                 available_class.default_spatial_dimension
             )
 
-        tags = ", ".join(available_class.tags)
-
         description = available_class.description
 
-        value = [
-            idx + 1,
-            f"{available_class_name}()",
-            f"{default_spatial_dimension}",
-            tags,
-            f"{description}",
-        ]
+        if tag is None:
+            tags = ", ".join(available_class.tags)
+            value = [
+                idx + 1,
+                f"{available_class_name}()",
+                f"{default_spatial_dimension}",
+                tags,
+                f"{description}",
+            ]
+        else:
+            value = [
+                idx + 1,
+                f"{available_class_name}()",
+                f"{default_spatial_dimension}",
+                f"{description}",
+            ]
 
         values.append(value)
 
-    table = tbl(
-        values,
-        headers=header_names,
-        stralign="center",
-        colalign=("center", "center", "center", "center", "left"),
-    )
+    if tag is None:
+        table = tbl(
+            values,
+            headers=header_names,
+            stralign="center",
+            colalign=("center", "center", "center", "center", "left"),
+        )
+    else:
+        table = tbl(
+            values,
+            headers=header_names,
+            stralign="center",
+            colalign=("center", "center", "center", "left"),
+        )
 
     print(table)
 


### PR DESCRIPTION
- To save terminal space, when list_functions() is called with the tag argument, the application tags are no longer displayed.

This PR should resolve Issue #210.