### PR TITLE
Update organization files for v0.2.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,33 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2023-06-26
+
 ### Added
 
-- An instance of NumPy random number generator is now attached to instances of
-  `UnivDist` and `ProbInput`. The random seed
-  number may be passed to the corresponding constructor for reproducibility.
 - The two-dimensional Franke functions (1st, 2nd, 3rd, 4th, 5th, and 6th),
   relevant for metamodeling exercises, are added as UQ test functions.
 - The two-dimensional McLain functions (S1, S2, S3, S4, and S5),
   relevant for metamodeling exercises, are added as UQ test functions.
-- An implementation of the Welch et al. (1992) test function, 
-  a 20-dimensional function used in the context of metamodeling and sensitivity
-  analysis.
+- An implementation of the Welch et al. (1992) test function, a 20-dimensional
+  function used in the context of metamodeling and sensitivity analysis.
 - Four M-dimensional test functions from Bratley et al. (1992) useful for
   testing multi-dimensional numerical integrations as well as 
-  global sensitivity analysis.
+  global sensitivity analysis methods.
 - Add a new parameterization to the Sobol'-G function taken from
   Bratley et al. (1992) and Saltelli and Sobol' (1995).
-- Two base classes are now available `UQTestFunBareABC` and `UQTestFunABC`.
-  The former is used to implement a _bare_ UQ test function
-  (with only `evaluate()` and `ProbInput`), while the latter is used to
-  implement _published_ UQ test functions in the code base (i.e., with 
-  additional metadata such as tags and description).
 - An implementation of the one-dimensional function from Forrester et al.
   (2008). The function was used as a test function for optimization approaches
   using metamodels.
 - An implementation of the Gramacy (2007) one-dimensional sine function,
   a function with two regimes.
+- Two base classes are now available `UQTestFunBareABC` and `UQTestFunABC`.
+  The former is used to implement a _bare_ UQ test function
+  (with only `evaluate()` and `ProbInput`), while the latter is used to
+  implement _published_ UQ test functions in the code base (i.e., with 
+  additional metadata such as tags and description).
+- An instance of NumPy random number generator is now attached to instances of
+  `UnivDist` and `ProbInput`. The random seed number may be passed 
+  to the corresponding constructor for reproducibility.
+- CITATION.cff file to the code base.
 
 ### Changed
 
@@ -43,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (alphanumeric labels, sorted by order of appearance).
 - When `list_functions()` is called with a `tag` argument,
   then the application tags are no longer displayed to save terminal spaces.
+- The one-dimensional `OakleyOHagan1D` function has been renamed to
+  `Oakley1D`.
 
 ### Fixed
 
@@ -51,7 +55,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - If a function is used as parameters in a test function (e.g., if
   variable dimension), then it must have the keyword parameter
   "spatial_dimension" for the function to be called when an instance of
-  a UQ test function is created.
+  a UQ test function is created. This is to allow an arbitrary function
+  (without a parameter named "spatial_dimension") to be a parameter of
+  UQ test function.
 - One-dimensional test function now returns a one-dimensional array.
 
 ## [0.1.1] - 2023-03-07
