### PR TITLE
Add Saltelli Linear function for sensitivity analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The M-dimensional linear function from Saltelli et al. (2008) for sensitivity
+  analysis.
 - The two-dimensional non-polynomial test function for metamodeling from
-  
+  Lim et al. (2002).
 - The two-dimensional polynomial test function for metamodeling from 
   Lim et al. (2002).
 - The three-dimensional sensitivity test function from Moon (2010).

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -119,6 +119,8 @@ parts:
             title: RS - Circular Bar
           - file: test-functions/rs-quadratic
             title: RS - Quadratic
+          - file: test-functions/saltelli-linear
+            title: Saltelli Linear
           - file: test-functions/sobol-g
             title: Sobol'-G
           - file: test-functions/speed-reducer-shaft

--- a/docs/fundamentals/sensitivity.md
+++ b/docs/fundamentals/sensitivity.md
@@ -17,25 +17,26 @@ kernelspec:
 The table below listed the available test functions typically used
 in the comparison of sensitivity analysis methods.
 
-|                             Name                             | Input Dimension |     Constructor      |
-|:------------------------------------------------------------:|:---------------:|:--------------------:|
-|          {ref}`Borehole <test-functions:borehole>`           |        8        |     `Borehole()`     |
-| {ref}`Bratley et al. (1992) A <test-functions:bratley1992a>` |        M        |   `Bratley1992a()`   |
-| {ref}`Bratley et al. (1992) B <test-functions:bratley1992b>` |        M        |   `Bratley1992b()`   |
-| {ref}`Bratley et al. (1992) C <test-functions:bratley1992c>` |        M        |   `Bratley1992c()`   |
-| {ref}`Bratley et al. (1992) D <test-functions:bratley1992d>` |        M        |   `Bratley1992d()`   |
-| {ref}`Damped Oscillator <test-functions:damped-oscillator>`  |        7        | `DampedOscillator()` |
-|             {ref}`Flood <test-functions:flood>`              |        8        |      `Flood()`       |
-|      {ref}`Friedman (6D) <test-functions:friedman-6d>`       |        6        |    `Friedman6D()`    |
-|          {ref}`Ishigami <test-functions:ishigami>`           |        3        |     `Ishigami()`     |
-|        {ref}`Moon (2010) 3D <test-functions:moon3d>`         |        3        |      `Moon3D()`      |
-|       {ref}`OTL Circuit <test-functions:otl-circuit>`        |     6 / 20      |    `OTLCircuit()`    |
-|       {ref}`Piston Simulation <test-functions:piston>`       |     7 / 20      |      `Piston()`      |
-| {ref}`Simple Portfolio Model <test-functions:portfolio-3d>`  |        3        |   `Portfolio3D()`    |
-|           {ref}`Sobol'-G <test-functions:sobol-g>`           |        M        |      `SobolG()`      |
-|            {ref}`Sulfur <test-functions:sulfur>`             |        9        |      `Sulfur()`      |
-|    {ref}`Welch et al. (1992) <test-functions:welch1992>`     |       20        |    `Welch1992()`     |
-|       {ref}`Wing Weight <test-functions:wing-weight>`        |       10        |    `WingWeight()`    |
+|                                     Name                                      | Input Dimension |     Constructor      |
+|:-----------------------------------------------------------------------------:|:---------------:|:--------------------:|
+|                   {ref}`Borehole <test-functions:borehole>`                   |        8        |     `Borehole()`     |
+|         {ref}`Bratley et al. (1992) A <test-functions:bratley1992a>`          |        M        |   `Bratley1992a()`   |
+|         {ref}`Bratley et al. (1992) B <test-functions:bratley1992b>`          |        M        |   `Bratley1992b()`   |
+|         {ref}`Bratley et al. (1992) C <test-functions:bratley1992c>`          |        M        |   `Bratley1992c()`   |
+|         {ref}`Bratley et al. (1992) D <test-functions:bratley1992d>`          |        M        |   `Bratley1992d()`   |
+|          {ref}`Damped Oscillator <test-functions:damped-oscillator>`          |        7        | `DampedOscillator()` |
+|                      {ref}`Flood <test-functions:flood>`                      |        8        |      `Flood()`       |
+|               {ref}`Friedman (6D) <test-functions:friedman-6d>`               |        6        |    `Friedman6D()`    |
+|                   {ref}`Ishigami <test-functions:ishigami>`                   |        3        |     `Ishigami()`     |
+|                 {ref}`Moon (2010) 3D <test-functions:moon3d>`                 |        3        |      `Moon3D()`      |
+|                {ref}`OTL Circuit <test-functions:otl-circuit>`                |     6 / 20      |    `OTLCircuit()`    |
+|               {ref}`Piston Simulation <test-functions:piston>`                |     7 / 20      |      `Piston()`      |
+|          {ref}`Simple Portfolio Model <test-functions:portfolio-3d>`          |        3        |   `Portfolio3D()`    |
+|            {ref}`SaltelliLinear <test-functions:saltelli-linear>`             |        M        |  `SaltelliLinear()`  |
+|                   {ref}`Sobol'-G <test-functions:sobol-g>`                    |        M        |      `SobolG()`      |
+|                     {ref}`Sulfur <test-functions:sulfur>`                     |        9        |      `Sulfur()`      |
+|             {ref}`Welch et al. (1992) <test-functions:welch1992>`             |       20        |    `Welch1992()`     |
+|                {ref}`Wing Weight <test-functions:wing-weight>`                |       10        |    `WingWeight()`    |
 
 In a Python terminal, you can list all the available functions relevant
 for metamodeling applications using ``list_functions()`` and filter the results

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -823,4 +823,14 @@ An orthogonal design in which the design matrix has uncorrelated columns is impo
   doi     = {10.2307/3315868},
 }
 
