### PR TITLE
Add Cheng2D test function for metamodeling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The two-dimensional test function from Cheng and Sandu (2010)
+  for metamodeling exercises.
 - The M-dimensional linear function from Saltelli et al. (2008) for sensitivity
   analysis.
 - The two-dimensional non-polynomial test function for metamodeling from

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -51,6 +51,8 @@ parts:
             title: Bratley et al. (1992) D
           - file: test-functions/cantilever-beam-2d
             title: Cantilever Beam (2D)
+          - file: test-functions/cheng2d
+            title: Cheng and Sandu (2010) 2D
           - file: test-functions/circular-pipe-crack
             title: Circular Pipe Crack
           - file: test-functions/convex-fail-domain

--- a/docs/fundamentals/metamodeling.md
+++ b/docs/fundamentals/metamodeling.md
@@ -23,6 +23,7 @@ in the comparison of metamodeling approaches.
 |  {ref}`Alemazkoor & Meidani (2018) 2D <test-functions:alemazkoor-2d>`  |        2        |   `Alemazkoor2D()`   |
 | {ref}`Alemazkoor & Meidani (2018) 20D <test-functions:alemazkoor-20d>` |       20        |  `Alemazkoor20D()`   |
 |               {ref}`Borehole <test-functions:borehole>`                |        8        |     `Borehole()`     |
+|       {ref}`Cheng and Sandu (2010) 2D <test-functions:cheng2d>`        |        2        |     `Cheng2D`        |
 |          {ref}`Damped Cosine <test-functions:damped-cosine>`           |        1        |   `DampedCosine()`   |
 |      {ref}`Damped Oscillator <test-functions:damped-oscillator>`       |        7        | `DampedOscillator()` |
 |                  {ref}`Flood <test-functions:flood>`                   |        8        |      `Flood()`       |

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -833,4 +833,16 @@ An orthogonal design in which the design matrix has uncorrelated columns is impo
   series    = {Wiley Series in Probability and Statistics},
 }
 
+ 
+@InProceedings{Cheng2010,
+  author    = {Cheng, Haiyan and Sandu, Adrian},
+  booktitle = {Proceedings of the 2010 Spring Simulation Multiconference},
+  title     = {Collocation least-squares polynomial chaos method},
+  year      = {2010},
+  pages     = {1--6},
+  publisher = {Society for Computer Simulation International},
+  series    = {SpringSim ’10},
+  doi       = {10.1145/1878537.1878621},
+}
+
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/docs/test-functions/available.md
+++ b/docs/test-functions/available.md
@@ -30,6 +30,7 @@ regardless of their typical applications.
 |            {ref}`Bratley et al. (1992) C <test-functions:bratley1992c>`             |        M        |        `Bratley1992c()`         |
 |            {ref}`Bratley et al. (1992) D <test-functions:bratley1992d>`             |        M        |        `Bratley1992d()`         |
 |           {ref}`Cantilever Beam (2D) <test-functions:cantilever-beam-2d>`           |        2        |       `CantileverBeam2D `       |
+|              {ref}`Cheng and Sandu (2010) 2D <test-functions:cheng2d>`              |        2        |           `Cheng2D `            |
 |           {ref}`Circular Pipe Crack <test-functions:circular-pipe-crack>`           |        2        |      `CircularPipeCrack()`      |
 |          {ref}`Convex Failure Domain <test-functions:convex-fail-domain>`           |        2        |      `ConvexFailDomain()`       |
 |                 {ref}`Damped Cosine <test-functions:damped-cosine>`                 |        1        |        `DampedCosine()`         |

