### PR TITLE
Rename UnivDist to Marginal across codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The class `UnivDist` has been renamed to `Marginal`. The name more clearly
+  refers to one-dimensional marginal distributions (of a univariate random
+  variable), which form a `ProbInput`.
 - The property `spatial_dimension` of `ProbInput` and `UQTestFunBareABC` is
   renamed to `input_dimension` for clarity (as opposed to `output_dimension`).
 - The property `name` of UQ test function instances has been renamed to

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -136,27 +136,27 @@ parts:
       - file: prob-input/probabilistic-input
         title: Probabilistic Input Model
       - file: prob-input/available
-        title: Univariate Distributions
+        title: One-Dimensional Marginal Distributions
         sections:
-          - file: prob-input/univariate-distributions/beta
+          - file: prob-input/marginal-distributions/beta
             title: Beta
-          - file: prob-input/univariate-distributions/exponential
+          - file: prob-input/marginal-distributions/exponential
             title: Exponential
-          - file: prob-input/univariate-distributions/gumbel
+          - file: prob-input/marginal-distributions/gumbel
             title: Gumbel (max.)
-          - file: prob-input/univariate-distributions/logitnormal
+          - file: prob-input/marginal-distributions/logitnormal
             title: Logit-Normal
-          - file: prob-input/univariate-distributions/lognormal
+          - file: prob-input/marginal-distributions/lognormal
             title: Log-Normal
-          - file: prob-input/univariate-distributions/normal
+          - file: prob-input/marginal-distributions/normal
             title: Normal (Gaussian)
-          - file: prob-input/univariate-distributions/triangular
+          - file: prob-input/marginal-distributions/triangular
             title: Triangular
-          - file: prob-input/univariate-distributions/trunc-gumbel
+          - file: prob-input/marginal-distributions/trunc-gumbel
             title: Truncated Gumbel (max.)
-          - file: prob-input/univariate-distributions/trunc-normal
+          - file: prob-input/marginal-distributions/trunc-normal
             title: Truncated Normal (Gaussian)
-          - file: prob-input/univariate-distributions/uniform
+          - file: prob-input/marginal-distributions/uniform
             title: Uniform
   - caption: API Reference
     chapters:
@@ -170,8 +170,8 @@ parts:
         title: UQTestFun
       - file: api/probinput
         title: ProbInput
-      - file: api/univdist
-        title: UnivDist
+      - file: api/marginal
+        title: Marginal
       - file: api/input-spec
         title: ProbInputSpec
       - file: api/funparams
@@ -188,8 +188,8 @@ parts:
         title: Test Function Docs
       - file: development/making-a-pull-request
         title: Making a Pull Request
-      - file: development/adding-univariate-distribution
-        title: Univariate Distribution
+      - file: development/adding-marginal-distribution
+        title: Adding a Marginal Distribution
       - file: development/about
         title: About UQTestFuns
       - file: development/code-of-conduct

--- a/docs/api/marginal.rst
+++ b/docs/api/marginal.rst
@@ -1,0 +1,9 @@
+.. _api_reference_marginal_distribution:
+
+One-Dimensional Marginal Distribution
+=====================================
+
+.. automodule:: uqtestfuns.core.prob_input.marginal
+
+.. autoclass:: uqtestfuns.core.prob_input.marginal.Marginal
+   :members:

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -21,14 +21,13 @@ let's start from the top, the {ref}`built-in test functions <test-functions:avai
   represents the input of an uncertainty quantification (UQ) test function.
 - An instance of the ``ProbInput`` class consists mainly of the one-dimensional
   marginals and a copula specification (not yet supported). Each one-dimensional
-  marginal comes from a univariate random variable which in turn
-  is represented by the {ref}`UnivDist <api_reference_univariate_distribution>`
-  class. 
-- An instance of class ``UnivDist`` has a (parametric) probability distribution.
-  Although different instances may have different probability distributions,
-  they are all instances of the same class.
-- As lightweight containers to specify the specifications of a ``ProbInput`` and
-  a ``UnivDist``, {ref}`three custom <api_reference_input_spec>` ``NamedTuple``
+  marginal comes is represented
+  by the {ref}`Marginal <api_reference_marginal_distribution>` class. 
+- An instance of the ``Marginal`` class has a (parametric) probability
+  distribution. Although different instances may have different
+  probability distributions, they are all instances of the same class.
+- As lightweight containers to specify the specifications of a ``ProbInput``
+  and a ``Marginal``, {ref}`three custom <api_reference_input_spec>` ``NamedTuple``
   are defined, namely {ref}`api_reference_input_spec_univdist`, 
   {ref}`api_reference_input_spec_fixdim`, and {ref}`api_reference_input_spec_vardim`.
 

--- a/docs/api/univdist.rst
+++ b/docs/api/univdist.rst
@@ -1,9 +1,0 @@
-.. _api_reference_univariate_distribution:
-
-Univariate Distribution
-=======================
-
-.. automodule:: uqtestfuns.core.prob_input.univariate_distribution
-
-.. autoclass:: uqtestfuns.core.prob_input.univariate_distribution.UnivDist
-   :members:

--- a/docs/development/adding-marginal-distribution.md
+++ b/docs/development/adding-marginal-distribution.md
@@ -1,8 +1,9 @@
-(development:adding-univ-dist)=
-# Adding a New Univariate Distribution Type
+(development:adding-marginal-distribution)=
+# Adding a New Marginal Distribution Type
 
-UQTestFuns is delivered with several {ref}`univariate distributions <prob-input:available-univariate-distributions>`
-that are used by the currently available test functions.
+UQTestFuns is delivered with several one-dimensional
+{ref}`marginal distributions <prob-input:available-marginal-distributions>`
+(i.e., univariate distributions) that are used by the currently available test functions.
 In case a new univariate distribution type is required for a new test function,
 the distribution should be added first to the code base.
 
@@ -27,12 +28,12 @@ For example:
 
 ```python
 >>> import uqtestfuns as uqtf
->>> my_var = uqtf.UnivDist(distribution="uniform", parameters=[3, 5])
+>>> my_var = uqtf.Marginal(distribution="uniform", parameters=[3, 5])
 ```
 
 ## Step 0: Putting things in the right place
 
-Univariate random variables in UQTestFuns are represented as instances of the `UnivDist` class.
+Univariate random variables in UQTestFuns are represented as instances of the `Marginal` class.
 The supported distributions for the random variables are implemented in separate modules
 located in the `src/uqtestfuns/core/prob_input/univariate_distributions` directory.
 Here's how the directory look:
@@ -361,11 +362,11 @@ SUPPORTED_MARGINALS = {
 }
 ```
 
-This way you can create a new instance of `UnivDist` class by passing the chosen name as the `distribution` and the corresponding parameters:
+This way you can create a new instance of `Marginal` class by passing the chosen name as the `distribution` and the corresponding parameters:
 
 ```python
 >>> import uqtestfuns as uqtf
->>> my_var = uqtf.UnivDist(distribution="uniform", parameters=[3, 5])
+>>> my_var = uqtf.Marginal(distribution="uniform", parameters=[3, 5])
 ```
 
 Remember that the name `uniform` was chosen as the name of this distribution via the module-level variable `DISTRIBUTION_NAME`.

--- a/docs/development/adding-test-function-implementation.md
+++ b/docs/development/adding-test-function-implementation.md
@@ -124,7 +124,7 @@ Here are some explanations:
   (the one-dimensional marginal specification) and `ProbInputSpecFixDim`
   (the probabilistic input model). These are lightweight _containers_
   (meaning no custom methods) of all the information required to construct,
-  later on, `UnivDist` and `ProbInput` instances, respectively.
+  later on, `Marginal` and `ProbInput` instances, respectively.
 
 ```{note}
 There is also the corresponding `ProbInputSpecVarDim` to store the information
@@ -221,7 +221,7 @@ The keyword is, by convention, the citation key of the particular reference as l
 
 Also notice that in the code above, we store the specifications of the marginals
 in a list of {ref}`api_reference_input_spec_univdist`.
-Each element of this list is used to create an instance of `UnivDist`.
+Each element of this list is used to create an instance of `Marginal`.
 
 With that, we have completed the input specification of the Branin function.
 

--- a/docs/development/overview.md
+++ b/docs/development/overview.md
@@ -45,7 +45,8 @@ be sure to check out the guides on:
 - {ref}`adding a new test function implementation <development:adding-test-function-implementation>`
 - {ref}`adding a new test function documentation <development:adding-test-function-docs>`
 - {ref}`making a pull request <development:making-a-pull-request>`
-- In case the univariate distribution types are not yet available: {ref}`adding a new univariate distribution <development:adding-univ-dist>`
+- In case the univariate distribution types are not yet available:
+  {ref}`adding a new univariate distribution <development:adding-marginal-distribution>`
 
 ## Updating the documentation
 

