### PR TITLE
`output_dimension` is now property of UQTestFunBareABC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `output_dimension` is now property of `UQTestFunBareABC` and inherited to
+  all concrete classes of UQ test functions.
 - Printing a test function instance now shows whether the function is 
   parameterized or not.
 - The information related to the parameterization of a function is now
@@ -23,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `list_functions()` is now printed in grid format and include information
+  regarding the output dimension and the parameterization. Furthermore,
+  filtering can be done based on the input dimension, output dimension,
+  tag, and parameterization.
 - The class `UnivDist` has been renamed to `Marginal`. The name more clearly
   refers to one-dimensional marginal distributions (of a univariate random
   variable), which form a `ProbInput`.

--- a/README.md
+++ b/README.md
@@ -33,17 +33,23 @@ To list the available functions:
 ```python-repl
 >>> import uqtestfuns as uqtf
 >>> uqtf.list_functions()
- No.            Constructor            Dimension                Application                Description
------  -----------------------------  -----------  --------------------------------------  ----------------------------------------------------------------------------
-  1              Ackley()                  M             optimization, metamodeling        Optimization test function from Ackley (1987)
-  2           Alemazkoor2D()               2                    metamodeling               Two-dimensional high-degree polynomial from Alemazkoor & Meidani (2018)
-  3             Borehole()                 8             metamodeling, sensitivity         Borehole function from Harper and Gupta (1983)
-  4           Bratley1992a()               M              integration, sensitivity         Integration test function #1 from Bratley et al. (1992)
-  5           Bratley1992b()               M              integration, sensitivity         Integration test function #2 from Bratley et al. (1992)
-  6           Bratley1992c()               M              integration, sensitivity         Integration test function #3 from Bratley et al. (1992)
-  7           Bratley1992d()               M              integration, sensitivity         Integration test function #4 from Bratley et al. (1992)
-  8         CantileverBeam2D()             2                    reliability                Cantilever beam reliability problem from Rajashekhar and Ellington (1993)
-  9         CircularPipeCrack()            2                    reliability                Circular pipe under bending moment from Verma et al. (2015)
++-------+-------------------------------+-----------+------------+----------+---------------+--------------------------------+
+|  No.  |          Constructor          |  # Input  |  # Output  |  Param.  |  Application  | Description                    |
++=======+===============================+===========+============+==========+===============+================================+
+|   1   |           Ackley()            |     M     |     1      |   True   | optimization, | Optimization test function     |
+|       |                               |           |            |          | metamodeling  | from Ackley (1987)             |
++-------+-------------------------------+-----------+------------+----------+---------------+--------------------------------+
+|   2   |        Alemazkoor20D()        |    20     |     1      |  False   | metamodeling  | High-dimensional low-degree    |
+|       |                               |           |            |          |               | polynomial from Alemazkoor &   |
+|       |                               |           |            |          |               | Meidani (2018)                 |
++-------+-------------------------------+-----------+------------+----------+---------------+--------------------------------+
+|   3   |        Alemazkoor2D()         |     2     |     1      |  False   | metamodeling  | Low-dimensional high-degree    |
+|       |                               |           |            |          |               | polynomial from Alemazkoor &   |
+|       |                               |           |            |          |               | Meidani (2018)                 |
++-------+-------------------------------+-----------+------------+----------+---------------+--------------------------------+
+|   4   |          Borehole()           |     8     |     1      |  False   | metamodeling, | Borehole function from Harper  |
+|       |                               |           |            |          |  sensitivity  | and Gupta (1983)               |
++-------+-------------------------------+-----------+------------+----------+---------------+--------------------------------+
 ...
 ```
 