--- a/docs/test-functions/cheng2d.md
+++ b/docs/test-functions/cheng2d.md
@@ -1,0 +1,142 @@
+---
+jupytext:
+  formats: ipynb,md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.14.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+(test-functions:cheng2d)=
+# Two-dimensional Function from Cheng and Sandu (2010)
+
+```{code-cell} ipython3
+import numpy as np
+import matplotlib.pyplot as plt
+import uqtestfuns as uqtf
+```
+
+The two-dimensional test function from Cheng and Sandu (2002) (or
+`Cheng2D` for short) is used in a metamodeling exercise via polynomial
+chaos expansion in {cite}`Cheng2010`.
+
+```{code-cell} ipython3
+:tags: [remove-input]
+
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+my_fun = uqtf.Cheng2D()
+
+# --- Create 2D data
+xx_1d = np.linspace(0.0, 1.0, 1000)[:, np.newaxis]
+mesh_2d = np.meshgrid(xx_1d, xx_1d)
+xx_2d = np.array(mesh_2d).T.reshape(-1, 2)
+yy_2d = my_fun(xx_2d)
+
+# --- Create two-dimensional plots
+fig = plt.figure(figsize=(10, 5))
+
+# Surface
+axs_1 = plt.subplot(121, projection='3d')
+axs_1.plot_surface(
+    mesh_2d[0],
+    mesh_2d[1],
+    yy_2d.reshape(1000,1000).T,
+    linewidth=0,
+    cmap="plasma",
+    antialiased=False,
+    alpha=0.5
+)
+axs_1.set_xlabel("$x_1$", fontsize=14)
+axs_1.set_ylabel("$x_2$", fontsize=14)
+axs_1.set_zlabel("$\mathcal{M}(x_1, x_2)$", fontsize=14)
+axs_1.set_title("Surface plot of LimPoly", fontsize=14)
+
+# Contour
+axs_2 = plt.subplot(122)
+cf = axs_2.contourf(
+    mesh_2d[0], mesh_2d[1], yy_2d.reshape(1000, 1000).T, cmap="plasma", levels=10,
+)
+axs_2.set_xlabel("$x_1$", fontsize=14)
+axs_2.set_ylabel("$x_2$", fontsize=14)
+axs_2.set_title("Contour plot of LimPoly", fontsize=14)
+divider = make_axes_locatable(axs_2)
+cax = divider.append_axes('right', size='5%', pad=0.05)
+fig.colorbar(cf, cax=cax, orientation='vertical')
+axs_2.axis('scaled')
+
+fig.tight_layout(pad=4.0)
+plt.gcf().set_dpi(75);
+```
+
+
+## Test function instance
+
+To create a default instance of the test function:
+
+```{code-cell} ipython3
+my_testfun = uqtf.Cheng2D()
+```
+
+Check if it has been correctly instantiated:
+
+```{code-cell} ipython3
+print(my_testfun)
+```
+
+## Description
+
+The test function is defined as follows[^location]:
+
+$$
+\mathcal{M}(\boldsymbol{x}) = \cos{(x_1 + x_2)} \exp{(x_1 x_2)},
+$$
+where $\boldsymbol{x} = \{ x_1, x_2 \}$
+is the two-dimensional vector of input variables further defined below.
+
+## Probabilistic input
+
+The input consists of two uniformly distributed random variables as shown
+below.
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+print(my_testfun.prob_input)
+```
+
+## Reference results
+
+This section provides several reference results of typical UQ analyses involving
+the test function.
+
+### Sample histogram
+
+Shown below is the histogram of the output based on $100'000$ random points:
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+xx_test = my_testfun.prob_input.get_sample(100000)
+yy_test = my_testfun(xx_test)
+
+plt.hist(yy_test, bins="auto", color="#8da0cb");
+plt.grid();
+plt.ylabel("Counts [-]");
+plt.xlabel("$\mathcal{M}(\mathbf{X})$");
+plt.gcf().set_dpi(150);
+```
+
+## References
+
+```{bibliography}
+:style: unsrtalpha
+:filter: docname in docnames
+```
+
+[^location]: See Eq. (6), Section 4, p. 4 {cite}`Cheng2010`.

