### PR TITLE
Add Sobol'-G* test function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The modified Sobol'-G test function (i.e., Sobol'-G*) from Saltelli et al.
+  (2010) for sensitivity analysis exercises.
 - The two-dimensional test function from Cheng and Sandu (2010)
   for metamodeling exercises.
 - The M-dimensional linear function from Saltelli et al. (2008) for sensitivity

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -125,6 +125,8 @@ parts:
             title: Saltelli Linear
           - file: test-functions/sobol-g
             title: Sobol'-G
+          - file: test-functions/sobol-g-star
+            title: Sobol'-G*
           - file: test-functions/speed-reducer-shaft
             title: Speed Reducer Shaft
           - file: test-functions/sulfur

--- a/docs/fundamentals/sensitivity.md
+++ b/docs/fundamentals/sensitivity.md
@@ -17,26 +17,27 @@ kernelspec:
 The table below listed the available test functions typically used
 in the comparison of sensitivity analysis methods.
 
-|                                     Name                                      | Input Dimension |     Constructor      |
-|:-----------------------------------------------------------------------------:|:---------------:|:--------------------:|
-|                   {ref}`Borehole <test-functions:borehole>`                   |        8        |     `Borehole()`     |
-|         {ref}`Bratley et al. (1992) A <test-functions:bratley1992a>`          |        M        |   `Bratley1992a()`   |
-|         {ref}`Bratley et al. (1992) B <test-functions:bratley1992b>`          |        M        |   `Bratley1992b()`   |
-|         {ref}`Bratley et al. (1992) C <test-functions:bratley1992c>`          |        M        |   `Bratley1992c()`   |
-|         {ref}`Bratley et al. (1992) D <test-functions:bratley1992d>`          |        M        |   `Bratley1992d()`   |
-|          {ref}`Damped Oscillator <test-functions:damped-oscillator>`          |        7        | `DampedOscillator()` |
-|                      {ref}`Flood <test-functions:flood>`                      |        8        |      `Flood()`       |
-|               {ref}`Friedman (6D) <test-functions:friedman-6d>`               |        6        |    `Friedman6D()`    |
-|                   {ref}`Ishigami <test-functions:ishigami>`                   |        3        |     `Ishigami()`     |
-|                 {ref}`Moon (2010) 3D <test-functions:moon3d>`                 |        3        |      `Moon3D()`      |
-|                {ref}`OTL Circuit <test-functions:otl-circuit>`                |     6 / 20      |    `OTLCircuit()`    |
-|               {ref}`Piston Simulation <test-functions:piston>`                |     7 / 20      |      `Piston()`      |
-|          {ref}`Simple Portfolio Model <test-functions:portfolio-3d>`          |        3        |   `Portfolio3D()`    |
-|            {ref}`SaltelliLinear <test-functions:saltelli-linear>`             |        M        |  `SaltelliLinear()`  |
-|                   {ref}`Sobol'-G <test-functions:sobol-g>`                    |        M        |      `SobolG()`      |
-|                     {ref}`Sulfur <test-functions:sulfur>`                     |        9        |      `Sulfur()`      |
-|             {ref}`Welch et al. (1992) <test-functions:welch1992>`             |       20        |    `Welch1992()`     |
-|                {ref}`Wing Weight <test-functions:wing-weight>`                |       10        |    `WingWeight()`    |
+|                                   Name                                   | Input Dimension |     Constructor      |
+|:------------------------------------------------------------------------:|:---------------:|:--------------------:|
+|                {ref}`Borehole <test-functions:borehole>`                 |        8        |     `Borehole()`     |
+|       {ref}`Bratley et al. (1992) A <test-functions:bratley1992a>`       |        M        |   `Bratley1992a()`   |
+|       {ref}`Bratley et al. (1992) B <test-functions:bratley1992b>`       |        M        |   `Bratley1992b()`   |
+|       {ref}`Bratley et al. (1992) C <test-functions:bratley1992c>`       |        M        |   `Bratley1992c()`   |
+|       {ref}`Bratley et al. (1992) D <test-functions:bratley1992d>`       |        M        |   `Bratley1992d()`   |
+|       {ref}`Damped Oscillator <test-functions:damped-oscillator>`        |        7        | `DampedOscillator()` |
+|                   {ref}`Flood <test-functions:flood>`                    |        8        |      `Flood()`       |
+|            {ref}`Friedman (6D) <test-functions:friedman-6d>`             |        6        |    `Friedman6D()`    |
+|                {ref}`Ishigami <test-functions:ishigami>`                 |        3        |     `Ishigami()`     |
+|              {ref}`Moon (2010) 3D <test-functions:moon3d>`               |        3        |      `Moon3D()`      |
+|             {ref}`OTL Circuit <test-functions:otl-circuit>`              |     6 / 20      |    `OTLCircuit()`    |
+|             {ref}`Piston Simulation <test-functions:piston>`             |     7 / 20      |      `Piston()`      |
+|       {ref}`Simple Portfolio Model <test-functions:portfolio-3d>`        |        3        |   `Portfolio3D()`    |
+|          {ref}`SaltelliLinear <test-functions:saltelli-linear>`          |        M        |  `SaltelliLinear()`  |
+|                 {ref}`Sobol'-G <test-functions:sobol-g>`                 |        M        |      `SobolG()`      |
+|              {ref}`Sobol'-G* <test-functions:sobol-g-star>`              |        M        |    `SobolGStar()`    |
+|                  {ref}`Sulfur <test-functions:sulfur>`                   |        9        |      `Sulfur()`      |
+|          {ref}`Welch et al. (1992) <test-functions:welch1992>`           |       20        |    `Welch1992()`     |
+|             {ref}`Wing Weight <test-functions:wing-weight>`              |       10        |    `WingWeight()`    |
 
 In a Python terminal, you can list all the available functions relevant
 for metamodeling applications using ``list_functions()`` and filter the results

--- a/docs/test-functions/available.md
+++ b/docs/test-functions/available.md
@@ -67,6 +67,7 @@ regardless of their typical applications.
 |                 {ref}`RS - Quadratic <test-functions:rs-quadratic>`                 |        2        |         `RSQuadratic()`         |
 |               {ref}`SaltelliLinear <test-functions:saltelli-linear>`                |        M        |       `SaltelliLinear()`        |
 |                      {ref}`Sobol'-G <test-functions:sobol-g>`                       |        M        |           `SobolG()`            |
+|                   {ref}`Sobol'-G* <test-functions:sobol-g-star>`                    |        M        |         `SobolGStar()`          |
 |           {ref}`Speed Reducer Shaft <test-functions:speed-reducer-shaft>`           |        5        |      `SpeedReducerShaft()`      |
 |                        {ref}`Sulfur <test-functions:sulfur>`                        |        9        |           `Sulfur()`            |
 |             {ref}`Webster et al. (1996) 2D <test-functions:webster-2d>`             |        2        |          `Webster2D()`          |

--- a/docs/test-functions/cheng2d.md
+++ b/docs/test-functions/cheng2d.md
@@ -55,7 +55,7 @@ axs_1.plot_surface(
 axs_1.set_xlabel("$x_1$", fontsize=14)
 axs_1.set_ylabel("$x_2$", fontsize=14)
 axs_1.set_zlabel("$\mathcal{M}(x_1, x_2)$", fontsize=14)
-axs_1.set_title("Surface plot of LimPoly", fontsize=14)
+axs_1.set_title("Surface plot of Cheng2D", fontsize=14)
 
 # Contour
 axs_2 = plt.subplot(122)
@@ -64,7 +64,7 @@ cf = axs_2.contourf(
 )
 axs_2.set_xlabel("$x_1$", fontsize=14)
 axs_2.set_ylabel("$x_2$", fontsize=14)
-axs_2.set_title("Contour plot of LimPoly", fontsize=14)
+axs_2.set_title("Contour plot of Cheng2D", fontsize=14)
 divider = make_axes_locatable(axs_2)
 cax = divider.append_axes('right', size='5%', pad=0.05)
 fig.colorbar(cf, cax=cax, orientation='vertical')

--- a/docs/test-functions/sobol-g-star.md
+++ b/docs/test-functions/sobol-g-star.md
@@ -1,0 +1,566 @@
+---
+jupytext:
+  formats: ipynb,md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.14.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+(test-functions:sobol-g-star)=
+# Sobol'-G* Function
+
+The Sobol'-G* function (modified Sobol'-G) is an $M$-dimensional
+scalar-valued function.
+It was introduced in {cite}`Saltelli2010` for testing sensitivity analysis
+methods (further use, see {cite}`Sun2022`).
+
+This function introduces shift and curvature parameters to the original 
+{ref}`Sobol'-G <test-functions:sobol-g>` test function
+{cite}`Saltelli1995`[^modified].
+
+```{code-cell} ipython3
+import numpy as np
+import matplotlib.pyplot as plt
+import uqtestfuns as uqtf
+```
+
+The plots for one-dimensional and two-dimensional Sobol'-G function can be seen
+below.
+
+```{code-cell} ipython3
+:tags: [remove-input]
+
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+# --- Create 1D data from Sobol'-G*
+my_sobolgstar_1d = uqtf.SobolGStar(input_dimension=1)
+rng = np.random.default_rng(42)
+delta = rng.random(1)
+my_sobolgstar_1d.parameters["delta"] = delta
+xx_1d = np.linspace(0, 1, 1000)[:, np.newaxis]
+yy_1d = my_sobolgstar_1d(xx_1d)
+
+# --- Create 2D data from Sobol'-G*
+my_sobolgstar_2d = uqtf.SobolGStar(input_dimension=2)
+delta = rng.random(2)
+my_sobolgstar_2d.parameters["delta"] = delta
+mesh_2d = np.meshgrid(xx_1d, xx_1d)
+xx_2d = np.array(mesh_2d).T.reshape(-1, 2)
+yy_2d = my_sobolgstar_2d(xx_2d)
+
+# --- Create two-dimensional plots
+fig = plt.figure(figsize=(15, 5))
+
+# 1D
+axs_1 = plt.subplot(131)
+axs_1.plot(xx_1d, yy_1d, color="#8da0cb")
+axs_1.grid()
+axs_1.set_xlabel("$x$", fontsize=14)
+axs_1.set_ylabel("$\mathcal{M}(x)$", fontsize=14)
+axs_1.set_title("1D Sobol'-G*")
+
+# Surface
+axs_2 = plt.subplot(132, projection='3d')
+axs_2.plot_surface(
+    mesh_2d[0],
+    mesh_2d[1],
+    yy_2d.reshape(1000, 1000).T,
+    cmap="plasma",
+    linewidth=0,
+    antialiased=False,
+    alpha=0.5
+)
+axs_2.set_xlabel("$x_1$", fontsize=14)
+axs_2.set_ylabel("$x_2$", fontsize=14)
+axs_2.set_zlabel("$\mathcal{M}(x_1, x_2)$", fontsize=14)
+axs_2.set_title("Surface plot of 2D Sobol'-G*", fontsize=14)
+
+# Contour
+axs_3 = plt.subplot(133)
+cf = axs_3.contourf(
+    mesh_2d[0], mesh_2d[1], yy_2d.reshape(1000, 1000).T, cmap="plasma"
+)
+axs_3.set_xlabel("$x_1$", fontsize=14)
+axs_3.set_ylabel("$x_2$", fontsize=14)
+axs_3.set_title("Contour plot of 2D Sobol'-G*", fontsize=14)
+divider = make_axes_locatable(axs_3)
+cax = divider.append_axes('right', size='5%', pad=0.05)
+fig.colorbar(cf, cax=cax, orientation='vertical')
+axs_3.axis('scaled')
+
+fig.tight_layout(pad=3.0)
+plt.gcf().set_dpi(150);
+```
+
+## Test function instance
+
+To create a default instance of the Sobol'-G test* function, type:
+
+```{code-cell} ipython3
+my_testfun = uqtf.SobolGStar()
+```
+
+Check if it has been correctly instantiated:
+
+```{code-cell} ipython3
+print(my_testfun)
+```
+
+By default, the input dimension is set to $2$[^default_dimension].
+To create an instance with another value of input dimension,
+pass an integer to the parameter `input_dimension` (the first parameter).
+For example, to create an instance of the Sobol'-G function in ten dimensions,
+type:
+
+```{code-cell} ipython3
+my_testfun = uqtf.SobolGStar(input_dimension=10)
+```
+
+In the subsequent section, the function will be illustrated
+using ten dimensions as it originally appeared in {cite}`Saltelli2010`.
+
+## Description
+
+The Sobol'-G* function is defined as follows[^location]:
+
+$$
+\mathcal{M}(\boldsymbol{x}; \boldsymbol{a}, \boldsymbol{\delta}, \boldsymbol{\alpha}) = \prod_{m = 1}^M g^*_m(x_i; a_i, \delta_i, \alpha_i)
+$$
+where
+
+$$
+g^*_m(x_i; a_i, \delta_i, \alpha_i) = \frac{(1 + \alpha_i) \lvert 2 (x_i + \delta_i - \lfloor x_i + \delta_i \rfloor) - 1 \rvert^{\alpha_i} + a_i}{1 + a_i}
+$$
+where $\boldsymbol{x} = \{ x_1, \ldots, x_M \}$ is the $M$-dimensional vector
+of input variables further defined below,
+and $\boldsymbol{a}$, $\boldsymbol{\delta}$, and $\boldsymbol{\alpha}$ are the
+parameters of the function further defined below.
+
+## Probabilistic input
+
+The probabilistic input model for the Sobol'-G* function consists of $M$
+independent uniform random variables with the ranges shown in the table below.
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+print(my_testfun.prob_input)
+```
+
+## Parameters
+
+The parameters of the Sobol-G* function (that is, the coefficients
+$\boldsymbol{a}$, the shift parameter $\boldsymbol{\delta}$, and the 
+curvature parameter $\boldsymbol{\alpha}$)
+determine the overall behavior of the function.
+The shift parameter, however, cancels out when moments and Sobol' sensitivity
+indices are computed.
+
+The available parameters for the Sobol'-G* function are shown in the table
+below.
+
+```{table} Parameters of the Sobol'-G* function
+:name: sobol-g-star-parameters
+| No. |                                      $\boldsymbol{a}$                                       |       $\boldsymbol{\delta}$        | $\boldsymbol{\alpha}$ |     Keyword      |                   Source                    |          Remark          |
+|:---:|:-------------------------------------------------------------------------------------------:|:----------------------------------:|:---------------------:|:----------------:|:-------------------------------------------:|:------------------------:|
+| 1.  |                           $a_1 = a_2 = 0$ <br> $a_3 = \ldots = 9$                           | $\delta_i \sim \mathcal{U}[0, 1]$  |   $\alpha_i = 1.0$    | `Saltelli2010-1` | {cite}`Saltelli2010` (Table 5, test case 1) | Low effective dimension  |
+| 2.  | $a_i = 0.1 (i - 1), 1 \leq i \leq 5$ <br> $a_6 = 0.8$ <br> $a_i = (i - 6), 7 \leq i \leq M$ | $\delta_i \sim \mathcal{U}[0, 1]$  |   $\alpha_i = 1.0$    | `Saltelli2010-2` | {cite}`Saltelli2010` (Table 5, test case 2) | High effective dimension |
+| 3.  |                           $a_1 = a_2 = 0$ <br> $a_3 = \ldots = 9$                           | $\delta_i \sim \mathcal{U}[0, 1]$  |   $\alpha_i = 0.5$    | `Saltelli2010-3` | {cite}`Saltelli2010` (Table 5, test case 3) |   Convex version of 1    |
+| 4.  | $a_i = 0.1 (i - 1), 1 \leq i \leq 5$ <br> $a_6 = 0.8$ <br> $a_i = (i - 6), 7 \leq i \leq M$ | $\delta_i \sim \mathcal{U}[0, 1]$  |   $\alpha_i = 0.5$    | `Saltelli2010-4` | {cite}`Saltelli2010` (Table 5, test case 4) |   Convex version of 2    |
+| 5.  |                           $a_1 = a_2 = 0$ <br> $a_3 = \ldots = 9$                           | $\delta_i \sim \mathcal{U}[0, 1]$  |   $\alpha_i = 2.0$    | `Saltelli2010-5` | {cite}`Saltelli2010` (Table 5, test case 5) |   Concave version of 1   |
+| 6.  | $a_i = 0.1 (i - 1), 1 \leq i \leq 5$ <br> $a_6 = 0.8$ <br> $a_i = (i - 6), 7 \leq i \leq M$ | $\delta_i \sim \mathcal{U}[0, 1]$  |   $\alpha_i = 2.0$    | `Saltelli2010-6` | {cite}`Saltelli2010` (Table 5, test case 6) |   Concave version of 2   |
+``` 
+
+The default parameter is shown below.
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+print(my_testfun.parameters)
+```
+
+````{note}
+To create an instance of the Sobol'-G* function with different built-in parameter values, 
+pass the corresponding keyword to the parameter `parameters_id`.
+For example, to use the parameters of test case 2 from {cite}`Saltelli2010`,
+type:
+
+```python
+my_testfun = uqtf.SobolG(parameters_id="Saltelli2010-2")
+```
+````
+
+```{note}
+The parameter $\boldsymbol{\delta}$ is randomly generated
+from a uniform distribution in $[0, 1]^M$ following {cite}`Saltelli2010` when
+an instance of the function is created;
+creating a new instance generates a new set of $\boldsymbol{\delta}$. 
+This parameter cancels out when relevant uncertainty quantification quantities
+of interest are computed (e.g., variance, sensitivity indices).
+
+To have control over the value of $\boldsymbol{\delta}$, you can set the value
+after an instance is created by assigning a set of new values to
+`my_fun.parameters["delta"]`.
+```
+
+## Reference results
+
+This section provides several reference results of typical UQ analyses involving
+the test function.
+
+### Sample histogram
+
+Shown below is the histogram of the output based on $100'000$ random points:
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+np.random.seed(42)
+xx_test = my_testfun.prob_input.get_sample(100000)
+yy_test = my_testfun(xx_test)
+
+plt.hist(yy_test, bins="auto", color="#8da0cb");
+plt.grid();
+plt.ylabel("Counts [-]");
+plt.xlabel("$\mathcal{M}(\mathbf{X})$");
+plt.gcf().set_dpi(150);
+```
+
+### Definite integration
+
+The integral value of the function over the whole domain $[0, 1]^M$
+is analytical:
+
+$$
+\int_{[0, 1]^M} \mathcal{M}(\boldsymbol{x}) \; d\boldsymbol{x} = 1.0.
+$$
+
+### Moments estimation
+
+The mean and variance of the Sobol'-G function can be computed analytically. 
+
+The mean[^integral] is given as follows:
+
+$$
+\mathbb{E}[Y] = 1.0,
+$$
+
+while the variance is given as follows:
+
+$$
+\mathbb{V}[Y] = \prod_{i = 1}^M (1 + V_i) - 1,
+$$
+where
+
+$$
+V_i \equiv \mathbb{V}_{X_i} (\mathbb{E}_{\sim \boldsymbol{X}_i} (Y | X_i)) = \frac{\alpha_i^2}{(1 + 2 \alpha_i) (1 + a_i)^2}.
+$$
+
+Notice that the value of the variance depend on the choice of the parameter values.
+
+Shown below is the convergence of a direct Monte-Carlo estimation of
+the output mean and variance with increasing sample sizes compared with the
+analytical values.
+The error bars corresponds to twice the standard deviation
+of the estimates obtained from $50$ replications.
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+# --- Compute the mean and variance estimate
+np.random.seed(42)
+sample_sizes = np.array([1e1, 1e2, 1e3, 1e4, 1e5, 1e6], dtype=int)
+mean_estimates = np.empty((len(sample_sizes), 50))
+var_estimates = np.empty((len(sample_sizes), 50))
+
+for i, sample_size in enumerate(sample_sizes):
+    for j in range(50):
+        xx_test = my_testfun.prob_input.get_sample(sample_size)
+        yy_test = my_testfun(xx_test)
+        mean_estimates[i, j] = np.mean(yy_test)
+        var_estimates[i, j] = np.var(yy_test)
+
+mean_estimates_errors = np.std(mean_estimates, axis=1)
+var_estimates_errors = np.std(var_estimates, axis=1)
+
+# --- Compute analytical mean and variance
+mean_analytical = 1.0
+aa = my_testfun.parameters["aa"]
+alpha = my_testfun.parameters["alpha"]
+vv = alpha**2 / (1 + 2 * alpha) / (1 + aa)**2
+var_analytical = np.prod(1 + vv) - 1
+
+# --- Plot the mean and variance estimates
+fig, ax_1 = plt.subplots(figsize=(6,4))
+
+ext_sample_sizes = np.insert(sample_sizes, 0, 1)
+ext_sample_sizes = np.insert(ext_sample_sizes, -1, 5e6)
+
+# --- Mean plot
+ax_1.errorbar(
+    sample_sizes,
+    mean_estimates[:,0],
+    yerr=2.0*mean_estimates_errors,
+    marker="o",
+    color="#66c2a5",
+    label="Mean"
+)
+# Plot the analytical mean
+ax_1.plot(
+    ext_sample_sizes,
+    np.repeat(mean_analytical, len(ext_sample_sizes)),
+    linestyle="--",
+    color="#66c2a5",
+    label="Analytical mean",
+)
+ax_1.set_xlim([5, 5e6])
+ax_1.set_xlabel("Sample size")
+ax_1.set_ylabel("Output mean estimate")
+ax_1.set_xscale("log");
+ax_2 = ax_1.twinx()
+
+# --- Variance plot
+ax_2.errorbar(
+    sample_sizes+1,
+    var_estimates[:,0],
+    yerr=2.0*var_estimates_errors,
+    marker="o",
+    color="#fc8d62",
+    label="Variance",
+)
+# Plot the analytical variance
+ax_2.plot(
+    ext_sample_sizes,
+    np.repeat(var_analytical, len(ext_sample_sizes)),
+    linestyle="--",
+    color="#fc8d62",
+    label="Analytical variance",
+)
+ax_2.set_ylabel("Output variance estimate")
+
+# Add the two plots together to have a common legend
+ln_1, labels_1 = ax_1.get_legend_handles_labels()
+ln_2, labels_2 = ax_2.get_legend_handles_labels()
+ax_2.legend(ln_1 + ln_2, labels_1 + labels_2, loc=0)
+
+plt.grid()
+fig.set_dpi(150)
+```
+
+The tabulated results for each sample size is shown below.
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+from tabulate import tabulate
+
+# --- Compile data row-wise
+outputs = [
+    [
+        np.nan,
+        mean_analytical,
+        0.0,
+        var_analytical,
+        0.0,
+        "Analytical",
+    ]
+]
+
+for (
+    sample_size,
+    mean_estimate,
+    mean_estimate_error,
+    var_estimate,
+    var_estimate_error,
+) in zip(
+    sample_sizes,
+    mean_estimates[:,0],
+    2.0*mean_estimates_errors,
+    var_estimates[:,0],
+    2.0*var_estimates_errors,
+):
+    outputs += [
+        [
+            sample_size,
+            mean_estimate,
+            mean_estimate_error,
+            var_estimate,
+            var_estimate_error,
+            "Monte-Carlo",
+        ],
+    ]
+
+header_names = [
+    "Sample size",
+    "Mean",
+    "Mean error",
+    "Variance",
+    "Variance error",
+    "Remark",
+]
+
+tabulate(
+    outputs,
+    numalign="center",
+    stralign="center",
+    tablefmt="html",
+    floatfmt=(".1e", ".4e", ".4e", ".4e", ".4e", "s"),
+    headers=header_names
+)
+```
+
+### Sensitivity indices
+
+The main-effect Sobol' sensitivity indices of the Sobol'-G* function are given
+by the following formula:
+
+$$
+S_i \equiv \frac{V_i}{\mathbb{V}[Y]}, \; i = 1, \ldots, M,
+$$
+
+where
+
+$$
+\mathbb{V}[Y] = \prod_{i = 1}^M (1 + V_i) - 1,
+$$
+
+and
+
+$$
+V_i = \frac{\alpha_i^2}{(1 + 2 \alpha_i) (1 + a_i)^2}.
+$$
+
+The total-effect Sobol' sensitivity indices, on the other hand, are given
+by the following formula:
+
+$$
+ST_i \equiv \frac{VT_i}{\mathbb{V}[Y]}, \; i = 1, \ldots, M,
+$$
+
+where
+
+$$
+VT_i = V_i \prod_{j = 1, j \neq i}^M (1 + V_j).
+$$
+
+Some example values of the Sobol' main- and total-effect sensitivity indices
+for $10$-dimensional Sobol'-G* test function are shown in the table below.
+
+::::{tab-set}
+
+:::{tab-item} Saltelli2010-1
+|  Input   |          $S_i$           |          $ST_i$           |
+|:--------:|:------------------------:|:-------------------------:|
+|  $X_1$   | $4.03677 \times 10^{-1}$ | $5.52758 \times 10^{-1}$  | 
+|  $X_2$   | $4.03677 \times 10^{-1}$ | $5.52758 \times 10^{-1}$  | 
+|  $X_3$   | $4.03677 \times 10^{-3}$ | $7.34562 \times 10^{-3}$  | 
+|  $X_4$   | $4.03677 \times 10^{-3}$ | $7.34562 \times 10^{-3}$  | 
+|  $X_5$   | $4.03677 \times 10^{-3}$ | $7.34562 \times 10^{-3}$  | 
+|  $X_6$   | $4.03677 \times 10^{-3}$ | $7.34562 \times 10^{-3}$  | 
+|  $X_7$   | $4.03677 \times 10^{-3}$ | $7.34562 \times 10^{-3}$  | 
+|  $X_8$   | $4.03677 \times 10^{-3}$ | $7.34562 \times 10^{-3}$  | 
+|  $X_9$   | $4.03677 \times 10^{-3}$ | $7.34562 \times 10^{-3}$  | 
+| $X_{10}$ | $4.03677 \times 10^{-3}$ | $7.34562 \times 10^{-3}$  |
+:::
+
+
+:::{tab-item} Saltelli2010-2
+|  Input   |          $S_i$           |          $ST_i$           |
+|:--------:|:------------------------:|:-------------------------:|
+|  $X_1$   | $1.20759 \times 10^{-1}$ | $3.40569 \times 10^{-1}$  | 
+|  $X_2$   | $9.98008 \times 10^{-2}$ | $2.94228 \times 10^{-1}$  | 
+|  $X_3$   | $8.38604 \times 10^{-2}$ | $2.56067 \times 10^{-1}$  | 
+|  $X_4$   | $7.14550 \times 10^{-2}$ | $2.24428 \times 10^{-1}$  | 
+|  $X_5$   | $6.16117 \times 10^{-2}$ | $1.98005 \times 10^{-1}$  | 
+|  $X_6$   | $3.72713 \times 10^{-2}$ | $1.27078 \times 10^{-1}$  | 
+|  $X_7$   | $3.01897 \times 10^{-2}$ | $1.04791 \times 10^{-1}$  | 
+|  $X_8$   | $1.34177 \times 10^{-2}$ | $4.86527 \times 10^{-2}$  | 
+|  $X_9$   | $7.54743 \times 10^{-3}$ | $2.78016 \times 10^{-2}$  | 
+| $X_{10}$ | $4.83036 \times 10^{-3}$ | $1.79247 \times 10^{-2}$  |
+:::
+
+:::{tab-item} Saltelli2010-3
+|  Input   |          $S_i$           |          $ST_i$           |
+|:--------:|:------------------------:|:-------------------------:|
+|  $X_1$   | $4.49096 \times 10^{-1}$ | $5.10308 \times 10^{-1}$  | 
+|  $X_2$   | $4.49096 \times 10^{-1}$ | $5.10308 \times 10^{-1}$  | 
+|  $X_3$   | $4.49096 \times 10^{-3}$ | $5.73380 \times 10^{-3}$  | 
+|  $X_4$   | $4.49096 \times 10^{-3}$ | $5.73380 \times 10^{-3}$  | 
+|  $X_5$   | $4.49096 \times 10^{-3}$ | $5.73380 \times 10^{-3}$  | 
+|  $X_6$   | $4.49096 \times 10^{-3}$ | $5.73380 \times 10^{-3}$  | 
+|  $X_7$   | $4.49096 \times 10^{-3}$ | $5.73380 \times 10^{-3}$  | 
+|  $X_8$   | $4.49096 \times 10^{-3}$ | $5.73380 \times 10^{-3}$  | 
+|  $X_9$   | $4.49096 \times 10^{-3}$ | $5.73380 \times 10^{-3}$  | 
+| $X_{10}$ | $4.49096 \times 10^{-3}$ | $5.73380 \times 10^{-3}$  |
+:::
+
+:::{tab-item} Saltelli2010-4
+|  Input   |           $S_i$           |          $ST_i$          |
+|:--------:|:-------------------------:|:------------------------:|
+|  $X_1$   | $1.79845 \times 10^{-1}$  | $2.70974 \times 10^{-1}$ | 
+|  $X_2$   | $1.48633 \times 10^{-1}$  | $2.28349 \times 10^{-1}$ | 
+|  $X_3$   | $1.24893 \times 10^{-1}$  | $1.94789 \times 10^{-1}$ | 
+|  $X_4$   | $1.06417 \times 10^{-1}$  | $1.67959 \times 10^{-1}$ | 
+|  $X_5$   | $9.17578 \times 10^{-2}$  | $1.46209 \times 10^{-1}$ | 
+|  $X_6$   | $5.55078 \times 10^{-2}$  | $9.05930 \times 10^{-2}$ | 
+|  $X_7$   | $4.49613 \times 10^{-2}$  | $7.39019 \times 10^{-2}$ | 
+|  $X_8$   | $1.99828 \times 10^{-2}$  | $3.34077 \times 10^{-2}$ | 
+|  $X_9$   | $1.12403 \times 10^{-2}$  | $1.89051 \times 10^{-2}$ | 
+| $X_{10}$ | $7.19381 \times 10^{-3}$  | $1.21331 \times 10^{-2}$ |
+:::
+
+:::{tab-item} Saltelli2010-5
+|  Input   |          $S_i$           |          $ST_i$          |
+|:--------:|:------------------------:|:------------------------:|
+|  $X_1$   | $3.26097 \times 10^{-1}$ | $6.25609 \times 10^{-1}$ | 
+|  $X_2$   | $3.26097 \times 10^{-1}$ | $6.25609 \times 10^{-1}$ | 
+|  $X_3$   | $3.26097 \times 10^{-3}$ | $1.11716 \times 10^{-2}$ | 
+|  $X_4$   | $3.26097 \times 10^{-3}$ | $1.11716 \times 10^{-2}$ | 
+|  $X_5$   | $3.26097 \times 10^{-3}$ | $1.11716 \times 10^{-2}$ | 
+|  $X_6$   | $3.26097 \times 10^{-3}$ | $1.11716 \times 10^{-2}$ | 
+|  $X_7$   | $3.26097 \times 10^{-3}$ | $1.11716 \times 10^{-2}$ | 
+|  $X_8$   | $3.26097 \times 10^{-3}$ | $1.11716 \times 10^{-2}$ | 
+|  $X_9$   | $3.26097 \times 10^{-3}$ | $1.11716 \times 10^{-2}$ | 
+| $X_{10}$ | $3.26097 \times 10^{-3}$ | $1.11716 \times 10^{-2}$ |
+:::
+
+:::{tab-item} Saltelli2010-6
+|  Input   |          $S_i$           |          $ST_i$          |
+|:--------:|:------------------------:|:------------------------:|
+|  $X_1$   | $4.98832 \times 10^{-2}$ | $4.72157 \times 10^{-1}$ | 
+|  $X_2$   | $4.12258 \times 10^{-2}$ | $4.22827 \times 10^{-1}$ | 
+|  $X_3$   | $3.46411 \times 10^{-2}$ | $3.79412 \times 10^{-1}$ | 
+|  $X_4$   | $2.95167 \times 10^{-2}$ | $3.41319 \times 10^{-1}$ | 
+|  $X_5$   | $2.54506 \times 10^{-2}$ | $3.07929 \times 10^{-1}$ | 
+|  $X_6$   | $1.53961 \times 10^{-2}$ | $2.10367 \times 10^{-1}$ | 
+|  $X_7$   | $1.24708 \times 10^{-2}$ | $1.77059 \times 10^{-1}$ | 
+|  $X_8$   | $5.54258 \times 10^{-3}$ | $8.67228 \times 10^{-2}$ | 
+|  $X_9$   | $3.11770 \times 10^{-3}$ | $5.05883 \times 10^{-2}$ | 
+| $X_{10}$ | $1.99533 \times 10^{-3}$ | $3.29412 \times 10^{-2}$ |
+:::
+
+::::
+
+## References
+
+```{bibliography}
+:style: unsrtalpha
+:filter: docname in docnames
+```
+
+[^modified]: In particular, to avoid unfair advantage to a design of experiment
+where the mid-point of the domain is discontinuous in the original formula.
+
+[^location]: see Eqs. (27) and (28), p. 265 in {cite}`Saltelli2010`.
+
+[^integral]: The expected value is the same as the integral over the domain
+because the input is uniform in a unit hypercube.
+
+[^default_dimension]: This default dimension applies to all variable dimension
+test functions. It will be used if the `input_dimension` argument is not given.

--- a/docs/test-functions/sobol-g.md
+++ b/docs/test-functions/sobol-g.md
@@ -230,7 +230,7 @@ and the results are:
 - $\mathbb{E}[Y] = 1.0$[^integral]
 - $\mathbb{V}[Y] = \prod_{m = 1}^{M} \frac{\frac{4}{3} + 2 a_m + a_m^2}{(1 + a_m)^2} - 1$
 
-Notice that the values of these two moments depend on the choice of the parameter values.
+Notice that the value of the variance depends on the choice of the parameter values.
 
 Shown below is the convergence of a direct Monte-Carlo estimation of
 the output mean and variance with increasing sample sizes compared with the

--- a/src/uqtestfuns/test_functions/__init__.py
+++ b/src/uqtestfuns/test_functions/__init__.py
@@ -32,6 +32,7 @@ from .rs_circular_bar import RSCircularBar
 from .rs_quadratic import RSQuadratic
 from .saltelli_linear import SaltelliLinear
 from .sobol_g import SobolG
+from .sobol_g_star import SobolGStar
 from .speed_reducer_shaft import SpeedReducerShaft
 from .sulfur import Sulfur
 from .webster import Webster2D
@@ -88,6 +89,7 @@ __all__ = [
     "RSQuadratic",
     "SaltelliLinear",
     "SobolG",
+    "SobolGStar",
     "SpeedReducerShaft",
     "Sulfur",
     "Webster2D",

--- a/src/uqtestfuns/test_functions/sobol_g_star.py
+++ b/src/uqtestfuns/test_functions/sobol_g_star.py
@@ -1,0 +1,371 @@
+"""
+Module with an implementation of the Modified Sobol-G test function.
+
+The modified Sobol'-G function, often written as Sobol'-G* function,
+is a scalar-valued function in M dimensions.
+It was first introduced in [1] to serve as a test function for sensitivity
+analysis methods.
+This function, which introduces shift and curvature parameters,
+is a modification of the original Sobol'-G test function [2].
+
+The function has found application in the study of sensitivity analysis, e.g.,
+[3].
+
+There are several sets of parameters used in the literature.
+
+References
+----------
+
+1. A. Saltelli, P. Annoni, I. Azzini, F. Campolongo, M. Ratto,
+   and S. Tarantola, “Variance based sensitivity analysis of model output.
+   Design and estimator for the total sensitivity index,”
+   Computer Physics Communications, vol. 181, no. 2, pp. 259–270, 2010.
+   DOI: 10.1016/j.cpc.2009.09.018
+2. A. Saltelli and I. M. Sobol’, “About the use of rank transformation in
+   sensitivity analysis of model output,” Reliability Engineering
+   & System Safety, vol. 50, no. 3, pp. 225–239, 1995.
+   DOI: 10.1016/0951-8320(95)00099-2.
+3. X. Sun, B. Croke, A. Jakeman, S. Roberts, "Benchmarking Active Subspace
+   methods of global sensitivity analysis against variance-based Sobol’
+   and Morris methods with established test functions," Environmental Modelling
+   & Software, vol. 149, p. 105310, 2022.
+   DOI: 10.1016/j.envsoft.2022.105310
+"""
+
+import numpy as np
+
+from uqtestfuns.core.custom_typing import ProbInputSpecs, FunParamSpecs
+from uqtestfuns.core.uqtestfun_abc import UQTestFunVarDimABC
+
+__all__ = ["SobolGStar"]
+
+
+AVAILABLE_INPUTS: ProbInputSpecs = {
+    "Saltelli2010": {
+        "function_id": "SobolGStar",
+        "description": (
+            "Probabilistic input model for the Sobol'-G* function "
+            "from Saltelli et al. (2010)"
+        ),
+        "marginals": [
+            {
+                "name": "X",
+                "distribution": "uniform",
+                "parameters": [0.0, 1.0],
+                "description": None,
+            },
+        ],
+        "copulas": None,
+    },
+}
+
+
+def _get_aa_saltelli_2010_a(input_dimension: int) -> np.ndarray:
+    """Construct a coefficients array for the Sobol'-G* function from [1].
+
+    Notes
+    -----
+    - This value is used in test case 1, 3, and 5 (see Table 5 in [1]).
+    - In [1], an input dimension of 10 was used. If the input dimension is less
+      than 10, the parameters array is truncated; if the input dimension exceed
+      10, the parameters are is extrapolated.
+    - With the selected parameters, the function is of low effective dimension.
+    """
+    aa = 9 * np.ones(input_dimension)
+    aa[:2] = 0
+
+    return aa
+
+
+def _get_aa_saltelli_2010_b(input_dimension: int) -> np.ndarray:
+    """Construct a coefficients array for the Sobol'-G* function from [1].
+
+    Notes
+    -----
+    - This value is used in test case 2, 5, and 6 (see Table 5 in [1]).
+    - In [1], an input dimension of 10 was used. If the input dimension is less
+      than 10, the parameters array is truncated; if the input dimension exceed
+      10, the parameters are is extrapolated.
+    """
+    aa = np.array([0.0, 0.1, 0.2, 0.3, 0.4, 0.8, 1, 2, 3, 4])
+
+    if input_dimension > 10:
+        aa_ext = np.arange(5, input_dimension - 5)
+        aa = np.append(aa, aa_ext)
+
+    return aa[:input_dimension]
+
+
+def _get_alpha_saltelli_2010_a(input_dimension: int) -> np.ndarray:
+    """Construct an alpha array for the Sobol'-G* function from [1].
+
+    Notes
+    -----
+    - This value is used in test case 1 and 2 (see Table 5 in [1]).
+    - In [1], an input dimension of 10 was used. If the input dimension is less
+      than 10, the parameters array is truncated; if the input dimension exceed
+      10, the parameters are is extrapolated.
+    """
+    alpha = np.ones(input_dimension)
+
+    return alpha
+
+
+def _get_alpha_saltelli_2010_b(input_dimension: int) -> np.ndarray:
+    """Construct an alpha array for the Sobol'-G* function from [1].
+
+    Notes
+    -----
+    - This value is used in test case 3 and 4 (see Table 5 in [1]).
+    - In [1], an input dimension of 10 was used. If the input dimension is less
+      than 10, the parameters array is truncated; if the input dimension exceed
+      10, the parameters are is extrapolated.
+    """
+    alpha = 0.5 * np.ones(input_dimension)
+
+    return alpha
+
+
+def _get_alpha_saltelli_2010_c(input_dimension: int) -> np.ndarray:
+    """Construct an alpha array for the Sobol'-G* function from [1].
+
+    Notes
+    -----
+    - This value is used in test case 5 and 6 (see Table 5 in [1]).
+    - In [1], an input dimension of 10 was used. If the input dimension is less
+      than 10, the parameters array is truncated; if the input dimension exceed
+      10, the parameters are is extrapolated.
+    """
+    alpha = 2 * np.ones(input_dimension)
+
+    return alpha
+
+
+def _get_delta_saltelli_2010(input_dimension: int) -> np.ndarray:
+    """Construct a delta array for the Sobol'-G* function from [1].
+
+    The parameter delta (shift parameter) is randomly generated
+    from a uniform distribution in [0, 1].
+    """
+    rng = np.random.default_rng()
+    delta = rng.random(input_dimension)
+
+    return delta
+
+
+AVAILABLE_PARAMETERS: FunParamSpecs = {
+    "Saltelli2010-1": {
+        "function_id": "SobolGStar",
+        "description": (
+            "Parameter set for the Sobol-G* function from Saltelli et al."
+            "(2010), test case 1; low-effective dimension, easier than "
+            "test case 2"
+        ),
+        "declared_parameters": [
+            {
+                "keyword": "aa",
+                "value": _get_aa_saltelli_2010_a,
+                "type": np.ndarray,
+                "description": "Coefficients 'a'",
+            },
+            {
+                "keyword": "delta",
+                "value": _get_delta_saltelli_2010,
+                "type": np.ndarray,
+                "description": "Shift parameter",
+            },
+            {
+                "keyword": "alpha",
+                "value": _get_alpha_saltelli_2010_a,
+                "type": np.ndarray,
+                "description": "Curvature parameter",
+            },
+        ],
+    },
+    "Saltelli2010-2": {
+        "function_id": "SobolGStar",
+        "description": (
+            "Parameter set for the Sobol-G* function from Saltelli et al. "
+            "(2010), test case 2; high-effective dimension, more difficult "
+            "than test case 1"
+        ),
+        "declared_parameters": [
+            {
+                "keyword": "aa",
+                "value": _get_aa_saltelli_2010_b,
+                "type": np.ndarray,
+                "description": "Coefficients 'a'",
+            },
+            {
+                "keyword": "delta",
+                "value": _get_delta_saltelli_2010,
+                "type": np.ndarray,
+                "description": "Shift parameter",
+            },
+            {
+                "keyword": "alpha",
+                "value": _get_alpha_saltelli_2010_a,
+                "type": np.ndarray,
+                "description": "Curvature parameter",
+            },
+        ],
+    },
+    "Saltelli2010-3": {
+        "function_id": "SobolGStar",
+        "description": (
+            "Parameter set for the Sobol-G* function from Saltelli et al. "
+            "(2010), test case 3; concave version of test case 1"
+        ),
+        "declared_parameters": [
+            {
+                "keyword": "aa",
+                "value": _get_aa_saltelli_2010_a,
+                "type": np.ndarray,
+                "description": "Coefficients 'a'",
+            },
+            {
+                "keyword": "delta",
+                "value": _get_delta_saltelli_2010,
+                "type": np.ndarray,
+                "description": "Shift parameter",
+            },
+            {
+                "keyword": "alpha",
+                "value": _get_alpha_saltelli_2010_b,
+                "type": np.ndarray,
+                "description": "Curvature parameter",
+            },
+        ],
+    },
+    "Saltelli2010-4": {
+        "function_id": "SobolGStar",
+        "description": (
+            "Parameter set for the Sobol-G* function from Saltelli et al. "
+            "(2010), test case 4; concave version of test case 2"
+        ),
+        "declared_parameters": [
+            {
+                "keyword": "aa",
+                "value": _get_aa_saltelli_2010_b,
+                "type": np.ndarray,
+                "description": "Coefficients 'a'",
+            },
+            {
+                "keyword": "delta",
+                "value": _get_delta_saltelli_2010,
+                "type": np.ndarray,
+                "description": "Shift parameter",
+            },
+            {
+                "keyword": "alpha",
+                "value": _get_alpha_saltelli_2010_b,
+                "type": np.ndarray,
+                "description": "Curvature parameter",
+            },
+        ],
+    },
+    "Saltelli2010-5": {
+        "function_id": "SobolGStar",
+        "description": (
+            "Parameter set for the Sobol-G* function from Saltelli et al. "
+            "(2010), test case 5; convex version of test case 1"
+        ),
+        "declared_parameters": [
+            {
+                "keyword": "aa",
+                "value": _get_aa_saltelli_2010_a,
+                "type": np.ndarray,
+                "description": "Coefficients 'a'",
+            },
+            {
+                "keyword": "delta",
+                "value": _get_delta_saltelli_2010,
+                "type": np.ndarray,
+                "description": "Shift parameter",
+            },
+            {
+                "keyword": "alpha",
+                "value": _get_alpha_saltelli_2010_c,
+                "type": np.ndarray,
+                "description": "Curvature parameter",
+            },
+        ],
+    },
+    "Saltelli2010-6": {
+        "function_id": "SobolGStar",
+        "description": (
+            "Parameter set for the Sobol-G* function from Saltelli et al. "
+            "(2010), test case 6; convex version of test case 2"
+        ),
+        "declared_parameters": [
+            {
+                "keyword": "aa",
+                "value": _get_aa_saltelli_2010_b,
+                "type": np.ndarray,
+                "description": "Coefficients 'a'",
+            },
+            {
+                "keyword": "delta",
+                "value": _get_delta_saltelli_2010,
+                "type": np.ndarray,
+                "description": "Shift parameter",
+            },
+            {
+                "keyword": "alpha",
+                "value": _get_alpha_saltelli_2010_c,
+                "type": np.ndarray,
+                "description": "Curvature parameter",
+            },
+        ],
+    },
+}
+
+DEFAULT_PARAMETERS_SELECTION = "Saltelli2010-1"
+
+
+def evaluate(
+    xx: np.ndarray,
+    aa: np.ndarray,
+    delta: np.ndarray,
+    alpha: np.ndarray,
+) -> np.ndarray:
+    """Evaluate the modified Sobol-G function on a set of input values.
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        M-Dimensional input values given by an N-by-M array where
+        N is the number of input values.
+    aa : np.ndarray
+        The vector of parameters (i.e., coefficients) of the modified Sobol'-G
+        function; the length of the vector is the same as the number
+        of input dimensions.
+    delta: np.ndarray
+        The vector of shift parameters of length M.
+    alpha: np.ndarray
+        The vector of curvature parameters of length M.
+
+    Returns
+    -------
+    np.ndarray
+        The output of the test function evaluated on the input values.
+        The output is a 1-dimensional array of length N.
+    """
+    term = np.abs(2 * (xx + delta - np.floor(xx + delta)) - 1) ** alpha
+    g_star = ((1 + alpha) * term + aa) / (1 + aa)
+
+    yy = np.prod(g_star, axis=1)
+
+    return yy
+
+
+class SobolGStar(UQTestFunVarDimABC):
+    """An implementation of the M-dimensional Sobol'-G* test function."""
+
+    _tags = ["sensitivity"]
+    _description = "Sobol'-G* function from Saltelli et al. (2010)"
+    _available_inputs = AVAILABLE_INPUTS
+    _available_parameters = AVAILABLE_PARAMETERS
+    _default_parameters_id = DEFAULT_PARAMETERS_SELECTION
+
+    evaluate = staticmethod(evaluate)  # type: ignore


### PR DESCRIPTION
The modified Sobol'-G (or Sobol'-G*) test function is now added to the code base.
The M-dimensional test function from Saltelli et al. (2010) is typically used in sensitivity analysis exercises.

This PR should resolve Issue #357.