--- a/docs/getting-started/tutorial-custom-functions.md
+++ b/docs/getting-started/tutorial-custom-functions.md
@@ -146,8 +146,8 @@ class  and an instance of it can be defined as follows:
 ```{code-cell} ipython3
 # Define a list of marginals
 marginals = [
-    uqtf.UnivDist(distribution="uniform", parameters=[-5, 10], name="x1"),
-    uqtf.UnivDist(distribution="uniform", parameters=[0, 15], name="x2"),
+    uqtf.Marginal(distribution="uniform", parameters=[-5, 10], name="x1"),
+    uqtf.Marginal(distribution="uniform", parameters=[0, 15], name="x2"),
 ]
 # Create a probabilistic input
 my_input = uqtf.ProbInput(marginals=marginals, name="Branin-Input")

--- a/docs/prob-input/available.md
+++ b/docs/prob-input/available.md
@@ -1,19 +1,20 @@
-(prob-input:available-univariate-distributions)=
-# Available Univariate Distributions
+(prob-input:available-marginal-distributions)=
+# Available One-Dimensional Marginal Distributions
 
-The table below lists all the available univariate distribution types used
-to construct ``UnivDist`` instances. ``UnivDist`` are used to represent the
-univariate marginals of a (possibly, multivariate) probabilistic input model.
+The table below lists all the available one-dimensional marginal distribution
+types used to construct ``Marginal`` instances.
+``Marginal`` instances are used to represent the one-dimensional marginals
+of a (possibly, multivariate) probabilistic input model.
 
-|                                         Name                                          | Keyword value for `distribution` |                     Notation                      |             Support              | Number of parameters |
-|:-------------------------------------------------------------------------------------:|:--------------------------------:|:-------------------------------------------------:|:--------------------------------:|:--------------------:|
-|                {ref}`Beta <prob-input:univariate-distributions:beta>`                 |             `"beta"`             |       $\mathrm{Beta}(\alpha, \beta, a, b)$        | $[a, b], \; a, b \in \mathbb{R}$ |          4           |
-|         {ref}`Exponential <prob-input:univariate-distributions:exponential>`          |         `"exponential"`          |              $\mathcal{E}(\lambda)$               |          $[0, \infty)$           |          1           |
-|           {ref}`Gumbel (max.) <prob-input:univariate-distributions:gumbel>`           |            `"gumbel"`            |           $\mathrm{Gumbel}(\mu, \beta)$           |       $(-\infty, \infty)$        |          2           |
-|         {ref}`Logit-Normal <prob-input:univariate-distributions:logitnormal>`         |         `"logitnormal"`          |    $\mathcal{N}_{\mathrm{logit}}(\mu, \sigma)$    |             $(0, 1)$             |          2           |
-|           {ref}`Log-Normal <prob-input:univariate-distributions:lognormal>`           |          `"lognormal"`           |    $\mathcal{N}_{\mathrm{log}} (\mu, \sigma)$     |          $(0, \infty)$           |          2           |
-|         {ref}`Normal (Gaussian) <prob-input:univariate-distributions:normal>`         |            `"normal"`            |            $\mathcal{N}(\mu, \sigma)$             |       $(-\infty, \infty)$        |          2           |
-|          {ref}`Triangular <prob-input:univariate-distributions:triangular>`           |          `"triangular"`          |             $\mathcal{T}_r(a, b, c)$              | $[a, b], \; a, b \in \mathbb{R}$ |          3           |
-|   {ref}`Truncated Gumbel (max.) <prob-input:univariate-distributions:trunc-gumbel>`   |         `"trunc-gumbel"`         | $\mathrm{Gumbel}_{\mathrm{Tr}}(\mu, \beta, a, b)$ | $[a, b], \; a, b \in \mathbb{R}$ |          4           |
-| {ref}`Truncated Normal (Gaussian) <prob-input:univariate-distributions:trunc-normal>` |         `"trunc-normal"`         |  $\mathcal{N}_{\mathrm{Tr}}(\mu, \sigma, a, b)$   | $[a, b], \; a, b \in \mathbb{R}$ |          4           |
-|             {ref}`Uniform <prob-input:univariate-distributions:uniform>`              |           `"uniform"`            |                $\mathcal{U}(a, b)$                | $[a, b], \; a, b \in \mathbb{R}$ |          2           |
+|                                        Name                                         | Keyword value for `distribution` |                     Notation                      |             Support              | Number of parameters |
+|:-----------------------------------------------------------------------------------:|:--------------------------------:|:-------------------------------------------------:|:--------------------------------:|:--------------------:|
+|                {ref}`Beta <prob-input:marginal-distributions:beta>`                 |             `"beta"`             |       $\mathrm{Beta}(\alpha, \beta, a, b)$        | $[a, b], \; a, b \in \mathbb{R}$ |          4           |
+|         {ref}`Exponential <prob-input:marginal-distributions:exponential>`          |         `"exponential"`          |              $\mathcal{E}(\lambda)$               |          $[0, \infty)$           |          1           |
+|           {ref}`Gumbel (max.) <prob-input:marginal-distributions:gumbel>`           |            `"gumbel"`            |           $\mathrm{Gumbel}(\mu, \beta)$           |       $(-\infty, \infty)$        |          2           |
+|         {ref}`Logit-Normal <prob-input:marginal-distributions:logitnormal>`         |         `"logitnormal"`          |    $\mathcal{N}_{\mathrm{logit}}(\mu, \sigma)$    |             $(0, 1)$             |          2           |
+|           {ref}`Log-Normal <prob-input:marginal-distributions:lognormal>`           |          `"lognormal"`           |    $\mathcal{N}_{\mathrm{log}} (\mu, \sigma)$     |          $(0, \infty)$           |          2           |
+|         {ref}`Normal (Gaussian) <prob-input:marginal-distributions:normal>`         |            `"normal"`            |            $\mathcal{N}(\mu, \sigma)$             |       $(-\infty, \infty)$        |          2           |
+|          {ref}`Triangular <prob-input:marginal-distributions:triangular>`           |          `"triangular"`          |             $\mathcal{T}_r(a, b, c)$              | $[a, b], \; a, b \in \mathbb{R}$ |          3           |
+|   {ref}`Truncated Gumbel (max.) <prob-input:marginal-distributions:trunc-gumbel>`   |         `"trunc-gumbel"`         | $\mathrm{Gumbel}_{\mathrm{Tr}}(\mu, \beta, a, b)$ | $[a, b], \; a, b \in \mathbb{R}$ |          4           |
+| {ref}`Truncated Normal (Gaussian) <prob-input:marginal-distributions:trunc-normal>` |         `"trunc-normal"`         |  $\mathcal{N}_{\mathrm{Tr}}(\mu, \sigma, a, b)$   | $[a, b], \; a, b \in \mathbb{R}$ |          4           |
+|             {ref}`Uniform <prob-input:marginal-distributions:uniform>`              |           `"uniform"`            |                $\mathcal{U}(a, b)$                | $[a, b], \; a, b \in \mathbb{R}$ |          2           |

--- a/docs/prob-input/marginal-distributions/beta.md
+++ b/docs/prob-input/marginal-distributions/beta.md
@@ -12,7 +12,7 @@ kernelspec:
   name: python3
 ---
 
-(prob-input:univariate-distributions:beta)=
+(prob-input:marginal-distributions:beta)=
 # Beta Distribution
 
 The Beta distribution is a four-parameter continuous probability distribution.
@@ -83,7 +83,7 @@ colors = ["#a6cee3", "#1f78b4", "#b2df8a", "#33a02c"]
 
 univ_dists = []
 for parameter in parameters:
-    univ_dists.append(uqtf.UnivDist(distribution="beta", parameters=parameter))
+    univ_dists.append(uqtf.Marginal(distribution="beta", parameters=parameter))
 
 fig, axs = plt.subplots(2, 2, figsize=(10,10))
 

--- a/docs/prob-input/marginal-distributions/exponential.md
+++ b/docs/prob-input/marginal-distributions/exponential.md
@@ -20,22 +20,22 @@ import matplotlib.pyplot as plt
 import numpy as np
 ```
 
-(prob-input:univariate-distributions:uniform)=
-# Uniform Distribution
+(prob-input:marginal-distributions:exponential)=
+# Exponential Distribution
 
-The uniform distribution is a two-parameter continuous probability distribution.
+The exponential distribution is a single-parameter continuous probability
+distribution.
+
 The table below summarizes some important aspects of the distribution.
 
-|                      |                                                                                                          |
-|---------------------:|----------------------------------------------------------------------------------------------------------|
-|         **Notation** | $X \sim \mathcal{U}(a, b)$                                                                               |
-|       **Parameters** | $a \in (-\infty, b)$ (lower bound)                                                                       |
-|                      | $b \in (a, \infty)$ (upper bound)                                                                        |
-|  **{term}`Support`** | $\mathcal{D}_X = [a, b] \subset \mathbb{R}$                                                              |
-|      **{term}`PDF`** | $f_X (x; a, b) = \begin{cases} \frac{1}{b - a} & x \in [a, b] \\ 0 & x \notin [a, b] \end{cases}$        |
-|      **{term}`CDF`** | $F_X (x; a, b) = \begin{cases} 0 & x < a \\ \frac{x - a}{b - a} & x \in [a, b] \\ 1 & x > b \end{cases}$ |
-|     **{term}`ICDF`** | $F^{-1}_X (x; a, b) = a + (b - a) \, x$                                                                  |
-
+|                      |                                                             |
+|---------------------:|-------------------------------------------------------------|
+|         **Notation** | $X \sim \mathcal{E}(\lambda)$                               |
+|       **Parameters** | $\lambda \in \mathbb{R}_{>0}$ (rate parameter)              |
+|  **{term}`Support`** | $\mathcal{D}_X = [0.0, \infty)$                             |
+|      **{term}`PDF`** | $f_X (x; \lambda) = \lambda e^{-\lambda x}$                 |
+|      **{term}`CDF`** | $F_X (x; \lambda) = 1 - e^{-\lambda x}$                     |
+|     **{term}`ICDF`** | $F^{-1}_X (x; \lambda) = - \frac{1}{\lambda} \ln{(1 - x)}$  |
 
 The plots of probability density functions (PDFs),
 sample histogram (of $5'000$ points),
@@ -50,23 +50,23 @@ import numpy as np
 import matplotlib.pyplot as plt
 import uqtestfuns as uqtf
 
-parameters = [[0, 1], [-1, 1.0], [-5, -2], [1, 5]]
+parameters = [[2.0], [1.5], [1.0], [0.5]]
 colors = ["#a6cee3", "#1f78b4", "#b2df8a", "#33a02c"]
 
 univ_dists = []
 for parameter in parameters:
-    univ_dists.append(uqtf.UnivDist(distribution="uniform", parameters=parameter))
+    univ_dists.append(uqtf.Marginal(distribution="exponential", parameters=parameter))
 
 fig, axs = plt.subplots(2, 2, figsize=(10,10))
 
 # --- PDF
-xx = np.linspace(-6, 6, 1000)
+xx = np.linspace(0, 5, 1000)
 for i, univ_dist in enumerate(univ_dists):
     axs[0, 0].plot(
         xx,
         univ_dist.pdf(xx),
         color=colors[i],
-        label=f"$a = {univ_dist.parameters[0]}, b={univ_dist.parameters[1]}$",
+        label=f"$\\lambda = {univ_dist.parameters[0]}$",
         linewidth=2,
     )
 axs[0, 0].legend();
@@ -84,11 +84,11 @@ for col, univ_dist in zip(reversed(colors), reversed(univ_dists)):
         alpha=0.75
     )
 axs[0, 1].grid();