@@ -101,6 +107,7 @@ First public release of UQTestFuns.
 - Mirror GitHub action to the [CASUS organization](https://github.com/casus)
 
 [Unreleased]: https://github.com/damar-wicaksono/uqtestfuns/compare/main...dev
+[0.2.0]: https://github.com/damar-wicaksono/uqtestfuns/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/damar-wicaksono/uqtestfuns/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/damar-wicaksono/uqtestfuns/compare/v0.0.1...v0.1.0
 [0.0.1]: https://github.com/damar-wicaksono/uqtestfuns/releases/tag/v0.0.1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,8 +14,8 @@ authors:
     orcid: 'https://orcid.org/0000-0001-8587-7730'
 identifiers:
   - type: doi
-    value: 10.5281/zenodo.7703917
-    description: The Zenodo URL of version 0.1.1 of the package
+    value: 10.5281/zenodo.7703922
+    description: The Zenodo URL of version 0.2.0 of the package
 repository-code: 'https://github.com/damar-wicaksono/uqtestfuns'
 url: 'https://uqtestfuns.readthedocs.io/en/latest/'
 repository-artifact: 'https://pypi.org/project/uqtestfuns/'
@@ -35,6 +35,5 @@ keywords:
   - sensitivity-analysis
   - metamodeling
 license: MIT
-commit: f6a2c9247a59a18a42451592059a2bf16e3c3647
-version: 0.1.1
-date-released: '2023-03-07'
+version: 0.2.0
+date-released: '2023-06-26'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # UQTestFuns
-[![DOI](http://img.shields.io/badge/DOI-10.5281/zenodo.7703917-blue.svg?style=flat-square)](https://zenodo.org/record/7703917)
+[![DOI](http://img.shields.io/badge/DOI-10.5281/zenodo.7703922-blue.svg?style=flat-square)](https://doi.org/10.5281/zenodo.7703922)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat-square)](https://github.com/psf/black)
 [![Python 3.8](https://img.shields.io/badge/python-3.7-blue.svg?style=flat-square)](https://www.python.org/downloads/release/python-370/)
 [![License](https://img.shields.io/github/license/damar-wicaksono/uqtestfuns?style=flat-square)](https://choosealicense.com/licenses/mit/)

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -57,8 +57,8 @@ parts:
             title: Gramacy (2007) Sine
           - file: test-functions/ishigami
             title: Ishigami
-          - file: test-functions/oakley-ohagan-1d
-            title: Oakley-O'Hagan 1D
+          - file: test-functions/oakley-1d
+            title: Oakley & O'Hagan (2002) 1D
           - file: test-functions/otl-circuit
             title: OTL Circuit
           - file: test-functions/mclain-s1

--- a/docs/fundamentals/metamodeling.md
+++ b/docs/fundamentals/metamodeling.md
@@ -31,7 +31,7 @@ in the comparison of metamodeling approaches.
 |         {ref}`(5th) Franke <test-functions:franke-5>`          |         2         |     `Franke5()`      |
 |         {ref}`(6th) Franke <test-functions:franke-6>`          |         2         |     `Franke6()`      |
 | {ref}`Gramacy (2007) 1D Sine <test-functions:gramacy-1d-sine>` |         1         |  `Gramacy1DSine()`   |
-|   {ref}`Oakley-O'Hagan 1D <test-functions:oakley-ohagan-1d>`   |         1         |  `OakleyOHagan1D()`  |
+| {ref}`Oakley and O'Hagan (2002) 1D <test-functions:oakley-1d>` |         1         |     `Oakley1D()`     |
 |        {ref}`OTL Circuit <test-functions:otl-circuit>`         |      6 / 20       |    `OTLCircuit()`    |
 |          {ref}`McLain S1 <test-functions:mclain-s1>`           |         2         |     `McLainS1()`     |
 |          {ref}`McLain S2 <test-functions:mclain-s2>`           |         2         |     `McLainS2()`     |

--- a/docs/test-functions/available.md
+++ b/docs/test-functions/available.md
@@ -37,7 +37,7 @@ available in the current UQTestFuns, regardless of their typical applications.
 |         {ref}`(6th) Franke <test-functions:franke-6>`          |         2         |     `Franke6()`      |
 | {ref}`Gramacy (2007) 1D Sine <test-functions:gramacy-1d-sine>` |         1         |  `Gramacy1DSine()`   |
 |           {ref}`Ishigami <test-functions:ishigami>`            |         3         |     `Ishigami()`     |
-|   {ref}`Oakley-O'Hagan 1D <test-functions:oakley-ohagan-1d>`   |         1         |  `OakleyOHagan1D()`  |
+| {ref}`Oakley and O'Hagan (2002) 1D <test-functions:oakley-1d>` |         1         |     `Oakley1D()`     |
 |        {ref}`OTL Circuit <test-functions:otl-circuit>`         |      6 / 20       |    `OTLCircuit()`    |
 |          {ref}`McLain S1 <test-functions:mclain-s1>`           |         2         |     `McLainS1()`     |
 |          {ref}`McLain S2 <test-functions:mclain-s2>`           |         2         |     `McLainS2()`     |

--- a/docs/test-functions/oakley-1d.md
+++ b/docs/test-functions/oakley-1d.md
@@ -12,12 +12,13 @@ kernelspec:
   name: python3
 ---
 
-(test-functions:oakley-ohagan-1d)=
-# One-dimensional (1D) Oakley-O'Hagan Function
+(test-functions:oakley-1d)=
+# Oakley and O'Hagan (2002) One-dimensional (1D) Function
 
-The 1D Oakley-O'Hagan function is a one-dimensional scalar-valued function.
-It was used in {cite}`Oakley2002` as a test function for illustrating
-metamodeling and uncertainty propagation approaches.
+The 1D function from Oakley and O'Hagan (2002) (or `Oakley1D` function
+for short) is a scalar-valued test function.
+It was used in {cite}`Oakley2002` as a test function for illustrating metamodeling
+and uncertainty propagation approaches.
 
 ```{code-cell} ipython3
 import numpy as np
@@ -30,7 +31,7 @@ A plot of the function is shown below for $x \in [-12, 12]$.
 ```{code-cell} ipython3
 :tags: [remove-input]
 
-my_testfun = uqtf.OakleyOHagan1D()
+my_testfun = uqtf.Oakley1D()
 xx = np.linspace(-12, 12, 1000)[:, np.newaxis]
 yy = my_testfun(xx)
 
@@ -45,11 +46,10 @@ plt.gcf().set_dpi(150);
 
 ## Test function instance
 
-To create a default instance of the one-dimensional Oakley-O'Hagan
-test function:
+To create a default instance of the test function:
 
 ```{code-cell} ipython3
-my_testfun = uqtf.OakleyOHagan1D()
+my_testfun = uqtf.Oakley1D()
 ```
 
 Check if it has been correctly instantiated:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = uqtestfuns
-version = 0.1.1
+version = 0.2.0
 url = https://github.com/damar-wicaksono/uqtestfuns
 author = Damar Wicaksono
 author_email = damar.wicaksono@outlook.com

--- a/src/uqtestfuns/test_functions/__init__.py
+++ b/src/uqtestfuns/test_functions/__init__.py
@@ -10,7 +10,7 @@ from .forrester import Forrester2008
 from .franke import Franke1, Franke2, Franke3, Franke4, Franke5, Franke6
 from .gramacy2007 import Gramacy1DSine
 from .ishigami import Ishigami
-from .oakley_ohagan_1d import OakleyOHagan1D
+from .oakley2002 import Oakley1D
 from .otl_circuit import OTLCircuit
 from .mclain import McLainS1, McLainS2, McLainS3, McLainS4, McLainS5
 from .piston import Piston
@@ -40,7 +40,7 @@ __all__ = [
     "Franke6",
     "Gramacy1DSine",
     "Ishigami",
-    "OakleyOHagan1D",
+    "Oakley1D",
     "OTLCircuit",
     "McLainS1",
     "McLainS2",

--- a/src/uqtestfuns/test_functions/oakley2002.py
+++ b/src/uqtestfuns/test_functions/oakley2002.py
@@ -1,8 +1,9 @@
 """
-Module with an implementation of the 1D Oakley-O'Hagan test function.
+Module with implementations of test functions from Oakley and O'Hagan (2002).
 
-The 1D Oakley-O'Hagan test function is a one-dimensional scalar-valued
-function. It was used in [1] as a test function for illustrating metamodeling
+The 1D test function from Oakley and O'Hagan (2002) (or `Oakley1D` function
+for short) is a one-dimensional scalar-valued function.
+It was used in [1] as a test function for illustrating metamodeling
 and uncertainty propagation approaches.
 
 References
@@ -18,7 +19,7 @@ import numpy as np
 from ..core.prob_input.input_spec import UnivDistSpec, ProbInputSpecFixDim
 from ..core.uqtestfun_abc import UQTestFunABC
 
-__all__ = ["OakleyOHagan1D"]
+__all__ = ["Oakley1D"]
 
 AVAILABLE_INPUT_SPECS = {
     "Oakley2002": ProbInputSpecFixDim(
@@ -61,8 +62,8 @@ def evaluate(xx: np.ndarray) -> np.ndarray:
     return yy
 
 
-class OakleyOHagan1D(UQTestFunABC):
-    """A concrete implementation of the 1D Oakley-O'Hagan test function."""
+class Oakley1D(UQTestFunABC):
+    """An implementation of the 1D function from Oakley & O'Hagan (2002)."""
 
     _tags = ["metamodeling"]
     _description = "One-dimensional function from Oakley and O'Hagan (2002)"


### PR DESCRIPTION
- CHANGELOG, README, CITATION, setup.cfg all have been updated accordingly.
- The one-dimensional test function `OakleyOHagan1D` has been renamed to `Oakley1D`.

This PR should resolve Issue #238; the next release of UQTestFuns is ready.