@@ -53,33 +59,35 @@ and sensitivity analysis purposes; to create an instance of this test function:
 ```python-repl
 >>> my_testfun = uqtf.Borehole()
 >>> print(my_testfun)
-Name              : Borehole
-Spatial dimension : 8
-Description       : Borehole function from Harper and Gupta (1983)
+Function ID      : Borehole
+Input Dimension  : 8
+Output Dimension : 1
+Parameterized    : False
+Description      : Borehole function from Harper and Gupta (1983)
 ```
 
 The probabilistic input specification of this test function is built-in:
 
 ```python-repl
 >>> print(my_testfun.prob_input)
-Name         : Borehole-Harper-1983
-Spatial Dim. : 8
-Description  : Probabilistic input model of the Borehole model from Harper and Gupta (1983).
-Marginals    :
+Name            : Borehole-Harper-1983
+Input Dimension : 8
+Description     : Probabilistic input model of the Borehole model from
+                  Harper and Gupta (1983).
+Marginals       :
 
-  No.   Name    Distribution        Parameters                          Description                  
-                                                                                                     
+ No.    Name    Distribution        Parameters                          Description
 -----  ------  --------------  ---------------------  -----------------------------------------------
-    1    rw        normal      [0.1       0.0161812]            radius of the borehole [m]
-    2    r       lognormal        [7.71   1.0056]                 radius of influence [m]
-    3    Tu       uniform        [ 63070. 115600.]      transmissivity of upper aquifer [m^2/year]
-    4    Hu       uniform          [ 990. 1100.]         potentiometric head of upper aquifer [m]
-    5    Tl       uniform          [ 63.1 116. ]        transmissivity of lower aquifer [m^2/year]
-    6    Hl       uniform           [700. 820.]          potentiometric head of lower aquifer [m]    
-    7    L        uniform          [1120. 1680.]                length of the borehole [m]                                       
-    8    Kw       uniform         [ 9985. 12045.]     hydraulic conductivity of the borehole [m/year]
+  1      rw        normal      [0.1       0.0161812]            radius of the borehole [m]
+  2      r       lognormal        [7.71   1.0056]                 radius of influence [m]
+  3      Tu       uniform        [ 63070. 115600.]      transmissivity of upper aquifer [m^2/year]
+  4      Hu       uniform          [ 990. 1100.]         potentiometric head of upper aquifer [m]
+  5      Tl       uniform          [ 63.1 116. ]        transmissivity of lower aquifer [m^2/year]
+  6      Hl       uniform           [700. 820.]          potentiometric head of lower aquifer [m]
+  7      L        uniform          [1120. 1680.]                length of the borehole [m]
+  8      Kw       uniform         [ 9985. 12045.]     hydraulic conductivity of the borehole [m/year]
 
-    Copulas      : None
+Copulas         : None
 ```
 
 A sample of input values can be generated from the input model:

--- a/docs/fundamentals/integration.md
+++ b/docs/fundamentals/integration.md
@@ -35,5 +35,5 @@ using the ``tag`` parameter:
 
 import uqtestfuns as uqtf
 
-uqtf.list_functions(tag="integration")
+uqtf.list_functions(tag="integration", tablefmt="html")
 ```

--- a/docs/fundamentals/metamodeling.md
+++ b/docs/fundamentals/metamodeling.md
@@ -58,5 +58,5 @@ using the ``tag`` parameter:
 
 import uqtestfuns as uqtf
 
-uqtf.list_functions(tag="metamodeling")
+uqtf.list_functions(tag="metamodeling", tablefmt="html")
 ```

--- a/docs/fundamentals/optimization.md
+++ b/docs/fundamentals/optimization.md
@@ -31,5 +31,5 @@ using the ``tag`` parameter:
 
 import uqtestfuns as uqtf
 
-uqtf.list_functions(tag="optimization")
+uqtf.list_functions(tag="optimization", tablefmt="html")
 ```

--- a/docs/fundamentals/reliability.md
+++ b/docs/fundamentals/reliability.md
@@ -39,7 +39,7 @@ using the ``tag`` parameter:
 
 import uqtestfuns as uqtf
 
-uqtf.list_functions(tag="reliability")
+uqtf.list_functions(tag="reliability", tablefmt="html")
 ```
 
 ## About reliability analysis

--- a/docs/fundamentals/sensitivity.md
+++ b/docs/fundamentals/sensitivity.md
@@ -45,5 +45,5 @@ using the ``tag`` parameter:
 
 import uqtestfuns as uqtf
 
-uqtf.list_functions(tag="sensitivity")
+uqtf.list_functions(tag="sensitivity", tablefmt="html")
 ```

--- a/docs/test-functions/available.md
+++ b/docs/test-functions/available.md
@@ -69,12 +69,13 @@ regardless of their typical applications.
 |                   {ref}`Wing Weight <test-functions:wing-weight>`                   |       10        |         `WingWeight()`          |
 
 In a Python terminal, you can list all the available functions
-along with the corresponding constructor using ``list_functions()``:
+along with the corresponding constructor using ``list_functions()``
+(shown below in the HTML format):
 
 ```{code-cell} ipython3
 :tags: ["output_scroll"]
 
 import uqtestfuns as uqtf
 