-axs[0, 1].set_xlim([-6, 6]);
+axs[0, 1].set_xlim([0, 5]);
 axs[0, 1].set_title("Sample histogram");
 
 # --- CDF
-xx = np.linspace(-6, 6, 1000)
+xx = np.linspace(0, 5, 1000)
 for i, univ_dist in enumerate(univ_dists):
     axs[1, 0].plot(
         xx,
@@ -109,7 +109,7 @@ for i, univ_dist in enumerate(univ_dists):
         linewidth=2
     )
 axs[1, 1].grid();
-axs[1, 1].set_ylim([-6, 6]);
+axs[1, 1].set_ylim([0, 6]);
 axs[1, 1].set_title("Inverse CDF");
 
 plt.gcf().set_dpi(150)

--- a/docs/prob-input/marginal-distributions/gumbel.md
+++ b/docs/prob-input/marginal-distributions/gumbel.md
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 ```
 
-(prob-input:univariate-distributions:gumbel)=
+(prob-input:marginal-distributions:gumbel)=
 # Gumbel (max.) Distribution
 
 The Gumbel (max.) distribution is a two-parameter continuous probability distribution.
@@ -54,7 +54,7 @@ colors = ["#a6cee3", "#1f78b4", "#b2df8a", "#33a02c"]
 
 univ_dists = []
 for parameter in parameters:
-    univ_dists.append(uqtf.UnivDist(distribution="gumbel", parameters=parameter))
+    univ_dists.append(uqtf.Marginal(distribution="gumbel", parameters=parameter))
     
 fig, axs = plt.subplots(2, 2, figsize=(10,10))
 

--- a/docs/prob-input/marginal-distributions/logitnormal.md
+++ b/docs/prob-input/marginal-distributions/logitnormal.md
@@ -20,12 +20,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 ```
 
-(prob-input:univariate-distributions:logitnormal)=
+(prob-input:marginal-distributions:logitnormal)=
 # Logit-Normal Distribution
 
 The logit-normal distribution is a two-parameter continuous probability distribution.
 A logit-normal random variable is a variable whose _logit_ is
-a {ref}`normally distributed <prob-input:univariate-distributions:normal>` 
+a {ref}`normally distributed <prob-input:marginal-distributions:normal>` 
 random variable.
 
 ```{admonition} Logit and logistic function
@@ -85,7 +85,7 @@ colors = ["#a6cee3", "#1f78b4", "#b2df8a", "#33a02c"]
 univ_dists = []
 for parameter in parameters:
     univ_dists.append(
-    uqtf.UnivDist(distribution="logitnormal", parameters=parameter)
+    uqtf.Marginal(distribution="logitnormal", parameters=parameter)
     )
 
 fig, axs = plt.subplots(2, 2, figsize=(10,10))

--- a/docs/prob-input/marginal-distributions/lognormal.md
+++ b/docs/prob-input/marginal-distributions/lognormal.md
@@ -12,12 +12,12 @@ kernelspec:
   name: python3
 ---
 
-(prob-input:univariate-distributions:lognormal)=
+(prob-input:marginal-distributions:lognormal)=
 # Log-Normal Distribution
 
 The log-normal distribution is a two-parameter continuous probability distribution.
 A log-normal random variable is a variable whose (natural) logarithm is 
-a {ref}`normally distributed <prob-input:univariate-distributions:normal>`
+a {ref}`normally distributed <prob-input:marginal-distributions:normal>`
 random variable.
 The table below summarizes some important aspects of the distribution.
 
@@ -60,7 +60,7 @@ colors = ["#a6cee3", "#1f78b4", "#b2df8a", "#33a02c"]
 univ_dists = []
 for parameter in parameters:
     univ_dists.append(
-        uqtf.UnivDist(distribution="lognormal", parameters=parameter)
+        uqtf.Marginal(distribution="lognormal", parameters=parameter)
     )
 
 fig, axs = plt.subplots(2, 2, figsize=(10,10))

--- a/docs/prob-input/marginal-distributions/normal.md
+++ b/docs/prob-input/marginal-distributions/normal.md
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 ```
 
-(prob-input:univariate-distributions:normal)=
+(prob-input:marginal-distributions:normal)=
 # Normal (Gaussian) Distribution
 
 The normal (or Gaussian) distribution is a two-parameter continuous probability
@@ -66,7 +66,7 @@ colors = ["#a6cee3", "#1f78b4", "#b2df8a", "#33a02c"]
 
 univ_dists = []
 for parameter in parameters:
-    univ_dists.append(uqtf.UnivDist(distribution="normal", parameters=parameter))
+    univ_dists.append(uqtf.Marginal(distribution="normal", parameters=parameter))
 
 fig, axs = plt.subplots(2, 2, figsize=(10,10))
 

--- a/docs/prob-input/marginal-distributions/triangular.md
+++ b/docs/prob-input/marginal-distributions/triangular.md
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 ```
 
-(prob-input:univariate-distributions:triangular)=
+(prob-input:marginal-distributions:triangular)=
 # Triangular Distribution
 
 The triangular distribution is a three-parameter continuous probability
@@ -57,7 +57,7 @@ colors = ["#a6cee3", "#1f78b4", "#b2df8a", "#33a02c"]
 
 univ_dists = []
 for parameter in parameters:
-    univ_dists.append(uqtf.UnivDist(distribution="triangular", parameters=parameter))
+    univ_dists.append(uqtf.Marginal(distribution="triangular", parameters=parameter))
 
 fig, axs = plt.subplots(2, 2, figsize=(10,10))
 

--- a/docs/prob-input/marginal-distributions/trunc-gumbel.md
+++ b/docs/prob-input/marginal-distributions/trunc-gumbel.md
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 ```
 
-(prob-input:univariate-distributions:trunc-gumbel)=
+(prob-input:marginal-distributions:trunc-gumbel)=
 # Truncated Gumbel (max.) Distribution
 
 The truncated Gumbel (max.) distribution is a four-parameter continuous
@@ -42,7 +42,7 @@ The table below summarizes some important aspects of the distribution.
 In the table above, $f_{\mathrm{Gumbel}}$, $F_{\mathrm{Gumbel}}$,
 and $F^{-1}_{\mathrm{Gumbel}}$ are the probability density,
 the cumulative, and the inverse cumulative distribution functions
-of {ref}`the (untruncated) Gumbel (max.) distribution <prob-input:univariate-distributions:gumbel>`,
+of {ref}`the (untruncated) Gumbel (max.) distribution <prob-input:marginal-distributions:gumbel>`,
 respectively.
 
 The plots of probability density functions (PDFs),
@@ -63,7 +63,7 @@ colors = ["#a6cee3", "#1f78b4", "#b2df8a", "#33a02c"]
 
 univ_dists = []
 for parameter in parameters:
-    univ_dists.append(uqtf.UnivDist(distribution="trunc-gumbel", parameters=parameter))
+    univ_dists.append(uqtf.Marginal(distribution="trunc-gumbel", parameters=parameter))
 
 fig, axs = plt.subplots(2, 2, figsize=(10,10))
 

--- a/docs/prob-input/marginal-distributions/trunc-normal.md
+++ b/docs/prob-input/marginal-distributions/trunc-normal.md
@@ -20,7 +20,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 ```
 
-(prob-input:univariate-distributions:trunc-normal)=
+(prob-input:marginal-distributions:trunc-normal)=
 # Truncated Normal (Gaussian) Distribution
 
 The normal (or Gaussian) distribution is a two-parameter continuous probability
@@ -62,7 +62,7 @@ colors = ["#a6cee3", "#1f78b4", "#b2df8a", "#33a02c"]
 
 univ_dists = []
 for parameter in parameters:
-    univ_dists.append(uqtf.UnivDist(distribution="trunc-normal", parameters=parameter))
+    univ_dists.append(uqtf.Marginal(distribution="trunc-normal", parameters=parameter))
 
 fig, axs = plt.subplots(2, 2, figsize=(10,10))
 

--- a/docs/prob-input/marginal-distributions/uniform.md
+++ b/docs/prob-input/marginal-distributions/uniform.md
@@ -20,22 +20,22 @@ import matplotlib.pyplot as plt
 import numpy as np
 ```
 
