### PR TITLE
Fix issue with the name of test function Welch1992

### DIFF
--- a/docs/fundamentals/metamodeling.md
+++ b/docs/fundamentals/metamodeling.md
@@ -46,7 +46,7 @@ in the comparison of metamodeling approaches.
 |            {ref}`Piston Simulation <test-functions:piston>`            |     7 / 20      |      `Piston()`      |
 |      {ref}`Webster et al. (1996) 2D <test-functions:webster-2d>`       |        2        |    `Webster2D()`     |
 |                 {ref}`Sulfur <test-functions:sulfur>`                  |        9        |      `Sulfur()`      |
-|              {ref}`Welch1992 <test-functions:welch1992>`               |       20        |    `Welch1992()`     |
+|         {ref}`Welch et al. (1992) <test-functions:welch1992>`          |       20        |    `Welch1992()`     |
 |            {ref}`Wing Weight <test-functions:wing-weight>`             |       10        |    `WingWeight()`    |
 
 In a Python terminal, you can list all the available functions relevant

--- a/docs/test-functions/available.md
+++ b/docs/test-functions/available.md
@@ -65,7 +65,7 @@ regardless of their typical applications.
 |           {ref}`Speed Reducer Shaft <test-functions:speed-reducer-shaft>`           |        5        |      `SpeedReducerShaft()`      |
 |                        {ref}`Sulfur <test-functions:sulfur>`                        |        9        |           `Sulfur()`            |
 |             {ref}`Webster et al. (1996) 2D <test-functions:webster-2d>`             |        2        |          `Webster2D()`          |
-|                     {ref}`Welch1992 <test-functions:welch1992>`                     |       20        |          `Welch1992()`          |
+|                {ref}`Welch et al. (1992) <test-functions:welch1992>`                |       20        |          `Welch1992()`          |
 |                   {ref}`Wing Weight <test-functions:wing-weight>`                   |       10        |         `WingWeight()`          |
 
 In a Python terminal, you can list all the available functions

--- a/docs/test-functions/borehole.md
+++ b/docs/test-functions/borehole.md
@@ -87,7 +87,7 @@ For example, to create a Borehole test function using
 the input specification by {cite}`Morris1993`:
 
 ```python
-my_testfun = uqtf.Borehole(prob_input_selection="Morris1993")
+my_testfun = uqtf.Borehole(input_id="Morris1993")
 ```
 
 ## Reference results

--- a/docs/test-functions/ishigami.md
+++ b/docs/test-functions/ishigami.md
@@ -84,10 +84,10 @@ print(my_testfun.parameters)
 ````{note}
 To use another set of parameters, create a default test function
 and pass one of the available keywords
-(as indicated in the table above) to the `parameters_selection` parameter.
+(as indicated in the table above) to the `parameters_id` parameter.
 For example:
 ```python
-my_testfun = uqtf.Ishigami(parameters_selection="Sobol1999")
+my_testfun = uqtf.Ishigami(parameters_id="Sobol1999")
 ```
 ````
 

--- a/docs/test-functions/otl-circuit.md
+++ b/docs/test-functions/otl-circuit.md
@@ -84,10 +84,10 @@ these input variables, being inert, do not affect the output of the function.
 
 To create an instance of the OTL circuit test function with the probabilistic
 input specified in {cite}`Moon2010`, pass the corresponding keyword
-(`"Moon2010"`) to the parameter (`prob_input_selection`):
+(`"Moon2010"`) to the parameter `input_id`:
 
 ```python
-my_testfun = uqtf.OTLCircuit(prob_input_selection="Moon2010")
+my_testfun = uqtf.OTLCircuit(input_id="Moon2010")
 ```
 ````
 

--- a/docs/test-functions/piston.md
+++ b/docs/test-functions/piston.md
@@ -87,10 +87,10 @@ these input variables, being inert, do not affect the output of the function.
 To create an instance of the piston simulation test function
 with the probabilistic input specified in {cite}`Moon2010`,
 pass the corresponding keyword (`"Moon2010"`)
-to the parameter (`prob_input_selection`):
+to the parameter `input_id`):
 
 ```python
-my_testfun = uqtf.Piston(prob_input_selection="Moon2010")
+my_testfun = uqtf.Piston(input_id="Moon2010")
 ```
 ````
 

--- a/docs/test-functions/portfolio-3d.md
+++ b/docs/test-functions/portfolio-3d.md
@@ -96,7 +96,7 @@ To create an instance of the simple portfolio model with a different set of
 parameter values from the selection above, type:
 
 ```python
-my_testfun = uqtf.Portfolio3D(parameters_selection="Saltelli2004")
+my_testfun = uqtf.Portfolio3D(parameters_id="Saltelli2004-2")
 ```
 ````
 
@@ -116,9 +116,9 @@ for the simple portfolio model with three different sets of parameters.
 np.random.seed(42)
 xx_test = my_testfun.prob_input.get_sample(100000)
 yy_test_1 = my_testfun(xx_test)
-my_testfun_2 = uqtf.Portfolio3D(parameters_selection="Saltelli2004-2")
+my_testfun_2 = uqtf.Portfolio3D(parameters_id="Saltelli2004-2")
 yy_test_2 = my_testfun_2(xx_test)
-my_testfun_3 = uqtf.Portfolio3D(parameters_selection="Saltelli2004-3")
+my_testfun_3 = uqtf.Portfolio3D(parameters_id="Saltelli2004-3")
 yy_test_3 = my_testfun_3(xx_test)
 
 plt.hist(yy_test_3, bins="auto", color="#fc8d62", label="Saltelli2004-3")

--- a/docs/test-functions/sobol-g.md
+++ b/docs/test-functions/sobol-g.md
@@ -181,12 +181,12 @@ print(my_testfun.parameters)
 
 ````{note}
 To create an instance of the Sobol'-G function with different built-in parameter values, 
-pass the corresponding keyword to the parameter `parameters_selection`.
+pass the corresponding keyword to the parameter `parameters_id`.
 For example, to use the parameters of problem 3B from {cite}`Kucherenko2011`,
 type:
 
 ```python
-my_testfun = uqtf.SobolG(parameters_selection="Kucherenko2011-3b")
+my_testfun = uqtf.SobolG(parameters_id="Kucherenko2011-3b")
 ```
 ````
 ## Reference results


### PR DESCRIPTION
The function name as it appears in the docs should have been: "Welch et al. (1992)".
Furthermore, the usage of `parameters_selection` and `prob_input_selection` have been revised to `parameters_id` and `input_id`, respectively.

This PR should resolve Issue #346.