### PR TITLE
Add parameterization status to the output of printing a test function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Printing a test function instance now shows whether the function is 
+  parameterized or not.
+- The information related to the parameterization of a function is now
+  shown in the output of `list_functions()`
+- New class `FunParams` to organize function parameters.
 - The six-dimensional and ten-dimensional Friedman functions from
   Friedman et al. (1983) and Friedman (1991), respectively.
 - The three-dimensional simple portfolio model from Saltelli et al. (2004).
 - The 20-dimensional polynomial test function from Alemazkoor
   and Meidani (2018).
 - The exponential distribution as a distribution of `UnivDist` instances.
-- New class `FunParams` to organize function parameters.
 
 ### Changed
 

--- a/src/uqtestfuns/core/uqtestfun_abc.py
+++ b/src/uqtestfuns/core/uqtestfun_abc.py
@@ -152,7 +152,8 @@ class UQTestFunBareABC(abc.ABC):
     def __str__(self):
         out = (
             f"Name              : {self.name}\n"
-            f"Spatial dimension : {self.spatial_dimension}"
+            f"Spatial dimension : {self.spatial_dimension}\n"
+            f"Parameterized     : {bool(self.parameters)}"
         )
 
         return out
@@ -379,6 +380,7 @@ class UQTestFunABC(UQTestFunBareABC):
         out = (
             f"Name              : {self.name}\n"
             f"Spatial dimension : {self.spatial_dimension}\n"
+            f"Parameterized     : {bool(self.parameters)}\n"
             f"Description       : {self.description}"
         )
 

--- a/src/uqtestfuns/helpers.py
+++ b/src/uqtestfuns/helpers.py
@@ -98,6 +98,7 @@ def list_functions(
             "No.",
             "Constructor",
             "Dimension",
+            "Parameterized",
             "Application",
             "Description",
         ]
@@ -106,6 +107,7 @@ def list_functions(
             "No.",
             "Constructor",
             "Dimension",
+            "Parameterized",
             "Description",
         ]
 
@@ -123,6 +125,9 @@ def list_functions(
             )
 
         description = available_class.description
+        is_parameterized = (
+            True if available_class.available_parameters else False
+        )
 
         if tag is None:
             tags = ", ".join(available_class.tags)
@@ -130,6 +135,7 @@ def list_functions(
                 idx + 1,
                 f"{available_class_name}()",
                 f"{default_spatial_dimension}",
+                f"{is_parameterized}",
                 tags,
                 f"{description}",
             ]
@@ -138,6 +144,7 @@ def list_functions(
                 idx + 1,
                 f"{available_class_name}()",
                 f"{default_spatial_dimension}",
+                f"{is_parameterized}",
                 f"{description}",
             ]
 
@@ -148,14 +155,21 @@ def list_functions(
             values,
             headers=header_names,
             stralign="center",
-            colalign=("center", "center", "center", "center", "left"),
+            colalign=(
+                "center",
+                "center",
+                "center",
+                "center",
+                "center",
+                "left",
+            ),
         )
     else:
         table = tbl(
             values,
             headers=header_names,
             stralign="center",
-            colalign=("center", "center", "center", "left"),
+            colalign=("center", "center", "center", "center", "left"),
         )
 
     print(table)
@@ -228,6 +242,8 @@ def _verify_input_args(
         raise ValueError(
             f"Tag {tag!r} is not supported. Use one of {SUPPORTED_TAGS}!"
         )
+
+    # --- Parse 'parameterized'
 
     # --- Parse 'tabulate'
     if not isinstance(tabulate, (bool, type(None))):

--- a/tests/builtin_test_functions/test_test_functions.py
+++ b/tests/builtin_test_functions/test_test_functions.py
@@ -157,6 +157,7 @@ def test_str(builtin_testfun):
     str_ref = (
         f"Name              : {my_fun.name}\n"
         f"Spatial dimension : {my_fun.spatial_dimension}\n"
+        f"Parameterized     : {bool(my_fun.parameters)}\n"
         f"Description       : {my_fun.description}"
     )
 

--- a/tests/core/test_uqtestfun.py
+++ b/tests/core/test_uqtestfun.py
@@ -69,7 +69,8 @@ def test_str(uqtestfun):
 
     str_ref = (
         f"Name              : {uqtestfun_instance.name}\n"
-        f"Spatial dimension : {uqtestfun_instance.spatial_dimension}"
+        f"Spatial dimension : {uqtestfun_instance.spatial_dimension}\n"
+        f"Parameterized     : {bool(uqtestfun_instance.parameters)}"
     )
 
     assert uqtestfun_instance.__str__() == str_ref


### PR DESCRIPTION
This update enhances the output of printing function instances to include the parameterization status.
The `__str__` method and associated tests have been updated to reflect this change.
The `list_functions()` output now also displays whether functions are parameterized.

This PR should resolve Issue #361.