+@Book{Saltelli2008,
+  editor    = {Andrea Saltelli and Karen Chan and Evelyn Marian Scott},
+  publisher = {John Wiley & Sons},
+  title     = {Sensitivity analysis},
+  year      = {2008},
+  address   = {Hoboken, NJ},
+  isbn      = {9780470743829},
+  series    = {Wiley Series in Probability and Statistics},
+}
+
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/docs/test-functions/available.md
+++ b/docs/test-functions/available.md
@@ -64,6 +64,7 @@ regardless of their typical applications.
 |             {ref}`Simple Portfolio Model <test-functions:portfolio-3d>`             |        3        |         `Portfolio3D()`         |
 |              {ref}`RS - Circular Bar <test-functions:rs-circular-bar>`              |        2        |        `RSCircularBar()`        |
 |                 {ref}`RS - Quadratic <test-functions:rs-quadratic>`                 |        2        |         `RSQuadratic()`         |
+|               {ref}`SaltelliLinear <test-functions:saltelli-linear>`                |        M        |       `SaltelliLinear()`        |
 |                      {ref}`Sobol'-G <test-functions:sobol-g>`                       |        M        |           `SobolG()`            |
 |           {ref}`Speed Reducer Shaft <test-functions:speed-reducer-shaft>`           |        5        |      `SpeedReducerShaft()`      |
 |                        {ref}`Sulfur <test-functions:sulfur>`                        |        9        |           `Sulfur()`            |

--- a/docs/test-functions/ishigami.md
+++ b/docs/test-functions/ishigami.md
@@ -133,7 +133,7 @@ analytical values.
 :tags: [hide-input]
 
 # --- Compute the mean and variance estimate
-np.random.seed(42)
+my_testfun.prob_input.reset_rng(42)
 sample_sizes = np.array([1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7], dtype=int)
 mean_estimates = np.empty(len(sample_sizes))
 var_estimates = np.empty(len(sample_sizes))
@@ -160,7 +160,7 @@ ax_1.errorbar(
     label="Mean"
 )
 # Plot the analytical mean
