### PR TITLE
Follow the current best-practice of single-sourcing package version.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ install_requires =
    numpy>=1.13.3
    scipy>=1.7.3
    tabulate>=0.8.10
+   importlib-metadata>=1.0; python_version < "3.8"
 
 [options.packages.find]
 where = src

--- a/src/uqtestfuns/__init__.py
+++ b/src/uqtestfuns/__init__.py
@@ -1,7 +1,7 @@
 """
 This is the package init for UQTestFuns.
 """
-import pkg_resources
+import sys
 
 from .core import UnivDist
 from .core import ProbInput
@@ -17,7 +17,12 @@ from .meta import UQMetaTestFun
 
 from .helpers import list_functions
 
-__version__ = pkg_resources.require("uqtestfuns")[0].version
+if sys.version_info >= (3, 8):
+    from importlib import metadata
+else:
+    import importlib_metadata as metadata
+
+__version__ = metadata.version("uqtestfuns")
 
 __all__ = [
     "UnivDist",


### PR DESCRIPTION
- `pkg_resources` has been deprecated as an API and should not be used to fetch the package version. Instead the function `version()` from `importlib.metadata` (>= Python 3.8) or `importlib_metadata.metadata` (< Python 3.8) is used.

This PR should resolve Issue #223.