### PR TITLE
Remove `rng_seed_prob_input` from the constructor of UQTestFunABC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from an example in Santner et al. (2018).
 - The two-dimensional circular bar RS problem for reliability analysis
   exercises taken from an example in Verma et al. (2015).
+- New instance method for `UnivDist` and `ProbInput` classes
+  called `reset_rng()`. When called (optionally with a seed number),
+  a new instance of NumPy default RNG will be created and attached to the instance.
 
 ### Changed
 
+- `rng_seed_prob_input` keyword parameter has been removed from the list
+  of parameters to the constructor of all UQ test functions.
+  The accepted way to reset an RNG with a seed is to use the instance
+  method `reset_rng()` (optionally with a seed number)
+  of the `ProbInput` instance attached.
 - Some background information in the documentation has been changed
   to match the description in the JOSS paper draft.
 

--- a/docs/fundamentals/reliability.md
+++ b/docs/fundamentals/reliability.md
@@ -117,7 +117,8 @@ accurately with as few function/model evaluations as possible.
 import numpy as np
 import matplotlib.pyplot as plt
 
-my_fun = uqtf.CircularPipeCrack(rng_seed_prob_input=237324)
+my_fun = uqtf.CircularPipeCrack()
+my_fun.prob_input.reset_rng(237324)
 xx = my_fun.prob_input.get_sample(1000000)
 yy = my_fun(xx)
 idx_neg = yy <= 0.0

--- a/docs/getting-started/creating-a-built-in.md
+++ b/docs/getting-started/creating-a-built-in.md
@@ -49,20 +49,7 @@ in the context of metamodeling and sensitivity analysis.
 To instantiate a borehole test function, call the constructor as follows:
 
 ```{code-cell} ipython3
-my_testfun = uqtf.Borehole(rng_seed_prob_input=176326)
-```
-
-```{note}
-The parameter `rng_seed_prob_input` is optional; if not specified,
-the system entropy is used to initialized
-the [NumPy default random generator](https://numpy.org/doc/stable/reference/random/generator.html#numpy.random.default_rng).
-The number is given here such that the example is more or less reproducible.
-
-In UQTestFuns, each instance of test function carries its own pseudo-random
-number generator (RNG) for the corresponding probabilitic input model
-to avoid using the global NumPy random RNG.
-See this [blog post](https://albertcthomas.github.io/good-practices-random-number-generators/)
-regarding some good practices on using NumPy RNG.
+my_testfun = uqtf.Borehole()
 ```
 
 To verify whether the instance has been created,
@@ -147,6 +134,21 @@ plt.grid()
 plt.xlabel("$\mathcal{M}(\mathbf{X})$")
 plt.ylabel("Counts [-]")
 plt.gcf().set_dpi(150);