-a = my_testfun.parameters[0]
+a = my_testfun.parameters["a"]
 mean_analytical = a / 2.0
 ax_1.plot(
     sample_sizes,
@@ -185,7 +185,7 @@ ax_2.errorbar(
     label="Variance",
 )
 # Plot the analytical variance
-b = my_testfun.parameters[1]
+b = my_testfun.parameters["b"]
 var_analytical = a**2 / 8 + b * np.pi**4 / 5 + b**2 * np.pi**8 / 18 + 0.5
 ax_2.plot(
     sample_sizes,

--- a/src/uqtestfuns/core/custom_typing.py
+++ b/src/uqtestfuns/core/custom_typing.py
@@ -4,12 +4,13 @@ Core module that contains custom types used in UQTestFuns.
 Custom types are used to assist type checker during the code development.
 """
 
-from typing import List, Union, Optional, Any, Dict, Sequence
+from typing import Callable, List, Union, Optional, Any, Dict, Sequence
 from typing_extensions import TypedDict
 
 from uqtestfuns.core.prob_input.marginal import Marginal
 
 __all__ = [
+    "MarginalSpec",
     "MarginalSpecs",
     "ProbInputSpecs",
     "ProbInputArgs",
@@ -32,7 +33,7 @@ MarginalSpecs = List[MarginalSpec]
 class ProbInputSpec(TypedDict):
     function_id: str
     description: str
-    marginals: List[MarginalSpec]
+    marginals: Union[List[MarginalSpec], Callable]
     copulas: Optional[Any]
 
 

--- a/src/uqtestfuns/core/uqtestfun_abc.py
+++ b/src/uqtestfuns/core/uqtestfun_abc.py
@@ -579,11 +579,18 @@ class UQTestFunVarDimABC(UQTestFunABC, ABC):
         raw_data = deepcopy(self.available_inputs[input_id])
 
         # Process the marginals
-        marginals = []
-        for i in range(input_dim):
-            marginal = raw_data["marginals"][0].copy()
-            marginal["name"] = f"{marginal['name']}{i}"
-            marginals.append(Marginal(**marginal))
+        marginal = raw_data["marginals"]
+        if callable(marginal):
+            # Marginal specification is given as a function
+            marginals = marginal(input_dim)
+            marginals = [Marginal(**marginal) for marginal in marginals]
+        else:
+            # Marginal specification will be spawned up to the # of dimension
+            marginals = []
+            for i in range(input_dim):
+                marginal = raw_data["marginals"][0].copy()
+                marginal["name"] = f"{marginal['name']}{i}"
+                marginals.append(Marginal(**marginal))
 
         # Recast the type to satisfy type checker
         input_data = cast(ProbInputArgs, raw_data)

--- a/src/uqtestfuns/test_functions/__init__.py
+++ b/src/uqtestfuns/test_functions/__init__.py
@@ -29,6 +29,7 @@ from .piston import Piston
 from .portfolio_3d import Portfolio3D
 from .rs_circular_bar import RSCircularBar
 from .rs_quadratic import RSQuadratic
+from .saltelli_linear import SaltelliLinear
 from .sobol_g import SobolG
 from .speed_reducer_shaft import SpeedReducerShaft
 from .sulfur import Sulfur
@@ -83,6 +84,7 @@ __all__ = [
     "Portfolio3D",
     "RSCircularBar",
     "RSQuadratic",
+    "SaltelliLinear",
     "SobolG",
     "SpeedReducerShaft",
     "Sulfur",

--- a/src/uqtestfuns/test_functions/saltelli_linear.py
+++ b/src/uqtestfuns/test_functions/saltelli_linear.py
@@ -1,0 +1,111 @@
+"""
+Module with an implementation of the linear fun. from Saltelli et al. (2008).
+
+The linear function from Saltelli et al. (2008) is an M-dimensional
+scalar-valued function.
+It was introduced in [1] to illustrate sensitivity analysis methods and used
+in [2] for benchmarking purposes.
+
+Due to its simple structure, its moments and Sobol' sensitivity indices can
+be computed analytically.
+
+References
+----------
+1. A. Saltelli, K. Chan, and E. Scott, 2008. Sensitivity Analysis: Wiley Series
+   in Probability and Statistics. Wiley, New York.
+2. X. Sun, B. Croke, A. Jakeman, S. Roberts, "Benchmarking Active Subspace
+   methods of global sensitivity analysis against variance-based Sobol’
+   and Morris methods with established test functions," Environmental Modelling
+   & Software, vol. 149, p. 105310, 2022.
+   DOI: 10.1016/j.envsoft.2022.105310
+"""
+
+import numpy as np
+
+from uqtestfuns.core.custom_typing import (
+    MarginalSpec,
+    MarginalSpecs,
+    ProbInputSpecs,
+)
+from uqtestfuns.core.uqtestfun_abc import UQTestFunVarDimABC
+
+__all__ = ["SaltelliLinear"]
+
+
+def _create_marginals(input_dimension: int) -> MarginalSpecs:
+    """Create a list of marginal specifications of the given dimension.
+
+    .. math::
+
+      X_i \sim \mathcal{U}[x_{o, i} - \sigma_{o, i}, x_{o, i} + \sigma_{o, i}]
+
+    where :math:`x_{o, i} = 3^{i - 1}` and :math:`\sigma_{o, i} = 0.5 x_{o, i}`
+    for :math:`i = 1, 2, \ldots`.
+
+    Parameters
+    ----------
+    input_dimension : int
+        The number of marginal specifications in the list.
+
+    Returns
+    -------
+    MarginalSpecs
+        The list of marginal specifications.
+    """
+    marginals = []
+    for i in range(input_dimension):
+        mid = 3**i
+        delta = 0.5 * mid
+        marginal: MarginalSpec = {
+            "name": f"X{i + 1}",
+            "distribution": "uniform",
+            "parameters": [mid - delta, mid + delta],
+            "description": None,
+        }
+        marginals.append(marginal)
+
+    return marginals
+
+
+AVAILABLE_INPUTS: ProbInputSpecs = {
+    "Saltelli2000": {
+        "function_id": "SaltelliLinear",
+        "description": (
+            "Probabilistic input model for the linear function "
+            "from Saltelli et al. (2000)"
+        ),
+        "marginals": _create_marginals,
+        "copulas": None,
+    },
+}
+
+
+def evaluate(xx: np.ndarray):
+    """Evaluate the linear function on a set of input values.
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        M-Dimensional input values given by an N-by-M array where
+        N is the number of input values.
+
+    Returns
+    -------
+    np.ndarray
+        The output of the test function evaluated on the input values.
+        The output is a 1-dimensional array of length N.
+    """
+    yy = np.sum(xx, axis=1)
+
+    return yy
+
+
+class SaltelliLinear(UQTestFunVarDimABC):
+    """An implementation of the M-dimensional Saltelli linear function."""
+
+    _tags = ["sensitivity"]
+    _description = "Linear function from Saltelli et al. (2000)"
+    _available_inputs = AVAILABLE_INPUTS
+    _available_parameters = None
+
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/saltelli_linear.py
+++ b/src/uqtestfuns/test_functions/saltelli_linear.py
@@ -33,7 +33,7 @@ __all__ = ["SaltelliLinear"]
 
 
 def _create_marginals(input_dimension: int) -> MarginalSpecs:
-    """Create a list of marginal specifications of the given dimension.
+    r"""Create a list of marginal specifications of the given dimension.
 
     .. math::
 


### PR DESCRIPTION
The linear function from Saltelli et al. (2008) is used as a testing function for sensitivity analysis methods.
The documentation has been updated accordingly.

Furthermore:

- The core has been updated to deal with generating probability input where the marginals are not identical but coming from a function.
- The issue in the docs of the Ishigami function has been fixed.

This PR should resolve Issue #354.