### PR TITLE
Rename 'name' to 'function_id' in UQ test functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The property `name` of UQ test function instances has been renamed to
+  `function_id` that implies uniqueness although it is not strictly enforced.
 - The parameter in the Gramacy 1D sine function is now removed. Noise can
   be added on the fly if needed.
 - `evaluate()` abstract method is now must be implemented directly in the

--- a/docs/getting-started/tutorial-custom-functions.md
+++ b/docs/getting-started/tutorial-custom-functions.md
@@ -224,7 +224,7 @@ my_testfun = uqtf.UQTestFun(
   evaluate=evaluate_branin,
   prob_input=my_input,
   parameters=my_params,
-  name="Branin function",
+  function_id="Branin",
 )
 ```
 

--- a/src/uqtestfuns/core/uqtestfun.py
+++ b/src/uqtestfuns/core/uqtestfun.py
@@ -25,8 +25,8 @@ class UQTestFun(UQTestFunBareABC):
     parameters : Any, optional
         The parameters set of the UQ test function.
         If not specified, `None` is used.
-    name : str, optional
-        The name of the UQ test function.
+    function_id : str, optional
+        The ID of the UQ test function.
     """
 
     def __init__(
@@ -34,13 +34,13 @@ class UQTestFun(UQTestFunBareABC):
         evaluate: Callable,
         prob_input: ProbInput,
         parameters: Optional[FunParams] = None,
-        name: Optional[str] = None,
+        function_id: Optional[str] = None,
     ):
         if parameters is None:
             parameters = FunParams()
 
         self._evaluate = evaluate
-        super().__init__(prob_input, parameters, name)
+        super().__init__(prob_input, parameters, function_id)
 
     def _eval(self, xx):
         return self._evaluate(xx, **self.parameters.as_dict())

--- a/src/uqtestfuns/core/uqtestfun_abc.py
+++ b/src/uqtestfuns/core/uqtestfun_abc.py
@@ -46,24 +46,24 @@ class UQTestFunBareABC(abc.ABC):
         The probabilistic input model of the UQ test function.
     parameters : Any, optional
         A set of parameters. By default, it is None.
-    name : str, optional
-        The name of the UQ test function. By default, it is None.
+    function_id : str, optional
+        The ID of the UQ test function. By default, it is None.
 
     Notes
     -----
     - A bare UQ test function only includes the evaluation function,
-      probabilistic input model, parameters, and a (optional) name.
+      probabilistic input model, parameters, and a (optional) ID.
     """
 
     def __init__(
         self,
         prob_input: ProbInput,
         parameters: FunParams,
-        name: Optional[str] = None,
+        function_id: Optional[str] = None,
     ):
         self.prob_input = prob_input
         self._parameters = parameters
-        self._name = name
+        self._function_id = function_id
 
     @property
     def prob_input(self) -> ProbInput:
@@ -96,9 +96,9 @@ class UQTestFunBareABC(abc.ABC):
         self._parameters = value
 
     @property
-    def name(self) -> Optional[str]:
-        """The name of the UQ test function."""
-        return self._name
+    def function_id(self) -> Optional[str]:
+        """The ID of the UQ test function."""
+        return self._function_id
 
     @property
     def spatial_dimension(self) -> int:
@@ -151,7 +151,7 @@ class UQTestFunBareABC(abc.ABC):
 
     def __str__(self):
         out = (
-            f"Name              : {self.name}\n"
+            f"Function ID       : {self.function_id}\n"
             f"Spatial dimension : {self.spatial_dimension}\n"
             f"Parameterized     : {bool(self.parameters)}"
         )
@@ -202,9 +202,9 @@ class UQTestFunABC(UQTestFunBareABC):
         The selection of parameters set; this is used when there are multiple
         sets of parameters available in the literature.
         This is a keyword only parameter.
-    name : str, optional
-        The name of the UQ test function.
-        If not given, `None` is used as name.
+    function_id : str, optional
+        The ID of the UQ test function.
+        If not given, `None` is used as the function ID.
         This is a keyword only parameter.
 
     Notes
@@ -230,7 +230,7 @@ class UQTestFunABC(UQTestFunBareABC):
         spatial_dimension: Optional[int] = None,
         prob_input_selection: Optional[str] = None,
         parameters_selection: Optional[str] = None,
-        name: Optional[str] = None,
+        function_id: Optional[str] = None,
     ):
         # --- Create a probabilistic input model
         # Select the probabilistic input model
@@ -275,13 +275,15 @@ class UQTestFunABC(UQTestFunBareABC):
                 spatial_dimension,
             )
 
-        # --- Process the default name
-        if name is None:
-            name = self.__class__.__name__
+        # --- Process the default ID
+        if function_id is None:
+            function_id = self.__class__.__name__
 
         # --- Initialize the parent class
         super().__init__(
-            prob_input=prob_input, parameters=parameters, name=name
+            prob_input=prob_input,
+            parameters=parameters,
+            function_id=function_id,
         )
 
     @classmethod
@@ -378,7 +380,7 @@ class UQTestFunABC(UQTestFunBareABC):
 
     def __str__(self):
         out = (
-            f"Name              : {self.name}\n"
+            f"Function ID       : {self.function_id}\n"
             f"Spatial dimension : {self.spatial_dimension}\n"
             f"Parameterized     : {bool(self.parameters)}\n"
             f"Description       : {self.description}"

--- a/src/uqtestfuns/meta/uqmetatestfun.py
+++ b/src/uqtestfuns/meta/uqmetatestfun.py
@@ -161,7 +161,7 @@ class UQMetaTestFun:
                 evaluate=evaluate,
                 prob_input=prob_input,
                 parameters=parameters,
-                name=name,
+                function_id=name,
             )
 
         sample = []
@@ -185,7 +185,7 @@ class UQMetaTestFun:
                     evaluate=evaluate,
                     prob_input=prob_input,
                     parameters=parameters,
-                    name=name,
+                    function_id=name,
                 )
             )
 

--- a/tests/builtin_test_functions/test_test_functions.py
+++ b/tests/builtin_test_functions/test_test_functions.py
@@ -43,17 +43,17 @@ def test_create_instance_with_custom_name(builtin_testfun):
     testfun_class = builtin_testfun
 
     # Get the default name of the test function
-    name = testfun_class.__name__
+    function_id = testfun_class.__name__
 
     # Create a default instance
     my_fun = testfun_class()
 
     # Assertion
-    assert my_fun.name == name
+    assert my_fun.function_id == function_id
 
     # Use custom name to create a test function
-    my_fun = testfun_class(name=name)
-    assert my_fun.name == name
+    my_fun = testfun_class(function_id=function_id)
+    assert my_fun.function_id == function_id
 
 
 def test_create_instance_with_prob_input(builtin_testfun):
@@ -155,7 +155,7 @@ def test_str(builtin_testfun):
     my_fun = builtin_testfun()
 
     str_ref = (
-        f"Name              : {my_fun.name}\n"
+        f"Function ID       : {my_fun.function_id}\n"
         f"Spatial dimension : {my_fun.spatial_dimension}\n"
         f"Parameterized     : {bool(my_fun.parameters)}\n"
         f"Description       : {my_fun.description}"

--- a/tests/core/test_uqtestfun.py
+++ b/tests/core/test_uqtestfun.py
@@ -24,14 +24,14 @@ def uqtestfun():
         "evaluate": evaluate,
         "prob_input": ProbInput(input_marginals),
         "parameters": parameters,
-        "name": "Test function",
+        "function_id": "TestFunction",
     }
 
     uqtestfun_instance = UQTestFun(
         evaluate=evaluate,
         prob_input=ProbInput(input_marginals),
         parameters=parameters,
-        name="Test function",
+        function_id="TestFunction",
     )
 
     return uqtestfun_instance, my_args
@@ -43,7 +43,7 @@ def test_create_instance(uqtestfun):
     uqtestfun_instance, uqtestfun_dict = uqtestfun
 
     # Assertions
-    assert uqtestfun_instance.name == uqtestfun_dict["name"]
+    assert uqtestfun_instance.function_id == uqtestfun_dict["function_id"]
     # The original evaluate function is stored in a hidden attribute
     assert uqtestfun_instance._evaluate == uqtestfun_dict["evaluate"]
     assert (
@@ -68,7 +68,7 @@ def test_str(uqtestfun):
     uqtestfun_instance, _ = uqtestfun
 
     str_ref = (
-        f"Name              : {uqtestfun_instance.name}\n"
+        f"Function ID       : {uqtestfun_instance.function_id}\n"
         f"Spatial dimension : {uqtestfun_instance.spatial_dimension}\n"
         f"Parameterized     : {bool(uqtestfun_instance.parameters)}"
     )


### PR DESCRIPTION
Renamed the property 'name' to 'function_id' across the UQ test function classes for better clarity and to imply uniqueness.
Updated all relevant tests and documentation to reflect this change.

This PR should resolve Issue #362.