-(prob-input:univariate-distributions:exponential)=
-# Exponential Distribution
+(prob-input:marginal-distributions:uniform)=
+# Uniform Distribution
 
-The exponential distribution is a single-parameter continuous probability
-distribution.
-
+The uniform distribution is a two-parameter continuous probability distribution.
 The table below summarizes some important aspects of the distribution.
 
-|                      |                                                             |
-|---------------------:|-------------------------------------------------------------|
-|         **Notation** | $X \sim \mathcal{E}(\lambda)$                               |
-|       **Parameters** | $\lambda \in \mathbb{R}_{>0}$ (rate parameter)              |
-|  **{term}`Support`** | $\mathcal{D}_X = [0.0, \infty)$                             |
-|      **{term}`PDF`** | $f_X (x; \lambda) = \lambda e^{-\lambda x}$                 |
-|      **{term}`CDF`** | $F_X (x; \lambda) = 1 - e^{-\lambda x}$                     |
-|     **{term}`ICDF`** | $F^{-1}_X (x; \lambda) = - \frac{1}{\lambda} \ln{(1 - x)}$  |
+|                      |                                                                                                          |
+|---------------------:|----------------------------------------------------------------------------------------------------------|
+|         **Notation** | $X \sim \mathcal{U}(a, b)$                                                                               |
+|       **Parameters** | $a \in (-\infty, b)$ (lower bound)                                                                       |
+|                      | $b \in (a, \infty)$ (upper bound)                                                                        |
+|  **{term}`Support`** | $\mathcal{D}_X = [a, b] \subset \mathbb{R}$                                                              |
+|      **{term}`PDF`** | $f_X (x; a, b) = \begin{cases} \frac{1}{b - a} & x \in [a, b] \\ 0 & x \notin [a, b] \end{cases}$        |
+|      **{term}`CDF`** | $F_X (x; a, b) = \begin{cases} 0 & x < a \\ \frac{x - a}{b - a} & x \in [a, b] \\ 1 & x > b \end{cases}$ |
+|     **{term}`ICDF`** | $F^{-1}_X (x; a, b) = a + (b - a) \, x$                                                                  |
+
 
 The plots of probability density functions (PDFs),
 sample histogram (of $5'000$ points),
@@ -50,23 +50,23 @@ import numpy as np
 import matplotlib.pyplot as plt
 import uqtestfuns as uqtf
 
-parameters = [[2.0], [1.5], [1.0], [0.5]]
+parameters = [[0, 1], [-1, 1.0], [-5, -2], [1, 5]]
 colors = ["#a6cee3", "#1f78b4", "#b2df8a", "#33a02c"]
 
 univ_dists = []
 for parameter in parameters:
-    univ_dists.append(uqtf.UnivDist(distribution="exponential", parameters=parameter))
+    univ_dists.append(uqtf.Marginal(distribution="uniform", parameters=parameter))
 
 fig, axs = plt.subplots(2, 2, figsize=(10,10))
 
 # --- PDF
-xx = np.linspace(0, 5, 1000)
+xx = np.linspace(-6, 6, 1000)
 for i, univ_dist in enumerate(univ_dists):
     axs[0, 0].plot(
         xx,
         univ_dist.pdf(xx),
         color=colors[i],
-        label=f"$\\lambda = {univ_dist.parameters[0]}$",
+        label=f"$a = {univ_dist.parameters[0]}, b={univ_dist.parameters[1]}$",
         linewidth=2,
     )
 axs[0, 0].legend();
@@ -84,11 +84,11 @@ for col, univ_dist in zip(reversed(colors), reversed(univ_dists)):
         alpha=0.75
     )
 axs[0, 1].grid();
-axs[0, 1].set_xlim([0, 5]);
+axs[0, 1].set_xlim([-6, 6]);
 axs[0, 1].set_title("Sample histogram");
 
 # --- CDF
-xx = np.linspace(0, 5, 1000)
+xx = np.linspace(-6, 6, 1000)
 for i, univ_dist in enumerate(univ_dists):
     axs[1, 0].plot(
         xx,
@@ -109,7 +109,7 @@ for i, univ_dist in enumerate(univ_dists):
         linewidth=2
     )
 axs[1, 1].grid();
-axs[1, 1].set_ylim([0, 6]);
+axs[1, 1].set_ylim([-6, 6]);
 axs[1, 1].set_title("Inverse CDF");
 
 plt.gcf().set_dpi(150)

--- a/docs/prob-input/overview.md
+++ b/docs/prob-input/overview.md
@@ -28,7 +28,7 @@ to handle the representation of a wide range of distributions
 for practical applications.
 Density functions and dependency structures are only made available
 when a specific UQ test function requires them.
-The list of supported univariate distributions can be found {ref}`here <prob-input:available-univariate-distributions>`.
+The list of supported univariate distributions can be found {ref}`here <prob-input:available-marginal-distributions>`.
 
 This section of the documentation explains in more detail how to specify
 a probabilistic input in UQTestFuns.
@@ -37,7 +37,7 @@ each of which is represented as a univariate random variable with a prescribed
 distribution:
 
 - To learn more about how to create a univariate random variable,
-  check out the {ref}`Creating a Univariate Random Variable <prob-input:univariate-random-variable>`
+  check out the {ref}`Creating a One-Dimensional Marginal Distribution <prob-input:marginal-distribution>`
   page.
 - To learn more about how to model one or more input variables probabilistically,
   check out the {ref}`Creating a Probabilistic Input Model <prob-input:probabilistic-input-model>`

--- a/docs/prob-input/probabilistic-input.md
+++ b/docs/prob-input/probabilistic-input.md
@@ -54,34 +54,35 @@ The first step of creating the probabilistic input model is to define
 all one-dimensional marginals according to the specification above.
 One-dimensional marginals are the distributions
 of the component univariate random variables.
-In UQTestFuns, a univariate random variable is represented by ``UnivDist`` class
-(please refer to {ref}`prob-input:univariate-random-variable` for more detail).
+In UQTestFuns, the distribution of a univariate random variable is
+represented by ``Marginal`` class
+(please refer to {ref}`prob-input:marginal-distribution` for more detail).
 Because three marginals belong to a single probabilistic input model,
 we need to collect all the marginals inside a list (or a tuple) as follows:
 
 ```{code-cell} ipython3
 my_marginals = [
-  uqtf.UnivDist(
+  uqtf.Marginal(
       distribution="gumbel", parameters=[3, 4], name="X1", description="1st input"
   ),
-  uqtf.UnivDist(
+  uqtf.Marginal(
       distribution="normal", parameters=[1, 0.2], name="X2", description="2nd input"
   ),
-  uqtf.UnivDist(
+  uqtf.Marginal(
       distribution="beta", parameters=[5, 2, 0.25, 1.0], name="X3", description="3rd input"
   ),
 ]
 ```
 
 Note that in the snippet above,
-the parameters `name` and `description` of `UnivDist()` are optional.
+the parameters `name` and `description` of `Marginal()` are optional.
 
 ## A ``ProbInput`` instance
 
 A probabilistic input model in UQTestFuns is represented by the ``ProbInput`` class.
 To create an instance of the class, you need to pass the following arguments:
 
-- `marginals`: a list or tuple of one-dimensional marginals each represented by an instance of ``UnivDist``.
+- `marginals`: a list or tuple of one-dimensional marginals each represented by an instance of ``Marginal``.
 - `name`: the name of the probabilistic input model (optional)
 - `description`: a short text describing the input model (optional)
 