+```
+
+```{note}
+An `ProbInput` instance has a method called `reset_rng()`;
+You can call this method to create a new underlying RNG
+perhaps with a seed number.
+In that case, the seed number is optional; if not specified,
+the system entropy is used to initialized
+the [NumPy default random generator](https://numpy.org/doc/stable/reference/random/generator.html#numpy.random.default_rng).
+
+In UQTestFuns, each instance of probabilistic input model carries
+its own pseudo-random number generator (RNG)
+to avoid using the global NumPy random RNG.
+See this [blog post](https://albertcthomas.github.io/good-practices-random-number-generators/)
+regarding some good practices on using NumPy RNG.
 ```
 
 ## Transformation to the function domain

--- a/docs/test-functions/cantilever-beam-2d.md
+++ b/docs/test-functions/cantilever-beam-2d.md
@@ -36,7 +36,8 @@ overlaid.
 ```{code-cell} ipython3
 :tags: [remove-input]
 
-my_fun = uqtf.CantileverBeam2D(rng_seed_prob_input=237324)
+my_fun = uqtf.CantileverBeam2D()
+my_fun.prob_input.reset_rng(237324)
 xx = my_fun.prob_input.get_sample(1000000)
 yy = my_fun(xx)
 idx_neg = yy <= 0.0

--- a/docs/test-functions/circular-pipe-crack.md
+++ b/docs/test-functions/circular-pipe-crack.md
@@ -33,7 +33,8 @@ overlaid.
 ```{code-cell} ipython3
 :tags: [remove-input]
 
-my_fun = uqtf.CircularPipeCrack(rng_seed_prob_input=237324)
+my_fun = uqtf.CircularPipeCrack()
+my_fun.prob_input.reset_rng(237324)
 xx = my_fun.prob_input.get_sample(1000000)
 yy = my_fun(xx)
 idx_neg = yy <= 0.0

--- a/docs/test-functions/convex-fail-domain.md
+++ b/docs/test-functions/convex-fail-domain.md
@@ -33,7 +33,8 @@ overlaid.
 ```{code-cell} ipython3
 :tags: [remove-input]
 
-my_fun = uqtf.ConvexFailDomain(rng_seed_prob_input=237324)
+my_fun = uqtf.ConvexFailDomain()
+my_fun.prob_input.reset_rng(237324)
 xx = my_fun.prob_input.get_sample(1000000)
 yy = my_fun(xx)
 idx_neg = yy <= 0.0

--- a/docs/test-functions/four-branch.md
+++ b/docs/test-functions/four-branch.md
@@ -36,7 +36,8 @@ overlaid.
 ```{code-cell} ipython3
 :tags: [remove-input]
 
-my_fun = uqtf.FourBranch(rng_seed_prob_input=237324)
+my_fun = uqtf.FourBranch()
+my_fun.prob_input.reset_rng(237324)
 xx = my_fun.prob_input.get_sample(1000000)
 yy = my_fun(xx)
 idx_neg = yy <= 0.0

--- a/docs/test-functions/gayton-hat.md
+++ b/docs/test-functions/gayton-hat.md
@@ -33,7 +33,8 @@ overlaid.
 ```{code-cell} ipython3
 :tags: [remove-input]
 
-my_fun = uqtf.GaytonHat(rng_seed_prob_input=237324)
+my_fun = uqtf.GaytonHat()
+my_fun.prob_input.reset_rng(237324)
 xx = my_fun.prob_input.get_sample(1000000)
 yy = my_fun(xx)
 idx_neg = yy <= 0.0

--- a/docs/test-functions/hyper-sphere.md
+++ b/docs/test-functions/hyper-sphere.md
@@ -33,7 +33,8 @@ overlaid.
 ```{code-cell} ipython3
 :tags: [remove-input]
 
-my_fun = uqtf.HyperSphere(rng_seed_prob_input=237324)
+my_fun = uqtf.HyperSphere()
+my_fun.prob_input.reset_rng(237324)
 xx = my_fun.prob_input.get_sample(1000000)
 yy = my_fun(xx)
 idx_neg = yy <= 0.0

--- a/docs/test-functions/rs-circular-bar.md
+++ b/docs/test-functions/rs-circular-bar.md
@@ -34,7 +34,8 @@ overlaid.
 ```{code-cell} ipython3
 :tags: [remove-input]
 
-my_fun = uqtf.RSCircularBar(rng_seed_prob_input=237324)
+my_fun = uqtf.RSCircularBar()
+my_fun.prob_input.reset_rng(237324)
 xx = my_fun.prob_input.get_sample(1000000)
 yy = my_fun(xx)
 idx_neg = yy <= 0.0

--- a/docs/test-functions/rs-quadratic.md
+++ b/docs/test-functions/rs-quadratic.md
@@ -33,7 +33,8 @@ overlaid.
 ```{code-cell} ipython3
 :tags: [remove-input]
 
-my_fun = uqtf.RSQuadratic(rng_seed_prob_input=237324)
+my_fun = uqtf.RSQuadratic()
+my_fun.prob_input.reset_rng(237324)
 xx = my_fun.prob_input.get_sample(1000000)
 yy = my_fun(xx)
 idx_neg = yy <= 0.0

--- a/src/uqtestfuns/core/uqtestfun_abc.py
+++ b/src/uqtestfuns/core/uqtestfun_abc.py
@@ -193,11 +193,6 @@ class UQTestFunABC(UQTestFunBareABC):
         The name of the UQ test function.
         If not given, `None` is used as name.
         This is a keyword only parameter.
-    rng_seed_prob_input : int, optional
-        The seed number for the pseudo-random number generator of the
-        corresponding `ProbInput`; if not given, `None` is used
-        (taken from the system entropy).
-        This is a keyword only parameter.
 
     Notes
     -----
@@ -223,7 +218,6 @@ class UQTestFunABC(UQTestFunBareABC):
         prob_input_selection: Optional[str] = None,
         parameters_selection: Optional[str] = None,
         name: Optional[str] = None,
-        rng_seed_prob_input: Optional[int] = None,
     ):
         # --- Create a probabilistic input model
         # Select the probabilistic input model
@@ -249,12 +243,9 @@ class UQTestFunABC(UQTestFunBareABC):
             prob_input = ProbInput.from_spec(
                 prob_input_spec,
                 spatial_dimension=spatial_dimension,
-                rng_seed=rng_seed_prob_input,
             )
         else:
-            prob_input = ProbInput.from_spec(
-                prob_input_spec, rng_seed=rng_seed_prob_input
-            )
+            prob_input = ProbInput.from_spec(prob_input_spec)
 
         # --- Select the parameters set, when applicable
         available_parameters = self.available_parameters

--- a/tests/builtin_test_functions/test_test_functions.py
+++ b/tests/builtin_test_functions/test_test_functions.py
@@ -169,7 +169,8 @@ def test_transform_input(builtin_testfun):
     rng_seed = 32
 
     # Create an instance
-    my_fun = testfun(rng_seed_prob_input=rng_seed)
+    my_fun = testfun()
+    my_fun.prob_input.reset_rng(rng_seed)
 
     sample_size = 100
 
@@ -192,7 +193,8 @@ def test_transform_input_non_default(builtin_testfun):
     rng_seed = 1232
 
     # Create an instance
-    my_fun = testfun(rng_seed_prob_input=rng_seed)
+    my_fun = testfun()
+    my_fun.prob_input.reset_rng(rng_seed)
 
     sample_size = 100
 


### PR DESCRIPTION
- To reset an RNG attached to an instance of `ProbInput`, use the `reset_rng()` method of an instance of `ProbInput`, optionally with a seed number.

This PR should resolve Issue #279. 