### PR TITLE
Add `reset_rng()` method for `UnivDist` and `ProbInput` classes.

### DIFF
--- a/src/uqtestfuns/core/prob_input/probabilistic_input.py
+++ b/src/uqtestfuns/core/prob_input/probabilistic_input.py
@@ -113,6 +113,19 @@ class ProbInput:
 
         return xx
 
+    def reset_rng(self, rng_seed: Optional[int]) -> None:
+        """Reset the random number generator.
+
+        Parameters
+        ----------
+        rng_seed : int, optional.
+            The seed used to initialize the pseudo-random number generator.
+            If not specified, the value is taken from the system entropy.
+        """
+        rng = np.random.default_rng(rng_seed)
+        object.__setattr__(self, "_rng", rng)
+        object.__setattr__(self, "rng_seed", rng_seed)
+
     def pdf(self, xx: np.ndarray) -> np.ndarray:
         """Get the PDF value of the distribution on a set of values.
 

--- a/src/uqtestfuns/core/prob_input/univariate_distribution.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distribution.py
@@ -122,6 +122,19 @@ class UnivDist:
             xx, self.distribution, self.parameters, self.lower, self.upper
         )
 
+    def reset_rng(self, rng_seed: Optional[int]) -> None:
+        """Reset the random number generator.
+
+        Parameters
+        ----------
+        rng_seed : int, optional.
+            The seed used to initialize the pseudo-random number generator.
+            If not specified, the value is taken from the system entropy.
+        """
+        rng = np.random.default_rng(rng_seed)
+        object.__setattr__(self, "_rng", rng)
+        object.__setattr__(self, "rng_seed", rng_seed)
+
     def pdf(self, xx: Union[float, np.ndarray]) -> ARRAY_FLOAT:
         """Compute the PDF of the distribution on a set of values."""
         # TODO: check if you put a scalar inside

--- a/tests/core/prob_input/test_multivariate_input.py
+++ b/tests/core/prob_input/test_multivariate_input.py
@@ -242,6 +242,30 @@ def test_pass_random_seed(spatial_dimension):
 
 
 @pytest.mark.parametrize("spatial_dimension", [1, 2, 10, 100])
+def test_reset_rng(spatial_dimension):
+    """Test resetting the RNG once an instance has been created."""
+    marginals = create_random_marginals(spatial_dimension)
+
+    # Create two instances with an identical seed number
+    rng_seed = 42
+    my_input = ProbInput(marginals, rng_seed=rng_seed)
+
+    # Generate sample points
+    xx_1 = my_input.get_sample(1000)
+    xx_2 = my_input.get_sample(1000)
+
+    # Assertion: Both samples should not be equal
+    assert not np.allclose(xx_1, xx_2)
+
+    # Reset the RNG and generate new sample points
+    my_input.reset_rng(rng_seed)
+    xx_2 = my_input.get_sample(1000)
+
+    # Assertion: Both samples should now be equal
+    assert np.allclose(xx_1, xx_2)
+
+
+@pytest.mark.parametrize("spatial_dimension", [1, 2, 10, 100])
 def test_create_from_spec(spatial_dimension):
     """Test creating an instance from specification NamedTuple"""
     marginals: List[UnivDist] = create_random_marginals(spatial_dimension)

--- a/tests/core/prob_input/test_univariate_input.py
+++ b/tests/core/prob_input/test_univariate_input.py
@@ -232,3 +232,25 @@ def test_pass_random_seed():
 
     # Assertion: Both samples are equal because the seed is identical
     assert np.allclose(xx_1, xx_2)
+
+
+def test_reset_rng():
+    """Test resetting the RNG once an instance has been created."""
+
+    # Create two instances with an identical seed number
+    rng_seed = 42
+    my_input = UnivDist("uniform", [0, 1], rng_seed=rng_seed)
+
+    # Generate sample points
+    xx_1 = my_input.get_sample(1000)
+    xx_2 = my_input.get_sample(1000)
+
+    # Assertion: Both samples should not be equal
+    assert not np.allclose(xx_1, xx_2)
+
+    # Reset the RNG and generate new sample
+    my_input.reset_rng(rng_seed)
+    xx_2 = my_input.get_sample(1000)
+
+    # Assertion: Both samples should now be equal
+    assert np.allclose(xx_1, xx_2)


### PR DESCRIPTION
- The method when called (with an optional seed number) will create a new RNG attached to the instances.

This PR should resolve Issue #264.