### PR TITLE
Fix Issue #295: Be more explicit about the need for UQTestFuns.

### DIFF
--- a/docs/development/adding-test-function-implementation.md
+++ b/docs/development/adding-test-function-implementation.md
@@ -2,7 +2,8 @@
 # Adding a New Test Function Implementation
 
 In this guide, we will explain how to implement a new UQ test function into the UQTestFuns code base.
-A test function may be added on runtime using the ``UQTestFun`` class as illustrated {ref}`here <getting-started:creating-a-custom>`.
+A test function may be added on runtime using the ``UQTestFun`` class
+as illustrated {ref}`here <getting-started:tutorial-custom-functions>`.
 However, adding the test function directly to the code base is advantageous
 that it becomes exposed to the high-level convenient functionalities
 (such as `list_functions()`).

--- a/docs/getting-started/about-uq-test-functions.md
+++ b/docs/getting-started/about-uq-test-functions.md
@@ -1,8 +1,11 @@
 (getting-started:about-uq-test-functions)=
 # About UQ Test Functions
 
-If you're interested in some background information about the what and why of uncertainty quantification (UQ) test functions,
-their role within UQ analysis methods development, and how to usually get them, read on.
+This page provides some background information about the what and why
+of uncertainty quantification (UQ) test functions,
+their role within UQ analysis methods development,
+how to usually get them,
+as well as the motivation behind UQTestFuns.
 
 ## What are UQ test functions
 
@@ -212,8 +215,14 @@ Specifically, none of them provides:
 - an _opportunity for an open-source contribution_, supporting
   the implementation of new test functions or posting reference results.
 
-Satisfying all the above requirements is exactly the goal
+Satisfying all the above requirements is exactly the goal 
 of the UQTestFuns package.
+In essence, UQTestFuns aims to save the researchers' and developers' time 
+from having to reimplement many of the commonly used test functions from the
+UQ literature themselves.
+The available functions in UQTestFuns are ready to use
+for testing and benchmarking purposes.
+
 
 ## References
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,12 @@ Specifically, the package provides:
 - an _opportunity for an open-source contribution_, supporting
   the implementation of new test functions or posting reference results.
 
+UQTestFuns aims to save the researchers' and developers' time from having to
+reimplement many of the commonly used test functions (and the corresponding
+probabilistic input specifications) from the UQ literature themselves.
+More background information regarding UQ test functions and UQTestFuns
+can be found {ref}`here <getting-started:about-uq-test-functions>`.
+
 ::::{grid}
 :gutter: 2
 
@@ -31,15 +37,15 @@ To the UQTestFuns Tutorials
 :ref-type: myst
 :color: primary
 :outline:
-The what & why of UQ test functions
+About UQ Test Functions
 ```
 :::
 
 :::{grid-item-card} User Guide
 :text-align: center
 
-Be sure to browse through all the available test functions in UQTestFuns;
-they are also crudely classified into their usage in typical UQ analyses.
+Browse through all the available test functions in UQTestFuns;
+they are crudely classified into their usage in typical UQ analyses.
 Need a reference on how to define a probabilistic input model,
 there's a dedicated section on that!
 +++

--- a/docs/test-functions/bratley1992b.md
+++ b/docs/test-functions/bratley1992b.md
@@ -135,7 +135,7 @@ my_testfun = uqtf.Bratley1992b(spatial_dimension=10)
 The `Bratley1992b` function is defined as follows[^location]:
 
 $$
-\mathcal{M}(\boldsymbol{x}) = \prod_{m = 1}^{M} m \cos{(m x)},
+\mathcal{M}(\boldsymbol{x}) = \prod_{m = 1}^{M} m \cos{(m x_m)},
 $$
 
 where $\boldsymbol{x} = \{ x_1, \ldots, x_M \}$

--- a/docs/test-functions/speed-reducer-shaft.md
+++ b/docs/test-functions/speed-reducer-shaft.md
@@ -103,8 +103,7 @@ plt.gcf().set_dpi(150);
 ### Failure probability
 
 Some reference values for the failure probability $P_f$ and from the literature
-are summarized in the table below ($\mu_{F_s}$ is the log-normal distribution
-mean of $F_s$).
+are summarized in the table below.
 
 |    Method     |   $N$   |       $\hat{P}_f$       | $\mathrm{CoV}[\hat{P}_f]$ |           Source           |
 |:-------------:|:-------:|:-----------------------:|:-------------------------:|:--------------------------:|


### PR DESCRIPTION
- A statement of need for UQTestFuns is made more explicit in the landing page with a link to a more detailed discussion.
- Minor edit on the "About UQ Test Functions" edit.
- Fix Issue #289: remove an unnecessary sentence.
- Fix Issue #288: fix missing subscript in a notation.

This PR should resolve Issues #288, #289, and #295.