@@ -104,7 +105,7 @@ You can print the instance to the terminal to verify it:
 print(my_probinput)
 ```
 
-An instance of ``UnivDist`` exposes the following properties:
+An instance of ``Marginal`` exposes the following properties:
 
 |      Property       |                                             Description                                              |
 |:-------------------:|:----------------------------------------------------------------------------------------------------:|
@@ -204,9 +205,9 @@ consisting of three independent standard uniform distributions.
 
 ```{code-cell} ipython3
 my_marginals_2 = [
-  uqtf.UnivDist(distribution="uniform", parameters=[0, 1], name="X1", description="1st input"),
-  uqtf.UnivDist(distribution="uniform", parameters=[0, 1], name="X2", description="2nd input"),
-  uqtf.UnivDist(distribution="uniform", parameters=[0, 1], name="X3", description="3rd input"),
+  uqtf.Marginal(distribution="uniform", parameters=[0, 1], name="X1", description="1st input"),
+  uqtf.Marginal(distribution="uniform", parameters=[0, 1], name="X2", description="2nd input"),
+  uqtf.Marginal(distribution="uniform", parameters=[0, 1], name="X3", description="3rd input"),
 ]
 my_probinput_2 = uqtf.ProbInput(
   marginals=my_marginals_2,

--- a/docs/prob-input/univariate-random-variable.md
+++ b/docs/prob-input/univariate-random-variable.md
@@ -12,15 +12,15 @@ kernelspec:
   name: python3
 ---
 
-(prob-input:univariate-random-variable)=
-# Creating a Univariate Random Variable
+(prob-input:marginal-distribution)=
+# Creating a One-Dimensional Marginal Distribution
 
 A probabilistic input to a UQ test function consists of input variables
 each of which is a (univariate) random variable.
 Therefore, the starting point of defining a (possibly multivariate)
 probabilistic input is defining the distribution
 for each of the constituent random variables.
-This page explains how such a random variable can be created in UQTestFuns.
+This page explains how such a marginal distribution can be created in UQTestFuns.
 
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt
@@ -28,8 +28,8 @@ import numpy as np
 import uqtestfuns as uqtf
 ```
 
-Suppose we would like to define a univariate random variable $X$
-whose distribution is triangular:
+Suppose we would like to define one-dimensional triangular marginal distribution
+for random variable $X$:
 
 $$
 X \sim \mathcal{T}_r(a, b, c)
@@ -40,12 +40,12 @@ These parameters correspond to the lower bound, the upper bound,
 and the mid-point of the distribution. 
 For this particular example, we set these values to $3.0$, $5.0$, and $4.0$.
 
-## A ``UnivDist`` instance
+## A ``Marginal`` instance
 
-A univariate random variable is represented in UQTestFuns by the ``UnivDist`` class.
+A univariate random variable is represented in UQTestFuns by the ``Marginal`` class.
 To create an instance of the class, you need to pass the following arguments:
 
-- `distribution`: the chosen univariate distribution (one from this {ref}`list <prob-input:available-univariate-distributions>`)
+- `distribution`: the chosen univariate distribution (one from this {ref}`list <prob-input:available-marginal-distributions>`)
 - `parameters`: the parameters of the distribution (note that the number of required parameters differs from distribution to another)
 - `name`: the name of the random variable (optional)
 - `description`: a short text describing the random variable (optional) 
@@ -53,7 +53,7 @@ To create an instance of the class, you need to pass the following arguments:
 To create an instance, type:
 
 ```{code-cell} ipython3
-my_rand_var = uqtf.UnivDist(
+my_rand_var = uqtf.Marginal(
     distribution="triangular",
     parameters=[3.0, 5.0, 4.0],
     name="X",
@@ -66,22 +66,22 @@ The variable `my_rand_var` now stores an instance
 of a univariate random variable distributed as triangular
 with the specified parameters.
 
-An instance of ``UnivDist`` exposes the following properties:
+An instance of ``Marginal`` exposes the following properties:
 
-|    Property    |                                               Description                                                |
-|:--------------:|:--------------------------------------------------------------------------------------------------------:|
-|     `name`     |                         the assigned name of the random variable (may be `None`)                         |
-| `description`  |                     the assigned description of the random variable (may be `None`)                      |
-| `distribution` | the distribution (one of {ref}`available distributions <prob-input:available-univariate-distributions>`) |
-|  `parameters`  |                                    the parameters of the distribution                                    |
-|    `lower`     |                                   the lower bound of the distribution                                    |
-|    `upper`     |                                   the upper bound of the distribution                                    |
+|    Property    |                                              Description                                               |
+|:--------------:|:------------------------------------------------------------------------------------------------------:|
+|     `name`     |                        the assigned name of the random variable (may be `None`)                        |
+| `description`  |                    the assigned description of the random variable (may be `None`)                     |
+| `distribution` | the distribution (one of {ref}`available distributions <prob-input:available-marginal-distributions>`) |
+|  `parameters`  |                                   the parameters of the distribution                                   |
+|    `lower`     |                                  the lower bound of the distribution                                   |
+|    `upper`     |                                  the upper bound of the distribution                                   |
 
 and methods:
 
 |            Method             |                                     Description                                      |
 |:-----------------------------:|:------------------------------------------------------------------------------------:|
-|           `cdf(xx)`           |       compute the cumulative distribution function on a set of values `xx`           |
+|           `cdf(xx)`           |         compute the cumulative distribution function on a set of values `xx`         |
 |           `pdf(xx)`           |           compute the probability density function on a set of values `xx`           |
 |          `icdf(xx)`           |     compute the inverse cumulative distribution function on a set of values `xx`     |
 |   `get_sample(sample_size)`   |               get a sample of size `sample_size` from the distribution               |
@@ -195,7 +195,7 @@ Let's suppose, complementary to the random variable $X$ we define
 another random variable as follows:
 
 ```{code-cell} ipython3
-my_rand_var_2 = uqtf.UnivDist(distribution="normal", parameters=[0, 1], name="Y")
+my_rand_var_2 = uqtf.Marginal(distribution="normal", parameters=[0, 1], name="Y")
 ```
 
 In other words, the variable $Y$ is a standard normal random variable.
@@ -239,7 +239,7 @@ Its support is, strictly speaking, $\mathcal{D}_X = (-\infty, \infty)$.
 This is an example of distributions that are supported on the whole real line;
 it is neither bounded from below nor from above.
 
-The properties of a ``UnivDist`` instance include among other things,
+The properties of a ``Marginal`` instance include among other things,
 `lower` (lower bound) and `upper` (upper bound).
 For the triangular distribution defined above, the lower and upper bounds are indeed:
 

--- a/docs/test-functions/portfolio-3d.md
+++ b/docs/test-functions/portfolio-3d.md
@@ -228,7 +228,7 @@ The relation implies that the main-effect Sobol' sensitivity indices are
 the squared of the hybrid local-global measures.
 
 ```{table} Main-effect Sobol' sensitivity indices of the simple portfolio model
-:name: portfolio-3d-hybrid-measure
+:name: portfolio-3d-sobol-indices
 
 |    Parameter     |   $P_s$   |  $P_t$   |   $P_j$   |
 |:----------------:|:---------:|:--------:|:---------:|

--- a/src/uqtestfuns/__init__.py
+++ b/src/uqtestfuns/__init__.py
@@ -4,7 +4,7 @@ This is the package init for UQTestFuns.
 
 import sys
 
-from .core import UnivDist
+from .core import Marginal
 from .core import ProbInput
 from .core import UQTestFunBareABC, UQTestFunABC
 from .core import UQTestFun
@@ -27,7 +27,7 @@ else:  # pragma: no cover
 __version__ = metadata.version("uqtestfuns")
 
 __all__ = [
-    "UnivDist",
+    "Marginal",
     "ProbInput",
     "FunParams",
     "UQTestFunABC",

--- a/src/uqtestfuns/core/__init__.py
+++ b/src/uqtestfuns/core/__init__.py
@@ -3,13 +3,13 @@ The core subpackage of uqtestfuns.
 """
 
 from .parameters import FunParams
-from .prob_input.univariate_distribution import UnivDist
+from .prob_input.marginal import Marginal
 from .prob_input.probabilistic_input import ProbInput
 from .uqtestfun_abc import UQTestFunBareABC, UQTestFunABC
 from .uqtestfun import UQTestFun
 
 __all__ = [
-    "UnivDist",
+    "Marginal",
     "ProbInput",
     "FunParams",
     "UQTestFunBareABC",

--- a/src/uqtestfuns/core/prob_input/marginal.py
+++ b/src/uqtestfuns/core/prob_input/marginal.py
@@ -1,7 +1,8 @@
 """
-Module with an implementation of the ``UnivDist`` class.
+Module with an implementation of the ``Marginal`` class.
 
-The ``UnivDist`` class represents a univariate random variable.
+The ``Marginal`` class represents a one-dimensional marginal random variable
+(i.e., univariate random variable).
 Each random variable has a (parametric) probability distribution.
 """
 
@@ -25,20 +26,20 @@ from .utils import (
 from .input_spec import UnivDistSpec
 from ...global_settings import ARRAY_FLOAT
 
-__all__ = ["UnivDist"]
+__all__ = ["Marginal"]
 
 # Ordered field names for printing purpose
 FIELD_NAMES = ["name", "distribution", "parameters", "description"]
 
 
 @dataclass(frozen=True)
-class UnivDist:
-    """A class for univariate random variables.
+class Marginal:
+    """A class for one-dimensional marginal random variables.
 
     Parameters
     ----------
     distribution : str
-        The type of the probability distribution
+        The type of the probability distribution.
     parameters : ArrayLike
         The parameters of the chosen probability distribution
     name : str, optional
@@ -94,11 +95,11 @@ class UnivDist:
     def transform_sample(
         self,
         xx: Union[float, np.ndarray],
-        other: UnivDist,
+        other: Marginal,
     ) -> np.ndarray:
         """Transform a sample from a given distribution to another."""
-        if not isinstance(other, UnivDist):
-            raise TypeError("Other instance must be of UnivariateType!")
+        if not isinstance(other, Marginal):
+            raise TypeError("Other instance must be of Marginal type!")
 
         xx_trans = self.cdf(xx)
 

--- a/src/uqtestfuns/core/prob_input/probabilistic_input.py
+++ b/src/uqtestfuns/core/prob_input/probabilistic_input.py
@@ -3,7 +3,7 @@ Module with an implementation of ``ProbInput`` class.
 
 The ``ProbInput`` class represents a probabilistic input model.
 Each probabilistic input has a set of one-dimensional marginals each of which
-is defined by an instance of the ``UnivDist`` class.
+is defined by an instance of the ``Marginal`` class.
 """
 
 from __future__ import annotations
@@ -16,7 +16,7 @@ from numpy.random._generator import Generator
 from tabulate import tabulate
 from typing import Any, List, Optional, Union, Tuple
 
-from .univariate_distribution import UnivDist, FIELD_NAMES
+from .marginal import Marginal, FIELD_NAMES
 from .input_spec import ProbInputSpecFixDim, ProbInputSpecVarDim
 
 __all__ = ["ProbInput"]
@@ -28,7 +28,7 @@ class ProbInput:
 
     Parameters
     ----------
-    marginals : Union[List[UnivDist], Tuple[UnivDist, ...]]
+    marginals : Union[List[Marginal], Tuple[Marginal, ...]]
         A list of one-dimensional marginals (univariate random variables).
     copulas : Any
         Copulas between univariate inputs that define dependence structure
@@ -52,7 +52,7 @@ class ProbInput:
     """
 
     input_dimension: int = field(init=False)
-    marginals: Union[List[UnivDist], Tuple[UnivDist, ...]]
+    marginals: Union[List[Marginal], Tuple[Marginal, ...]]
     copulas: Any = None
     name: Optional[str] = None
     description: Optional[str] = None
@@ -204,9 +204,9 @@ class ProbInput:
         else:
             marginals_spec = prob_input_spec.marginals
 
-        # Create a list of UnivDist instances representing univariate marginals
+        # Create a list of Marginal instances representing univariate marginals
         marginals = [
-            UnivDist.from_spec(marginal) for marginal in marginals_spec
+            Marginal.from_spec(marginal) for marginal in marginals_spec
         ]
 
         return cls(
@@ -219,7 +219,7 @@ class ProbInput:
 
 
 def _get_values_as_list(
-    univ_inputs: Union[List[UnivDist], Tuple[UnivDist, ...]],
+    univ_inputs: Union[List[Marginal], Tuple[Marginal, ...]],
     field_names: List[str],
 ) -> list:
     """Get the values from each field from a list of UnivariateInput

--- a/src/uqtestfuns/core/utils.py
+++ b/src/uqtestfuns/core/utils.py
@@ -2,7 +2,7 @@
 Utility module for all the UQ test functions.
 """
 
-from .prob_input.univariate_distribution import UnivDist
+from .prob_input.marginal import Marginal
 from .prob_input.probabilistic_input import ProbInput
 
 
@@ -31,7 +31,7 @@ def create_canonical_uniform_input(
 
     for i in range(input_dimension):
         marginals.append(
-            UnivDist(
+            Marginal(
                 name=f"X{i+1}",
                 distribution="uniform",
                 parameters=[min_value, max_value],

--- a/src/uqtestfuns/meta/metaspec.py
+++ b/src/uqtestfuns/meta/metaspec.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field, InitVar
 from scipy.special import comb
 from typing import Dict, Callable, Tuple, Optional, Union, List
 
-from ..core import UnivDist
+from ..core import Marginal
 
 __all__ = ["UQMetaFunSpec", "UQTestFunSpec"]
 
@@ -224,7 +224,7 @@ def _select_marginals(
         if name is None:
             name = f"X{num + 1}"
         # Create a new instance (now with a name)
-        selected_marginal = UnivDist(
+        selected_marginal = Marginal(
             name=name,
             distribution=selected_marginal.distribution,
             parameters=selected_marginal.parameters,
@@ -267,7 +267,7 @@ class UQTestFunSpec:
     selected_basis: Tuple[int, ...]
     effects_tuples: Dict[int, Tuple[Tuple[int, ...], ...]]
     effects_coeffs: Dict[int, np.ndarray]
-    inputs: Union[List[UnivDist], Tuple[UnivDist, ...]]
+    inputs: Union[List[Marginal], Tuple[Marginal, ...]]
 
 
 @dataclass
@@ -294,7 +294,7 @@ class UQMetaFunSpec:
     basis_functions: Dict[int, Callable]
     effects: Dict[int, int] = field(init=False)
     effects_dict: InitVar[Dict[int, Optional[int]]]
-    input_marginals: Union[List[UnivDist], Tuple[UnivDist, ...]]
+    input_marginals: Union[List[Marginal], Tuple[Marginal, ...]]
     coeffs_generator: Callable
     _effects_tuples: Optional[Dict[int, Tuple[Tuple[int, ...], ...]]] = field(
         init=False, repr=False

--- a/src/uqtestfuns/meta/uqmetatestfun.py
+++ b/src/uqtestfuns/meta/uqmetatestfun.py
@@ -24,7 +24,7 @@ from typing import Optional, Union, List
 from uqtestfuns.core.parameters import FunParams
 from .metaspec import UQMetaFunSpec, UQTestFunSpec
 from .basis_functions import BASIS_BY_ID
-from ..core import UQTestFun, ProbInput, UnivDist
+from ..core import UQTestFun, ProbInput, Marginal
 
 
 __all__ = ["UQMetaTestFun", "default_coeffs_gen"]
@@ -226,16 +226,16 @@ class UQMetaTestFun:
             input_id = np.random.randint(0, 8)
 
         input_marginals = [
-            UnivDist(distribution="uniform", parameters=[0, 1]),
-            UnivDist(
+            Marginal(distribution="uniform", parameters=[0, 1]),
+            Marginal(
                 distribution="trunc-normal",
                 parameters=[0.5, 0.15, 0.0, 1.0],
             ),
-            UnivDist(distribution="beta", parameters=[8.0, 2.0, 0.0, 1.0]),
-            UnivDist(distribution="beta", parameters=[2.0, 8.0, 0.0, 1.0]),
-            UnivDist(distribution="beta", parameters=[2.0, 0.8, 0.0, 1.0]),
-            UnivDist(distribution="beta", parameters=[0.8, 2.0, 0.0, 1.0]),
-            UnivDist(distribution="logitnormal", parameters=[0.0, 3.16]),
+            Marginal(distribution="beta", parameters=[8.0, 2.0, 0.0, 1.0]),
+            Marginal(distribution="beta", parameters=[2.0, 8.0, 0.0, 1.0]),
+            Marginal(distribution="beta", parameters=[2.0, 0.8, 0.0, 1.0]),
+            Marginal(distribution="beta", parameters=[0.8, 2.0, 0.0, 1.0]),
+            Marginal(distribution="logitnormal", parameters=[0.0, 3.16]),
         ]
 
         if input_id < 7:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import string
 from typing import List, Callable, Any
 
 from uqtestfuns.core.prob_input.utils import SUPPORTED_MARGINALS
-from uqtestfuns.core.prob_input.univariate_distribution import UnivDist
+from uqtestfuns.core.prob_input.marginal import Marginal
 
 MARGINALS = list(SUPPORTED_MARGINALS.keys())
 
@@ -37,7 +37,7 @@ def create_random_alphanumeric(length: int) -> str:
     return out
 
 
-def create_random_marginals(length: int) -> List[UnivDist]:
+def create_random_marginals(length: int) -> List[Marginal]:
     """Create a random list of univariate random variables.
 
     Parameters
@@ -47,7 +47,7 @@ def create_random_marginals(length: int) -> List[UnivDist]:
 
     Returns
     -------
-    List[UnivDist]
+    List[Marginal]
         List of dictionaries to specify a ProbInput instance.
     """
     marginals = []
@@ -77,7 +77,7 @@ def create_random_marginals(length: int) -> List[UnivDist]:
             parameters = np.sort(1 + 2 * np.random.rand(2))
 
         marginals.append(
-            UnivDist(
+            Marginal(
                 name=f"X{i+1}",
                 distribution=distribution,
                 parameters=parameters,

--- a/tests/core/prob_input/test_multivariate_input.py
+++ b/tests/core/prob_input/test_multivariate_input.py
@@ -3,7 +3,7 @@ import numpy as np
 from typing import List
 
 from uqtestfuns.core.prob_input.probabilistic_input import ProbInput
-from uqtestfuns.core.prob_input.univariate_distribution import UnivDist
+from uqtestfuns.core.prob_input.marginal import Marginal
 from uqtestfuns.core.prob_input.input_spec import (
     UnivDistSpec,
     ProbInputSpecFixDim,
@@ -208,7 +208,7 @@ def test_reset_rng(input_dimension):
 @pytest.mark.parametrize("input_dimension", [1, 2, 10, 100])
 def test_create_from_spec(input_dimension):
     """Test creating an instance from specification NamedTuple"""
-    marginals: List[UnivDist] = create_random_marginals(input_dimension)
+    marginals: List[Marginal] = create_random_marginals(input_dimension)
 
     # Create a ProbInputSpecFixDim
     name = "Test Name"

--- a/tests/core/prob_input/test_univariate_beta.py
+++ b/tests/core/prob_input/test_univariate_beta.py
@@ -5,7 +5,7 @@ Test module for UnivariateInput instances with a Beta distribution.
 import pytest
 import numpy as np
 
-from uqtestfuns.core.prob_input.univariate_distribution import UnivDist
+from uqtestfuns.core.prob_input.marginal import Marginal
 from uqtestfuns.global_settings import ARRAY_FLOAT
 from conftest import create_random_alphanumeric
 
@@ -43,7 +43,7 @@ def test_wrong_number_of_parameters() -> None:
     parameters = np.sort(np.random.rand(6))
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_failed_parameter_verification() -> None:
@@ -55,19 +55,19 @@ def test_failed_parameter_verification() -> None:
     parameters = [-7.71, 10, 1, 2]
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
     # The 2nd parameter of the Beta distribution must be strictly positive!
     parameters = [7.71, -10, 1, 2]
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
     # The lower bound must be smaller than upper bound!
     parameters = [1, 2, 4, 3]
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_estimate_mean() -> None:
@@ -78,7 +78,7 @@ def test_estimate_mean() -> None:
     distribution = "beta"
     parameters = np.sort(2 * np.random.rand(4))
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         name=name, distribution=distribution, parameters=parameters
     )
 
@@ -103,7 +103,7 @@ def test_estimate_std() -> None:
     distribution = "beta"
     parameters = np.sort(2 * np.random.rand(4))
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         name=name, distribution=distribution, parameters=parameters
     )
 

--- a/tests/core/prob_input/test_univariate_exponential.py
+++ b/tests/core/prob_input/test_univariate_exponential.py
@@ -1,11 +1,11 @@
 """
-Test module specifically for UnivDist instances with the exponential dist.
+Test module specifically for Marginal instances with the exponential dist.
 """
 
 import pytest
 import numpy as np
 
-from uqtestfuns.core.prob_input.univariate_distribution import UnivDist
+from uqtestfuns.core.prob_input.marginal import Marginal
 from conftest import create_random_alphanumeric
 
 DISTRIBUTION = "exponential"
@@ -19,7 +19,7 @@ def test_wrong_number_of_parameters() -> None:
     parameters = np.random.rand(num_params)
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=DISTRIBUTION, parameters=parameters)
+        Marginal(name=name, distribution=DISTRIBUTION, parameters=parameters)
 
 
 def test_failed_parameter_verification() -> None:
@@ -28,16 +28,16 @@ def test_failed_parameter_verification() -> None:
     parameters = [-5]
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=DISTRIBUTION, parameters=parameters)
+        Marginal(name=name, distribution=DISTRIBUTION, parameters=parameters)
 
 
 def test_get_pdf_values() -> None:
-    """Test the PDF values from an instance of UnivDist."""
+    """Test the PDF values from an instance of Marginal."""
 
     name = create_random_alphanumeric(5)
     parameters = np.sort(np.random.rand(1))
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         name=name, distribution=DISTRIBUTION, parameters=parameters
     )
 
@@ -56,11 +56,11 @@ def test_get_pdf_values() -> None:
 
 
 def test_mean() -> None:
-    """Test the mean values from an instance of UnivDist."""
+    """Test the mean values from an instance of Marginal."""
     name = create_random_alphanumeric(5)
     parameters = np.sort(np.random.rand(1))
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         name=name, distribution=DISTRIBUTION, parameters=parameters
     )
 
@@ -74,11 +74,11 @@ def test_mean() -> None:
 
 
 def test_variance() -> None:
-    """Test the variance values from an instance of UnivDist."""
+    """Test the variance values from an instance of Marginal."""
     name = create_random_alphanumeric(5)
     parameters = np.sort(np.random.rand(1))
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         name=name, distribution=DISTRIBUTION, parameters=parameters
     )
 
@@ -92,11 +92,11 @@ def test_variance() -> None:
 
 
 def test_median() -> None:
-    """Test the median values from an instance of UnivDist."""
+    """Test the median values from an instance of Marginal."""
     name = create_random_alphanumeric(5)
     parameters = np.sort(np.random.rand(1))
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         name=name, distribution=DISTRIBUTION, parameters=parameters
     )
 

--- a/tests/core/prob_input/test_univariate_gumbel.py
+++ b/tests/core/prob_input/test_univariate_gumbel.py
@@ -6,7 +6,7 @@ distribution.
 import pytest
 import numpy as np
 
-from uqtestfuns.core.prob_input.univariate_distribution import UnivDist
+from uqtestfuns.core.prob_input.marginal import Marginal
 from uqtestfuns.global_settings import ARRAY_FLOAT
 from conftest import create_random_alphanumeric
 
@@ -55,7 +55,7 @@ def test_wrong_number_of_parameters() -> None:
     parameters = np.sort(np.random.rand(5))
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_failed_parameter_verification() -> None:
@@ -66,7 +66,7 @@ def test_failed_parameter_verification() -> None:
     parameters = [7.71, -5.0]
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_estimate_mean() -> None:
@@ -75,7 +75,7 @@ def test_estimate_mean() -> None:
     parameters = np.sort(1 + 5 * np.random.rand(2))
 
     # Create an instance
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         distribution=DISTRIBUTION_NAME, parameters=parameters
     )
 
@@ -99,7 +99,7 @@ def test_estimate_variance() -> None:
     parameters = np.sort(1 + 5 * np.random.rand(2))
 
     # Create an instance
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         distribution=DISTRIBUTION_NAME, parameters=parameters
     )
 
@@ -123,7 +123,7 @@ def test_estimate_median() -> None:
     parameters = np.sort(1 + 5 * np.random.rand(2))
 
     # Create an instance
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         distribution=DISTRIBUTION_NAME, parameters=parameters
     )
 
@@ -147,7 +147,7 @@ def test_estimate_mode() -> None:
     parameters = np.sort(1 + 5 * np.random.rand(2))
 
     # Create an instance
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         distribution=DISTRIBUTION_NAME, parameters=parameters
     )
 

--- a/tests/core/prob_input/test_univariate_input.py
+++ b/tests/core/prob_input/test_univariate_input.py
@@ -8,7 +8,7 @@ import numpy as np
 from typing import Tuple, Dict, Union, Any
 from numpy.typing import ArrayLike
 
-from uqtestfuns.core.prob_input.univariate_distribution import UnivDist
+from uqtestfuns.core.prob_input.marginal import Marginal
 from uqtestfuns.core.prob_input.utils import SUPPORTED_MARGINALS
 from conftest import create_random_alphanumeric
 
@@ -19,7 +19,7 @@ MARGINALS = list(SUPPORTED_MARGINALS.keys())
 @pytest.fixture(params=MARGINALS)
 def univariate_input(
     request: Any,
-) -> Tuple[UnivDist, Dict[str, Union[str, ArrayLike]]]:
+) -> Tuple[Marginal, Dict[str, Union[str, ArrayLike]]]:
     """Test fixture, an instance of UnivariateInput."""
     name = create_random_alphanumeric(8)
     distribution = request.param
@@ -55,7 +55,7 @@ def univariate_input(
         "parameters": parameters,
     }
 
-    my_univariate_input = UnivDist(**specs)
+    my_univariate_input = Marginal(**specs)
 
     return my_univariate_input, specs
 
@@ -77,7 +77,7 @@ def test_create_instance_unsupported_marginal() -> None:
     parameters = list(np.sort(np.random.rand(2)))
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_generate_sample(univariate_input: Any) -> None:
@@ -158,7 +158,7 @@ def test_transform_sample() -> None:
     distribution_1 = "uniform"
     parameters_1 = np.sort(np.random.rand(2))
 
-    my_univariate_input_1 = UnivDist(
+    my_univariate_input_1 = Marginal(
         name=name_1, distribution=distribution_1, parameters=parameters_1
     )
 
@@ -169,7 +169,7 @@ def test_transform_sample() -> None:
     distribution_2 = "uniform"
     parameters_2 = np.sort(np.random.rand(2))
 
-    my_univariate_input_2 = UnivDist(
+    my_univariate_input_2 = Marginal(
         name=name_2, distribution=distribution_2, parameters=parameters_2
     )
 
@@ -188,7 +188,7 @@ def test_failed_transform_sample() -> None:
     distribution = "uniform"
     parameters = np.sort(np.random.rand(2))
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         name=name, distribution=distribution, parameters=parameters
     )
 
@@ -227,8 +227,8 @@ def test_pass_random_seed():
 
     # Create two instances with an identical seed number
     rng_seed = 42
-    my_input_1 = UnivDist("uniform", [0, 1], rng_seed=rng_seed)
-    my_input_2 = UnivDist("uniform", [0, 1], rng_seed=rng_seed)
+    my_input_1 = Marginal("uniform", [0, 1], rng_seed=rng_seed)
+    my_input_2 = Marginal("uniform", [0, 1], rng_seed=rng_seed)
 
     # Generate sample points
     xx_1 = my_input_1.get_sample(1000)
@@ -243,7 +243,7 @@ def test_reset_rng():
 
     # Create two instances with an identical seed number
     rng_seed = 42
-    my_input = UnivDist("uniform", [0, 1], rng_seed=rng_seed)
+    my_input = Marginal("uniform", [0, 1], rng_seed=rng_seed)
 
     # Generate sample points
     xx_1 = my_input.get_sample(1000)

--- a/tests/core/prob_input/test_univariate_logitnormal.py
+++ b/tests/core/prob_input/test_univariate_logitnormal.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from scipy.special import expit as logistic
 
-from uqtestfuns.core.prob_input.univariate_distribution import UnivDist
+from uqtestfuns.core.prob_input.marginal import Marginal
 from conftest import create_random_alphanumeric
 
 
@@ -19,7 +19,7 @@ def test_wrong_number_of_parameters() -> None:
     parameters = np.sort(np.random.rand(3))
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_failed_parameter_verification() -> None:
@@ -29,7 +29,7 @@ def test_failed_parameter_verification() -> None:
     parameters = [7.71, -10]
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_get_pdf_values() -> None:
@@ -39,7 +39,7 @@ def test_get_pdf_values() -> None:
     distribution = "logitnormal"
     parameters = np.sort(np.random.rand(2))
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         name=name, distribution=distribution, parameters=parameters
     )
 
@@ -63,7 +63,7 @@ def test_median() -> None:
     distribution = "logitnormal"
     parameters = np.sort(np.random.rand(2))
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         name=name, distribution=distribution, parameters=parameters
     )
 

--- a/tests/core/prob_input/test_univariate_lognormal.py
+++ b/tests/core/prob_input/test_univariate_lognormal.py
@@ -5,7 +5,7 @@ Test module specifically for UnivariateInput instances with lognormal dist.
 import pytest
 import numpy as np
 
-from uqtestfuns.core.prob_input.univariate_distribution import UnivDist
+from uqtestfuns.core.prob_input.marginal import Marginal
 from conftest import create_random_alphanumeric
 
 
@@ -17,7 +17,7 @@ def test_wrong_number_of_parameters() -> None:
     parameters = np.sort(np.random.rand(3))
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_failed_parameter_verification() -> None:
@@ -27,7 +27,7 @@ def test_failed_parameter_verification() -> None:
     parameters = [7.71, -10]
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_get_pdf_values() -> None:
@@ -37,7 +37,7 @@ def test_get_pdf_values() -> None:
     distribution = "lognormal"
     parameters = np.sort(np.random.rand(2))
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         name=name, distribution=distribution, parameters=parameters
     )
 

--- a/tests/core/prob_input/test_univariate_normal.py
+++ b/tests/core/prob_input/test_univariate_normal.py
@@ -5,7 +5,7 @@ Test module specifically for UnivariateInput instances with normal dist.
 import pytest
 import numpy as np
 
-from uqtestfuns.core.prob_input.univariate_distribution import UnivDist
+from uqtestfuns.core.prob_input.marginal import Marginal
 from conftest import create_random_alphanumeric
 
 
@@ -17,7 +17,7 @@ def test_wrong_number_of_parameters() -> None:
     parameters = np.sort(np.random.rand(10))
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_failed_parameter_verification() -> None:
@@ -28,7 +28,7 @@ def test_failed_parameter_verification() -> None:
     parameters = [7.71, -1]
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_get_pdf_values() -> None:
@@ -38,7 +38,7 @@ def test_get_pdf_values() -> None:
     distribution = "normal"
     parameters = np.sort(np.random.rand(2))
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         name=name, distribution=distribution, parameters=parameters
     )
 

--- a/tests/core/prob_input/test_univariate_triangular.py
+++ b/tests/core/prob_input/test_univariate_triangular.py
@@ -5,7 +5,7 @@ Test module specifically for UnivariateInput instances with triangular dist.
 import pytest
 import numpy as np
 
-from uqtestfuns.core.prob_input.univariate_distribution import UnivDist
+from uqtestfuns.core.prob_input.marginal import Marginal
 from conftest import create_random_alphanumeric
 
 DISTRIBUTION_NAME = "triangular"
@@ -18,7 +18,7 @@ def test_wrong_number_of_parameters() -> None:
     parameters = np.sort(np.random.rand(10))
 
     with pytest.raises(ValueError):
-        UnivDist(
+        Marginal(
             name=name, distribution=DISTRIBUTION_NAME, parameters=parameters
         )
 
@@ -30,7 +30,7 @@ def test_failed_parameter_verification() -> None:
     parameters = [5, 1, 3]
 
     with pytest.raises(ValueError):
-        UnivDist(
+        Marginal(
             name=name, distribution=DISTRIBUTION_NAME, parameters=parameters
         )
 
@@ -38,7 +38,7 @@ def test_failed_parameter_verification() -> None:
     parameters = [3, 4, 10]
 
     with pytest.raises(ValueError):
-        UnivDist(
+        Marginal(
             name=name, distribution=DISTRIBUTION_NAME, parameters=parameters
         )
 
@@ -50,7 +50,7 @@ def test_estimate_mode() -> None:
     parameters[[2, 1]] = parameters[[1, 2]]
 
     # Create an instance
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         distribution=DISTRIBUTION_NAME, parameters=parameters
     )
 

--- a/tests/core/prob_input/test_univariate_trunc_gumbel.py
+++ b/tests/core/prob_input/test_univariate_trunc_gumbel.py
@@ -8,7 +8,7 @@ import scipy.integrate as integrate
 
 from scipy.stats import gumbel_r
 
-from uqtestfuns.core.prob_input.univariate_distribution import UnivDist
+from uqtestfuns.core.prob_input.marginal import Marginal
 from uqtestfuns.global_settings import ARRAY_FLOAT
 from conftest import create_random_alphanumeric
 
@@ -66,7 +66,7 @@ def test_wrong_number_of_parameters() -> None:
     parameters = np.sort(np.random.rand(5))
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_failed_parameter_verification() -> None:
@@ -77,13 +77,13 @@ def test_failed_parameter_verification() -> None:
     parameters = [7.71, -5.0, 0, 10]
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
     # The lower bound is larger than the upper bound!
     parameters = [2.71, 0.5, 5, 0]
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_estimate_mode() -> None:
@@ -95,7 +95,7 @@ def test_estimate_mode() -> None:
     parameters = np.insert(parameters, 1, np.random.rand(1))
 
     # Create an instance
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         distribution=DISTRIBUTION_NAME, parameters=parameters
     )
 
@@ -123,7 +123,7 @@ def test_estimate_median() -> None:
     parameters = np.insert(parameters, 1, np.random.rand(1))
 
     # Create an instance
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         distribution=DISTRIBUTION_NAME, parameters=parameters
     )
 
@@ -157,12 +157,12 @@ def test_untruncated() -> None:
     distribution = DISTRIBUTION_NAME
     parameters = [10, 2, -np.inf, np.inf]
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         distribution=distribution, parameters=parameters
     )
 
     # Create a reference Gumbel distribution
-    my_univariate_input_ref = UnivDist(
+    my_univariate_input_ref = Marginal(
         distribution="gumbel", parameters=parameters[:2]
     )
 

--- a/tests/core/prob_input/test_univariate_trunc_normal.py
+++ b/tests/core/prob_input/test_univariate_trunc_normal.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from scipy.stats import norm
 
-from uqtestfuns.core.prob_input.univariate_distribution import UnivDist
+from uqtestfuns.core.prob_input.marginal import Marginal
 from uqtestfuns.global_settings import ARRAY_FLOAT
 from conftest import create_random_alphanumeric
 
@@ -56,7 +56,7 @@ def test_wrong_number_of_parameters() -> None:
     parameters = np.sort(np.random.rand(6))
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_failed_parameter_verification() -> None:
@@ -68,13 +68,13 @@ def test_failed_parameter_verification() -> None:
     parameters = [7.71, -10, 1, 2]
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
     # The lower bound must be smaller than upper bound!
     parameters = [3.5, 2, 4, 3]
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_estimate_mean() -> None:
@@ -89,7 +89,7 @@ def test_estimate_mean() -> None:
     # Insert sigma as the second parameter
     parameters = np.insert(parameters, 1, np.random.rand(1))
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         name=name, distribution=distribution, parameters=parameters
     )
 
@@ -118,7 +118,7 @@ def test_estimate_std() -> None:
     # Insert sigma as the second parameter
     parameters = np.insert(parameters, 1, np.random.rand(1))
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         name=name, distribution=distribution, parameters=parameters
     )
 
@@ -152,12 +152,12 @@ def test_untruncated() -> None:
     distribution = DISTRIBUTION_NAME
     parameters = [10, 2, -np.inf, np.inf]
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         name=name, distribution=distribution, parameters=parameters
     )
 
     # Create a reference normal distribution
-    my_univariate_input_ref = UnivDist(
+    my_univariate_input_ref = Marginal(
         distribution="normal", parameters=parameters[:2]
     )
 

--- a/tests/core/prob_input/test_univariate_uniform.py
+++ b/tests/core/prob_input/test_univariate_uniform.py
@@ -5,7 +5,7 @@ Test module specifically for UnivariateInput instances with uniform dist.
 import pytest
 import numpy as np
 
-from uqtestfuns.core.prob_input.univariate_distribution import UnivDist
+from uqtestfuns.core.prob_input.marginal import Marginal
 from conftest import create_random_alphanumeric
 
 
@@ -17,7 +17,7 @@ def test_wrong_parameters() -> None:
     parameters = np.sort(np.random.rand(1))
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_failed_parameter_verification() -> None:
@@ -28,7 +28,7 @@ def test_failed_parameter_verification() -> None:
     parameters = [10, -10]
 
     with pytest.raises(ValueError):
-        UnivDist(name=name, distribution=distribution, parameters=parameters)
+        Marginal(name=name, distribution=distribution, parameters=parameters)
 
 
 def test_get_pdf_values() -> None:
@@ -38,7 +38,7 @@ def test_get_pdf_values() -> None:
     distribution = "uniform"
     parameters = np.sort(np.random.rand(2))
 
-    my_univariate_input = UnivDist(
+    my_univariate_input = Marginal(
         name=name, distribution=distribution, parameters=parameters
     )
 

--- a/tests/metafun/test_uqmetatestfun.py
+++ b/tests/metafun/test_uqmetatestfun.py
@@ -7,7 +7,7 @@ import pytest
 
 from scipy.special import comb
 
-from uqtestfuns import UQMetaTestFun, UQTestFun, UQMetaFunSpec, UnivDist
+from uqtestfuns import UQMetaTestFun, UQTestFun, UQMetaFunSpec, Marginal
 from uqtestfuns.meta.metaspec import UQTestFunSpec
 from uqtestfuns.meta.basis_functions import BASIS_BY_ID
 from conftest import create_random_marginals, assert_call
@@ -199,7 +199,7 @@ def test_evaluate_sample(input_dimension):
     effects_dict = _create_args_effects_dict(input_dimension)
 
     input_marginals = [
-        UnivDist(distribution="uniform", parameters=[0, 1]),
+        Marginal(distribution="uniform", parameters=[0, 1]),
     ]
 
     coeffs_generator = np.random.rand


### PR DESCRIPTION
Renamed the `UnivDist` class to `Marginal` to better reflect its purpose of representing one-dimensional marginal distribution of a univariate random variable.
This change was applied to all affected modules, test files, and documentation to maintain consistency throughout the codebase.

This PR should resolve Issue #368.