### PR TITLE
Add Python v3.11 as a TOX environment for testing.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Packaging
+name: Testing and packaging
 
 on:
   - push
@@ -52,6 +52,8 @@ jobs:
             toxenv: "py38"
           - version: "3.9"
             toxenv: "py39"
+          - version: "3.11"
+            toxenv: "py311"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,6 +84,7 @@ envlist =
    py38
    py39
    py310
+   py311
 
 [testenv]
 deps =


### PR DESCRIPTION
- The GitHub action as well as the setup.cfg has been updated accordingly.
- Rename the GitHub actions workflow for testing and packaging.

This PR should resolve Issue #257.