-uqtf.list_functions()
+uqtf.list_functions(tablefmt="html")
 ```

--- a/src/uqtestfuns/core/uqtestfun_abc.py
+++ b/src/uqtestfuns/core/uqtestfun_abc.py
@@ -64,6 +64,7 @@ class UQTestFunBareABC(abc.ABC):
         self.prob_input = prob_input
         self._parameters = parameters
         self._function_id = function_id
+        self._output_dimension: Optional[int] = None
 
     @property
     def prob_input(self) -> ProbInput:
@@ -104,6 +105,21 @@ class UQTestFunBareABC(abc.ABC):
     def input_dimension(self) -> int:
         """The input dimension of the UQ test function."""
         return self.prob_input.input_dimension
+
+    @property
+    def output_dimension(self) -> int:
+        if self._output_dimension is None:
+            xx = self.prob_input.get_sample()
+            yy = self(xx)
+            if yy.ndim == 1:
+                self._output_dimension = 1
+            elif yy.ndim == 2:
+                self._output_dimension = yy.shape[1]
+            else:
+                self._output_dimension = yy.shape[1:]
+            return self._output_dimension
+
+        return self._output_dimension
 
     def transform_sample(
         self,
@@ -151,9 +167,10 @@ class UQTestFunBareABC(abc.ABC):
 
     def __str__(self):
         out = (
-            f"Function ID     : {self.function_id}\n"
-            f"Input Dimension : {self.input_dimension}\n"
-            f"Parameterized   : {bool(self.parameters)}"
+            f"Function ID      : {self.function_id}\n"
+            f"Input Dimension  : {self.input_dimension}\n"
+            f"Output Dimension : {self.output_dimension}\n"
+            f"Parameterized    : {bool(self.parameters)}"
         )
 
         return out
@@ -380,10 +397,11 @@ class UQTestFunABC(UQTestFunBareABC):
 
     def __str__(self):
         out = (
-            f"Function ID     : {self.function_id}\n"
-            f"Input Dimension : {self.input_dimension}\n"
-            f"Parameterized   : {bool(self.parameters)}\n"
-            f"Description     : {self.description}"
+            f"Function ID      : {self.function_id}\n"
+            f"Input Dimension  : {self.input_dimension}\n"
+            f"Output Dimension : {self.output_dimension}\n"
+            f"Parameterized    : {bool(self.parameters)}\n"
+            f"Description      : {self.description}"
         )
 
         return out

--- a/tests/builtin_test_functions/test_test_functions.py
+++ b/tests/builtin_test_functions/test_test_functions.py
@@ -155,10 +155,11 @@ def test_str(builtin_testfun):
     my_fun = builtin_testfun()
 
     str_ref = (
-        f"Function ID     : {my_fun.function_id}\n"
-        f"Input Dimension : {my_fun.input_dimension}\n"
-        f"Parameterized   : {bool(my_fun.parameters)}\n"
-        f"Description     : {my_fun.description}"
+        f"Function ID      : {my_fun.function_id}\n"
+        f"Input Dimension  : {my_fun.input_dimension}\n"
+        f"Output Dimension : {my_fun.output_dimension}\n"
+        f"Parameterized    : {bool(my_fun.parameters)}\n"
+        f"Description      : {my_fun.description}"
     )
 
     assert my_fun.__str__() == str_ref

--- a/tests/core/prob_input/test_univariate_input.py
+++ b/tests/core/prob_input/test_univariate_input.py
@@ -21,32 +21,37 @@ def univariate_input(
     request: Any,
 ) -> Tuple[Marginal, Dict[str, Union[str, ArrayLike]]]:
     """Test fixture, an instance of UnivariateInput."""
+
+    # All random values (distribution parameters are limited to 5 digits
+    # to avoid awkward yet unrealistic values)
     name = create_random_alphanumeric(8)
     distribution = request.param
     if request.param == "uniform":
-        parameters = np.sort(np.random.rand(2))
+        parameters = np.sort(np.round(np.random.rand(2), decimals=5))
     elif request.param == "beta":
-        parameters = np.sort(np.random.rand(4))
+        parameters = np.sort(np.round(np.random.rand(4), decimals=5))
     elif distribution == "exponential":
         # Single parameter, must be strictly positive
-        parameters = 1 + np.random.rand(1)
+        parameters = 1 + np.round(np.random.rand(1), decimals=5)
     elif distribution == "triangular":
-        parameters = np.sort(1 + 2 * np.random.rand(2))
+        parameters = np.sort(1 + 2 * np.round(np.random.rand(2), decimals=5))
         # Append the mid point
-        parameters = np.insert(
-            parameters, 2, np.random.uniform(parameters[0], parameters[1])
+        mid_p = np.round(
+            np.random.uniform(parameters[0], parameters[1]),
+            decimals=5,
         )
+        parameters = np.insert(parameters, 2, mid_p, axis=0)
     elif distribution in ["trunc-normal", "trunc-gumbel"]:
         # mu must be inside the bounds
-        parameters = np.sort(1 + 2 * np.random.rand(3))
+        parameters = np.sort(1 + 2 * np.round(np.random.rand(3), decimals=5))
         parameters[[0, 1]] = parameters[[1, 0]]
         # Insert sigma as the second parameter
         parameters = np.insert(parameters, 1, np.random.rand(1))
     elif distribution == "lognormal":
         # Limit the size of the parameters
-        parameters = 1 + np.random.rand(2)
+        parameters = 1 + np.round(np.random.rand(2), decimals=5)
     else:
-        parameters = 5 * np.random.rand(2)
+        parameters = 5 * np.round(np.random.rand(2), decimals=5)
         parameters[1] += 1.0
 
     specs = {

--- a/tests/core/test_uqtestfun.py
+++ b/tests/core/test_uqtestfun.py
@@ -68,9 +68,10 @@ def test_str(uqtestfun):
     uqtestfun_instance, _ = uqtestfun
 
     str_ref = (
-        f"Function ID     : {uqtestfun_instance.function_id}\n"
-        f"Input Dimension : {uqtestfun_instance.input_dimension}\n"
-        f"Parameterized   : {bool(uqtestfun_instance.parameters)}"
+        f"Function ID      : {uqtestfun_instance.function_id}\n"
+        f"Input Dimension  : {uqtestfun_instance.input_dimension}\n"
+        f"Output Dimension : {uqtestfun_instance.output_dimension}\n"
+        f"Parameterized    : {bool(uqtestfun_instance.parameters)}"
     )
 
     assert uqtestfun_instance.__str__() == str_ref

--- a/tests/test_list_functions.py
+++ b/tests/test_list_functions.py
@@ -15,31 +15,89 @@ def test_default_call():
     assert_call(list_functions)
 
 
-@pytest.mark.parametrize("input_dimension", [1, 2, 10, "M"])
-@pytest.mark.parametrize("tag", SUPPORTED_TAGS)
-@pytest.mark.parametrize("tabulate", [True, False, None])
-def test_call_valid_arguments(input_dimension, tag, tabulate):
-    """Test function call with valid arguments."""
-    assert_call(list_functions, input_dimension, tag, tabulate)
+class TestValidArgument:
+    """A series of tests for calling list_functions() with valid arguments."""
+
+    @pytest.mark.parametrize("input_dimension", [1, 2, 10, "M", None])
+    def test_input_dimension(self, input_dimension):
+        """Test function call with 'input_dimension' argument."""
+        assert_call(list_functions, input_dimension=input_dimension)
+
+    @pytest.mark.parametrize("tag", SUPPORTED_TAGS)
+    def test_tag(self, tag):
+        """Test function call with 'tag' argument."""
+        assert_call(list_functions, tag=tag)
+
+    @pytest.mark.parametrize("output_dimension", [1, 2, 3, None])
+    def test_output_dimension(self, output_dimension):
+        """Test function call with 'tag' argument."""
+        assert_call(list_functions, output_dimension=output_dimension)
+
+    @pytest.mark.parametrize("parameterized", [True, False, None])
+    def test_parameterized(self, parameterized):
+        """Test function call with 'tag' argument."""
+        assert_call(list_functions, parameterized=parameterized)
+
+    @pytest.mark.parametrize("tabulate", [True, False, None])
+    def test_tabulate(self, tabulate):
+        """Test function call with 'tag' argument."""
+        assert_call(list_functions, tabulate=tabulate)
 
 
-@pytest.mark.parametrize("input_dimension", [1, -2, -3, "a"])
-@pytest.mark.parametrize("tag", ["hello", "world"])
-def test_call_invalid_value_arguments(input_dimension, tag):
-    """Test function call with invalid argument values."""
+class TestInvalidValueArgument:
+    """A series of tests for calling list_functions() w/ invalid value arg."""
 
-    with pytest.raises(ValueError):
-        list_functions(input_dimension, tag)
+    @pytest.mark.parametrize("input_dimension", [-1, -2, -3, "a"])
+    def test_input_dimension(self, input_dimension):
+        """Test function call with invalid value for 'input_dimension'."""
+        with pytest.raises(ValueError):
+            list_functions(input_dimension=input_dimension)
+
+    @pytest.mark.parametrize("tag", ["hello", "world"])
+    def test_tag(self, tag):
+        """Test function call with invalid value for 'tag'."""
+        with pytest.raises(ValueError):
+            list_functions(tag=tag)
+
+    @pytest.mark.parametrize("output_dimension", [-1, -2, -3])
+    def test_output_dimension(self, output_dimension):
+        """Test function call with invalid value for 'output_dimension'."""
+        with pytest.raises(ValueError):
+            list_functions(output_dimension=output_dimension)
 
 
-@pytest.mark.parametrize("input_dimension", [1, 1.0, [2], True])
-@pytest.mark.parametrize("tag", ["reliability", 1.0, 5.0, False])
-@pytest.mark.parametrize("tabulate", [1.0, 100, "100"])
-def test_call_invalid_type_arguments(input_dimension, tag, tabulate):
-    """Test function call with invalid argument types."""
+class TestInvalidTypeArgument:
+    """A series of tests for calling list_functions() w/ invalid type arg."""
 
-    with pytest.raises(TypeError):
-        list_functions(input_dimension, tag, tabulate)  # noqa
+    @pytest.mark.parametrize("input_dimension", [1.0, [2]])
+    def test_input_dimension(self, input_dimension):
+        """Test function call with invalid type for 'input_dimension'."""
+        with pytest.raises(TypeError):
+            list_functions(input_dimension=input_dimension)
+
+    @pytest.mark.parametrize("tag", [1.0, 5.0, False])
+    def test_tag(self, tag):
+        """Test function call with invalid type for 'tag'."""
+        with pytest.raises(TypeError):
+            list_functions(tag=tag)
+
+    @pytest.mark.parametrize("output_dimension", ["a", [2]])
+    def test_output_dimension(self, output_dimension):
+        """Test function call with invalid type for 'output_dimension'."""
+        with pytest.raises(TypeError):
+            list_functions(output_dimension=output_dimension)
+
+    @pytest.mark.parametrize("parameterized", ["a", 1, 2])
+    def test_parameterized(self, parameterized):
+        """Test function call with invalid type for 'parameterized'."""
+        with pytest.raises(TypeError):
+            list_functions(parameterized=parameterized)
+
+    @pytest.mark.parametrize("tabulate", [1.0, 100, "100"])
+    def test_tabulate(self, tabulate):
+        """Test function call with invalid type for 'tabulate'."""
+        with pytest.raises(TypeError):
+            list_functions(tabulate=tabulate)
 
 
 def test_untabulated_call():
@@ -57,3 +115,12 @@ def test_untabulated_call():
     assert len(my_classes_from_list) == len(my_classes_ref)
     for my_class in my_classes_from_list:
         assert my_class in list(my_classes_ref.values())
+
+
+def test_tablefmt_html():
+    """Test function call with 'html' as tablefmt."""
+
+    table = list_functions(tablefmt="html")
+
+    # Assertion
+    assert isinstance(table, str)


### PR DESCRIPTION
Introduce the `output_dimension` property for UQ test functions and update related tests and documentations.

Furthermore, the high-level function `list_functions()` is updated to display additional information related to output dimension and parameterization in grid format.

This PR should resolve Issue #345.