### PR TITLE
evaluate() abstract method is now in UQTestFunBareABC

### DIFF
--- a/docs/development/adding-test-function-implementation.md
+++ b/docs/development/adding-test-function-implementation.md
@@ -249,7 +249,7 @@ Each built-in test function is an implementation of the abstract base class
 `UQTestFunABC`.
 A concrete implementation of this base class requires the following:
 
-- a static method named `eval_()`
+- a static method named `evaluate()`
 - several class-level properties, namely: `_tags`, `_description`, 
   `_available_inputs`, `_available_parameters`, `_default_spatial_dimension`,
   `_default_input`, and `_default_parameters`.
@@ -268,7 +268,7 @@ class Branin(UQTestFunFixDimABC):
     _default_input = "Dixon1978"       # Optional, if only one input is available
     _default_parameters = "Dixon1978"  # Optional, if only one set of parameters is available
 
-    eval_ = staticmethod(evaluate)  # assuming `evaluate()` has been defined
+    evaluate = staticmethod(evaluate)  # assuming `evaluate()` has been defined
 ```
 
 There is no need to define an `__init__()` method.

--- a/src/uqtestfuns/core/uqtestfun.py
+++ b/src/uqtestfuns/core/uqtestfun.py
@@ -38,8 +38,10 @@ class UQTestFun(UQTestFunBareABC):
         self._evaluate = evaluate
         super().__init__(prob_input, parameters, name)
 
-    def evaluate(self, xx):
-        if self.parameters is not None:
-            return self._evaluate(xx, self.parameters)
+    def _eval(self, xx):
+        if self.parameters is None:
+            return self._evaluate(xx)
 
-        return self._evaluate(xx)
+        return self._evaluate(xx, self.parameters)
+
+    evaluate = None  # type: ignore

--- a/src/uqtestfuns/core/uqtestfun_abc.py
+++ b/src/uqtestfuns/core/uqtestfun_abc.py
@@ -162,12 +162,20 @@ class UQTestFunBareABC(abc.ABC):
             ub = self.prob_input.marginals[dim_idx].upper
             _verify_sample_domain(xx[:, dim_idx], min_value=lb, max_value=ub)
 
-        return self.evaluate(xx)
+        return self._eval(xx)
 
+    @staticmethod
     @abc.abstractmethod
-    def evaluate(self, *args):
+    def evaluate(xx: np.ndarray, *args) -> np.ndarray:
         """Abstract method for the implementation of the UQ test function."""
         pass
+
+    def _eval(self, xx) -> np.ndarray:
+        """Actual computation is delegated to evaluate()."""
+        if self.parameters is None:
+            return self.__class__.evaluate(xx)
+
+        return self.__class__.evaluate(xx, self.parameters)
 
 
 class UQTestFunABC(UQTestFunBareABC):
@@ -380,25 +388,6 @@ class UQTestFunABC(UQTestFunBareABC):
         )
 
         return out
-
-    def evaluate(self, xx):
-        """Concrete implementation, actual function is delegated to eval_()."""
-        if self.parameters is None:
-            return self.__class__.eval_(xx)
-        else:
-            return self.__class__.eval_(xx, self.parameters)
-
-    @staticmethod
-    @abc.abstractmethod
-    def eval_(*args):  # pragma: no cover
-        """Static method for the concrete function implementation.
-
-        Notes
-        -----
-        - The function evaluation is implemented as a static method so the
-          function can be added without being bounded to the instance.
-        """
-        pass
 
 
 def _verify_sample_shape(xx: np.ndarray, num_cols: int):

--- a/src/uqtestfuns/test_functions/ackley.py
+++ b/src/uqtestfuns/test_functions/ackley.py
@@ -110,4 +110,4 @@ class Ackley(UQTestFunABC):
     _available_parameters = AVAILABLE_PARAMETERS
     _default_spatial_dimension = None  # Indicate that this is variable dim.
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/alemazkoor.py
+++ b/src/uqtestfuns/test_functions/alemazkoor.py
@@ -105,7 +105,7 @@ class Alemazkoor2D(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 2
 
-    eval_ = staticmethod(evaluate_2d)
+    evaluate = staticmethod(evaluate_2d)  # type: ignore
 
 
 def evaluate_20d(xx: np.ndarray) -> np.ndarray:
@@ -140,4 +140,4 @@ class Alemazkoor20D(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 20
 
-    eval_ = staticmethod(evaluate_20d)
+    evaluate = staticmethod(evaluate_20d)  # type: ignore

--- a/src/uqtestfuns/test_functions/borehole.py
+++ b/src/uqtestfuns/test_functions/borehole.py
@@ -163,4 +163,4 @@ class Borehole(UQTestFunABC):
     _default_input = DEFAULT_INPUT_SELECTION
     _default_spatial_dimension = 8
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/bratley1992.py
+++ b/src/uqtestfuns/test_functions/bratley1992.py
@@ -94,7 +94,7 @@ COMMON_METADATA = dict(
 )
 
 
-def evaluate_bratley1992a(xx: np.ndarray):
+def evaluate_bratley1992a(xx: np.ndarray) -> np.ndarray:
     """Evaluate the test function on a set of input values.
 
     Parameters
@@ -134,10 +134,10 @@ class Bratley1992a(UQTestFunABC):
     _available_parameters = COMMON_METADATA["_available_parameters"]
     _default_spatial_dimension = None
 
-    eval_ = staticmethod(evaluate_bratley1992a)
+    evaluate = staticmethod(evaluate_bratley1992a)  # type: ignore
 
 
-def evaluate_bratley1992b(xx: np.ndarray):
+def evaluate_bratley1992b(xx: np.ndarray) -> np.ndarray:
     """Evaluate the test function on a set of input values.
 
     Parameters
@@ -177,10 +177,10 @@ class Bratley1992b(UQTestFunABC):
     _available_parameters = COMMON_METADATA["_available_parameters"]
     _default_spatial_dimension = None
 
-    eval_ = staticmethod(evaluate_bratley1992b)
+    evaluate = staticmethod(evaluate_bratley1992b)  # type: ignore
 
 
-def evaluate_bratley1992c(xx: np.ndarray):
+def evaluate_bratley1992c(xx: np.ndarray) -> np.ndarray:
     """Evaluate the test function #3 of Bratley et al. (1992).
 
     Parameters
@@ -222,10 +222,10 @@ class Bratley1992c(UQTestFunABC):
     _available_parameters = COMMON_METADATA["_available_parameters"]
     _default_spatial_dimension = None
 
-    eval_ = staticmethod(evaluate_bratley1992c)
+    evaluate = staticmethod(evaluate_bratley1992c)  # type: ignore
 
 
-def evaluate_bratley1992d(xx: np.ndarray):
+def evaluate_bratley1992d(xx: np.ndarray) -> np.ndarray:
     """Evaluate the test function on a set of input values.
 
     Parameters
@@ -265,4 +265,4 @@ class Bratley1992d(UQTestFunABC):
     _available_parameters = COMMON_METADATA["_available_parameters"]
     _default_spatial_dimension = None
 
-    eval_ = staticmethod(evaluate_bratley1992d)
+    evaluate = staticmethod(evaluate_bratley1992d)  # type: ignore

--- a/src/uqtestfuns/test_functions/cantilever_beam_2d.py
+++ b/src/uqtestfuns/test_functions/cantilever_beam_2d.py
@@ -116,4 +116,4 @@ class CantileverBeam2D(UQTestFunABC):
     _available_parameters = AVAILABLE_PARAMETERS
     _default_spatial_dimension = 2
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/circular_pipe_crack.py
+++ b/src/uqtestfuns/test_functions/circular_pipe_crack.py
@@ -115,4 +115,4 @@ class CircularPipeCrack(UQTestFunABC):
     _available_parameters = AVAILABLE_PARAMETERS
     _default_spatial_dimension = 2
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/convex_fail_domain.py
+++ b/src/uqtestfuns/test_functions/convex_fail_domain.py
@@ -86,4 +86,4 @@ class ConvexFailDomain(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 2
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/damped_cosine.py
+++ b/src/uqtestfuns/test_functions/damped_cosine.py
@@ -68,4 +68,4 @@ class DampedCosine(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 1
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/damped_oscillator.py
+++ b/src/uqtestfuns/test_functions/damped_oscillator.py
@@ -261,7 +261,7 @@ class DampedOscillator(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 8
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore
 
 
 def evaluate_reliability(xx: np.ndarray, parameters: float):
@@ -306,4 +306,4 @@ class DampedOscillatorReliability(UQTestFunABC):
     _default_input = "DerKiureghian1990a"
     _default_parameters = "DerKiureghian1990"
 
-    eval_ = staticmethod(evaluate_reliability)
+    evaluate = staticmethod(evaluate_reliability)  # type: ignore

--- a/src/uqtestfuns/test_functions/flood.py
+++ b/src/uqtestfuns/test_functions/flood.py
@@ -147,4 +147,4 @@ class Flood(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 8
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/forrester.py
+++ b/src/uqtestfuns/test_functions/forrester.py
@@ -71,4 +71,4 @@ class Forrester2008(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 1
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/four_branch.py
+++ b/src/uqtestfuns/test_functions/four_branch.py
@@ -121,4 +121,4 @@ class FourBranch(UQTestFunABC):
     _default_spatial_dimension = 2
     _default_parameters = "Schueremans2005"
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/franke.py
+++ b/src/uqtestfuns/test_functions/franke.py
@@ -129,7 +129,7 @@ class Franke1(UQTestFunABC):
     _available_parameters = COMMON_METADATA["_available_parameters"]
     _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
 
-    eval_ = staticmethod(evaluate_franke1)
+    evaluate = staticmethod(evaluate_franke1)  # type: ignore
 
 
 def evaluate_franke2(xx: np.ndarray):
@@ -165,7 +165,7 @@ class Franke2(UQTestFunABC):
     _available_parameters = COMMON_METADATA["_available_parameters"]
     _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
 
-    eval_ = staticmethod(evaluate_franke2)
+    evaluate = staticmethod(evaluate_franke2)  # type: ignore
 
 
 def evaluate_franke3(xx: np.ndarray):
@@ -204,7 +204,7 @@ class Franke3(UQTestFunABC):
     _available_parameters = COMMON_METADATA["_available_parameters"]
     _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
 
-    eval_ = staticmethod(evaluate_franke3)
+    evaluate = staticmethod(evaluate_franke3)  # type: ignore
 
 
 def evaluate_franke4(xx: np.ndarray):
@@ -243,7 +243,7 @@ class Franke4(UQTestFunABC):
     _available_parameters = COMMON_METADATA["_available_parameters"]
     _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
 
-    eval_ = staticmethod(evaluate_franke4)
+    evaluate = staticmethod(evaluate_franke4)  # type: ignore
 
 
 def evaluate_franke5(xx: np.ndarray):
@@ -282,7 +282,7 @@ class Franke5(UQTestFunABC):
     _available_parameters = COMMON_METADATA["_available_parameters"]
     _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
 
-    eval_ = staticmethod(evaluate_franke5)
+    evaluate = staticmethod(evaluate_franke5)  # type: ignore
 
 
 def evaluate_franke6(xx: np.ndarray):
@@ -322,4 +322,4 @@ class Franke6(UQTestFunABC):
     _available_parameters = COMMON_METADATA["_available_parameters"]
     _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
 
-    eval_ = staticmethod(evaluate_franke6)
+    evaluate = staticmethod(evaluate_franke6)  # type: ignore

--- a/src/uqtestfuns/test_functions/friedman.py
+++ b/src/uqtestfuns/test_functions/friedman.py
@@ -107,7 +107,7 @@ class Friedman6D(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 6
 
-    eval_ = staticmethod(evaluate_friedman)
+    evaluate = staticmethod(evaluate_friedman)  # type: ignore
 
 
 class Friedman10D(UQTestFunABC):
@@ -119,4 +119,4 @@ class Friedman10D(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 10
 
-    eval_ = staticmethod(evaluate_friedman)
+    evaluate = staticmethod(evaluate_friedman)  # type: ignore

--- a/src/uqtestfuns/test_functions/gayton_hat.py
+++ b/src/uqtestfuns/test_functions/gayton_hat.py
@@ -79,4 +79,4 @@ class GaytonHat(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 2
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/gramacy2007.py
+++ b/src/uqtestfuns/test_functions/gramacy2007.py
@@ -102,4 +102,4 @@ class Gramacy1DSine(UQTestFunABC):
     _default_spatial_dimension = 1
     _default_parameters = "noisy"
 
-    eval_ = staticmethod(evaluate_1dsine)
+    evaluate = staticmethod(evaluate_1dsine)  # type: ignore

--- a/src/uqtestfuns/test_functions/hyper_sphere.py
+++ b/src/uqtestfuns/test_functions/hyper_sphere.py
@@ -78,4 +78,4 @@ class HyperSphere(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 2
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/ishigami.py
+++ b/src/uqtestfuns/test_functions/ishigami.py
@@ -116,4 +116,4 @@ class Ishigami(UQTestFunABC):
     _default_parameters = DEFAULT_PARAMETERS_SELECTION
     _default_spatial_dimension = 3
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/mclain.py
+++ b/src/uqtestfuns/test_functions/mclain.py
@@ -104,7 +104,7 @@ class McLainS1(UQTestFunABC):
     _available_parameters = COMMON_METADATA["_available_parameters"]
     _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
 
-    eval_ = staticmethod(evaluate_mclain_s1)
+    evaluate = staticmethod(evaluate_mclain_s1)  # type: ignore
 
 
 def evaluate_mclain_s2(xx: np.ndarray) -> np.ndarray:
@@ -139,7 +139,7 @@ class McLainS2(UQTestFunABC):
     _available_parameters = COMMON_METADATA["_available_parameters"]
     _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
 
-    eval_ = staticmethod(evaluate_mclain_s2)
+    evaluate = staticmethod(evaluate_mclain_s2)  # type: ignore
 
 
 def evaluate_mclain_s3(xx: np.ndarray) -> np.ndarray:
@@ -174,7 +174,7 @@ class McLainS3(UQTestFunABC):
     _available_parameters = COMMON_METADATA["_available_parameters"]
     _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
 
-    eval_ = staticmethod(evaluate_mclain_s3)
+    evaluate = staticmethod(evaluate_mclain_s3)  # type: ignore
 
 
 def evaluate_mclain_s4(xx: np.ndarray) -> np.ndarray:
@@ -212,7 +212,7 @@ class McLainS4(UQTestFunABC):
     _available_parameters = COMMON_METADATA["_available_parameters"]
     _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
 
-    eval_ = staticmethod(evaluate_mclain_s4)
+    evaluate = staticmethod(evaluate_mclain_s4)  # type: ignore
 
 
 def evaluate_mclain_s5(xx: np.ndarray) -> np.ndarray:
@@ -247,4 +247,4 @@ class McLainS5(UQTestFunABC):
     _available_parameters = COMMON_METADATA["_available_parameters"]
     _default_spatial_dimension = COMMON_METADATA["_default_spatial_dimension"]
 
-    eval_ = staticmethod(evaluate_mclain_s5)
+    evaluate = staticmethod(evaluate_mclain_s5)  # type: ignore

--- a/src/uqtestfuns/test_functions/oakley2002.py
+++ b/src/uqtestfuns/test_functions/oakley2002.py
@@ -72,4 +72,4 @@ class Oakley1D(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 1
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/otl_circuit.py
+++ b/src/uqtestfuns/test_functions/otl_circuit.py
@@ -160,4 +160,4 @@ class OTLCircuit(UQTestFunABC):
     _available_parameters = None
     _default_input = DEFAULT_INPUT_SELECTION
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/piston.py
+++ b/src/uqtestfuns/test_functions/piston.py
@@ -170,4 +170,4 @@ class Piston(UQTestFunABC):
     _default_spatial_dimension = 7
     _default_input = DEFAULT_INPUT_SELECTION
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/portfolio_3d.py
+++ b/src/uqtestfuns/test_functions/portfolio_3d.py
@@ -102,4 +102,4 @@ class Portfolio3D(UQTestFunABC):
     _default_parameters = DEFAULT_PARAMETERS_SELECTION
     _default_spatial_dimension = 3
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/rs_circular_bar.py
+++ b/src/uqtestfuns/test_functions/rs_circular_bar.py
@@ -86,4 +86,4 @@ class RSCircularBar(UQTestFunABC):
     _available_parameters = AVAILABLE_PARAMETERS
     _default_spatial_dimension = 2
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/rs_quadratic.py
+++ b/src/uqtestfuns/test_functions/rs_quadratic.py
@@ -74,4 +74,4 @@ class RSQuadratic(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 2
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/sobol_g.py
+++ b/src/uqtestfuns/test_functions/sobol_g.py
@@ -286,4 +286,4 @@ class SobolG(UQTestFunABC):
     _default_parameters = DEFAULT_PARAMETERS_SELECTION
     _default_spatial_dimension = None
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/speed_reducer_shaft.py
+++ b/src/uqtestfuns/test_functions/speed_reducer_shaft.py
@@ -116,4 +116,4 @@ class SpeedReducerShaft(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 5
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/sulfur.py
+++ b/src/uqtestfuns/test_functions/sulfur.py
@@ -203,4 +203,4 @@ class Sulfur(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 9
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/webster.py
+++ b/src/uqtestfuns/test_functions/webster.py
@@ -77,4 +77,4 @@ class Webster2D(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 2
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/welch1992.py
+++ b/src/uqtestfuns/test_functions/welch1992.py
@@ -104,4 +104,4 @@ class Welch1992(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 20
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/wing_weight.py
+++ b/src/uqtestfuns/test_functions/wing_weight.py
@@ -143,4 +143,4 @@ class WingWeight(UQTestFunABC):
     _available_parameters = None
     _default_spatial_dimension = 10
 
-    eval_ = staticmethod(evaluate)
+    evaluate = staticmethod(evaluate)  # type: ignore


### PR DESCRIPTION
To simplify the implementation, all evaluation related methods are put in UQTestFunBareABC and not be deferred to UQTestFunABC.

This PR should resolve Issue #358.