--- a/src/uqtestfuns/test_functions/__init__.py
+++ b/src/uqtestfuns/test_functions/__init__.py
@@ -7,6 +7,7 @@ from .alemazkoor import Alemazkoor2D, Alemazkoor20D
 from .borehole import Borehole
 from .bratley1992 import Bratley1992a, Bratley1992b, Bratley1992c, Bratley1992d
 from .cantilever_beam_2d import CantileverBeam2D
+from .cheng2010 import Cheng2D
 from .circular_pipe_crack import CircularPipeCrack
 from .convex_fail_domain import ConvexFailDomain
 from .damped_cosine import DampedCosine
@@ -50,6 +51,7 @@ __all__ = [
     "Bratley1992c",
     "Bratley1992d",
     "CantileverBeam2D",
+    "Cheng2D",
     "CircularPipeCrack",
     "ConvexFailDomain",
     "DampedCosine",

--- a/src/uqtestfuns/test_functions/cheng2010.py
+++ b/src/uqtestfuns/test_functions/cheng2010.py
@@ -1,0 +1,77 @@
+"""
+Module with an implementation of the 2D function from Cheng and Sandu (2010).
+
+The two-dimensional function was used in [1] as an example for metamodeling
+using polynomial chaos expansion.
+
+References
+----------
+1. H. Cheng and A. Sandu, “Collocation least-squares polynomial chaos method,”
+   in Proceedings of the 2010 Spring Simulation Multiconference, Orlando,
+   Florida: Society for Computer Simulation International, 2010, pp. 1–6.
+   DOI: 10.1145/1878537.1878621].
+"""
+
+import numpy as np
+
+from uqtestfuns.core.custom_typing import ProbInputSpecs
+from uqtestfuns.core.uqtestfun_abc import UQTestFunFixDimABC
+
+__all__ = ["Cheng2D"]
+
+
+AVAILABLE_INPUTS: ProbInputSpecs = {
+    "Cheng2010": {
+        "function_id": "Cheng2D",
+        "description": (
+            "Probabilistic input model for the 2D test function "
+            "from Cheng and Sandu (2010)"
+        ),
+        "marginals": [
+            {
+                "name": "X1",
+                "distribution": "uniform",
+                "parameters": [0.0, 1.0],
+                "description": None,
+            },
+            {
+                "name": "X2",
+                "distribution": "uniform",
+                "parameters": [0.0, 1.0],
+                "description": None,
+            },
+        ],
+        "copulas": None,
+    },
+}
+
+
+def evaluate(xx: np.ndarray) -> np.ndarray:
+    """Evaluate the 2D test function from Cheng and Sandu (2010).
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        A two-dimensional input values given by an N-by-2 array
+        where N is the number of input values.
+
+    Returns
+    -------
+    np.ndarray
+        The output of the test function evaluated on the input values.
+        The output is a 1-dimensional array of length N.
+    """
+    yy = np.cos(np.sum(xx, axis=1)) * np.exp(np.prod(xx, axis=1))
+
+    return yy
+
+
+class Cheng2D(UQTestFunFixDimABC):
+    """Concrete implementation of the function from Cheng and Sandu (2010)."""
+
+    _tags = ["metamodeling"]
+    _description = "Two-dimensional test function from Cheng and Sandu (2010)"
+    _available_inputs = AVAILABLE_INPUTS
+    _available_parameters = None
+
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/lim.py
+++ b/src/uqtestfuns/test_functions/lim.py
@@ -19,7 +19,7 @@ import numpy as np
 from uqtestfuns.core.custom_typing import ProbInputSpecs, MarginalSpecs
 from uqtestfuns.core.uqtestfun_abc import UQTestFunFixDimABC
 
-__all__ = ["LimPoly"]
+__all__ = ["LimPoly", "LimNonPoly"]
 
 
 MARGINALS_LIM2002: MarginalSpecs = [


### PR DESCRIPTION
Introduced the two-dimensional test function from Cheng and Sandu (2010).
This function is used in metamodeling exercises with polynomial chaos expansion.
Additionally, the documentation has been updated accordingly.

This PR should resolve Issue #335.