### PR TITLE
Add Morris2006 test function for sensitivity analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The M-dimensional test function from Morris et al. (2006) for sensitivity
+  analysis exercises.
 - The modified Sobol'-G test function (i.e., Sobol'-G*) from Saltelli et al.
   (2010) for sensitivity analysis exercises.
 - The two-dimensional test function from Cheng and Sandu (2010)

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -109,6 +109,8 @@ parts:
             title: McLain S5
           - file: test-functions/moon3d
             title: Moon (2010) 3D
+          - file: test-functions/morris2006
+            title: Morris et al. (2006)
           - file: test-functions/oakley-1d
             title: Oakley & O'Hagan (2002) 1D
           - file: test-functions/otl-circuit

--- a/docs/fundamentals/sensitivity.md
+++ b/docs/fundamentals/sensitivity.md
@@ -17,27 +17,28 @@ kernelspec:
 The table below listed the available test functions typically used
 in the comparison of sensitivity analysis methods.
 
-|                                   Name                                   | Input Dimension |     Constructor      |
-|:------------------------------------------------------------------------:|:---------------:|:--------------------:|
-|                {ref}`Borehole <test-functions:borehole>`                 |        8        |     `Borehole()`     |
-|       {ref}`Bratley et al. (1992) A <test-functions:bratley1992a>`       |        M        |   `Bratley1992a()`   |
-|       {ref}`Bratley et al. (1992) B <test-functions:bratley1992b>`       |        M        |   `Bratley1992b()`   |
-|       {ref}`Bratley et al. (1992) C <test-functions:bratley1992c>`       |        M        |   `Bratley1992c()`   |
-|       {ref}`Bratley et al. (1992) D <test-functions:bratley1992d>`       |        M        |   `Bratley1992d()`   |
-|       {ref}`Damped Oscillator <test-functions:damped-oscillator>`        |        7        | `DampedOscillator()` |
-|                   {ref}`Flood <test-functions:flood>`                    |        8        |      `Flood()`       |
-|            {ref}`Friedman (6D) <test-functions:friedman-6d>`             |        6        |    `Friedman6D()`    |
-|                {ref}`Ishigami <test-functions:ishigami>`                 |        3        |     `Ishigami()`     |
-|              {ref}`Moon (2010) 3D <test-functions:moon3d>`               |        3        |      `Moon3D()`      |
-|             {ref}`OTL Circuit <test-functions:otl-circuit>`              |     6 / 20      |    `OTLCircuit()`    |
-|             {ref}`Piston Simulation <test-functions:piston>`             |     7 / 20      |      `Piston()`      |
-|       {ref}`Simple Portfolio Model <test-functions:portfolio-3d>`        |        3        |   `Portfolio3D()`    |
-|          {ref}`SaltelliLinear <test-functions:saltelli-linear>`          |        M        |  `SaltelliLinear()`  |
-|                 {ref}`Sobol'-G <test-functions:sobol-g>`                 |        M        |      `SobolG()`      |
-|              {ref}`Sobol'-G* <test-functions:sobol-g-star>`              |        M        |    `SobolGStar()`    |
-|                  {ref}`Sulfur <test-functions:sulfur>`                   |        9        |      `Sulfur()`      |
-|          {ref}`Welch et al. (1992) <test-functions:welch1992>`           |       20        |    `Welch1992()`     |
-|             {ref}`Wing Weight <test-functions:wing-weight>`              |       10        |    `WingWeight()`    |
+|                             Name                             | Input Dimension |     Constructor      |
+|:------------------------------------------------------------:|:---------------:|:--------------------:|
+|          {ref}`Borehole <test-functions:borehole>`           |        8        |     `Borehole()`     |
+| {ref}`Bratley et al. (1992) A <test-functions:bratley1992a>` |        M        |   `Bratley1992a()`   |
+| {ref}`Bratley et al. (1992) B <test-functions:bratley1992b>` |        M        |   `Bratley1992b()`   |
+| {ref}`Bratley et al. (1992) C <test-functions:bratley1992c>` |        M        |   `Bratley1992c()`   |
+| {ref}`Bratley et al. (1992) D <test-functions:bratley1992d>` |        M        |   `Bratley1992d()`   |
+| {ref}`Damped Oscillator <test-functions:damped-oscillator>`  |        7        | `DampedOscillator()` |
+|             {ref}`Flood <test-functions:flood>`              |        8        |      `Flood()`       |
+|      {ref}`Friedman (6D) <test-functions:friedman-6d>`       |        6        |    `Friedman6D()`    |
+|          {ref}`Ishigami <test-functions:ishigami>`           |        3        |     `Ishigami()`     |
+|        {ref}`Moon (2010) 3D <test-functions:moon3d>`         |        3        |      `Moon3D()`      |
+|   {ref}`Morris et al. (2006) <test-functions:morris2006>`    |        M        |    `Morris2006()`    |
+|       {ref}`OTL Circuit <test-functions:otl-circuit>`        |     6 / 20      |    `OTLCircuit()`    |
+|       {ref}`Piston Simulation <test-functions:piston>`       |     7 / 20      |      `Piston()`      |
+| {ref}`Simple Portfolio Model <test-functions:portfolio-3d>`  |        3        |   `Portfolio3D()`    |
+|    {ref}`SaltelliLinear <test-functions:saltelli-linear>`    |        M        |  `SaltelliLinear()`  |
+|           {ref}`Sobol'-G <test-functions:sobol-g>`           |        M        |      `SobolG()`      |
+|        {ref}`Sobol'-G* <test-functions:sobol-g-star>`        |        M        |    `SobolGStar()`    |
+|            {ref}`Sulfur <test-functions:sulfur>`             |        9        |      `Sulfur()`      |
+|    {ref}`Welch et al. (1992) <test-functions:welch1992>`     |       20        |    `Welch1992()`     |
+|       {ref}`Wing Weight <test-functions:wing-weight>`        |       10        |    `WingWeight()`    |
 
 In a Python terminal, you can list all the available functions relevant
 for metamodeling applications using ``list_functions()`` and filter the results

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -845,4 +845,15 @@ An orthogonal design in which the design matrix has uncorrelated columns is impo
   doi       = {10.1145/1878537.1878621},
 }
 
+@Article{Morris2006,
+  author  = {Morris, Max D. and Moore, Leslie M. and McKay, Michael D.},
+  journal = {Journal of Statistical Planning and Inference},
+  title   = {Sampling plans based on balanced incomplete block designs for evaluating the importance of computer model inputs},
+  year    = {2006},
+  number  = {9},
+  pages   = {3203--3220},
+  volume  = {136},
+  doi     = {10.1016/j.jspi.2005.01.001},
+}
+
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/docs/test-functions/available.md
+++ b/docs/test-functions/available.md
@@ -59,6 +59,7 @@ regardless of their typical applications.
 |                     {ref}`McLain S4 <test-functions:mclain-s4>`                     |        2        |          `McLainS4()`           |
 |                     {ref}`McLain S5 <test-functions:mclain-s5>`                     |        2        |          `McLainS5()`           |
 |                    {ref}`Moon (2010) 3D <test-functions:moon3d>`                    |        3        |           `Moon3D()`            |
+|               {ref}`Morris et al. (2006) <test-functions:morris2006>`               |        M        |         `Morris2006()`          |
 |            {ref}`Oakley & O'Hagan (2002) 1D <test-functions:oakley-1d>`             |        1        |          `Oakley1D()`           |
 |                   {ref}`OTL Circuit <test-functions:otl-circuit>`                   |     6 / 20      |         `OTLCircuit()`          |
 |                  {ref}`Piston Simulation <test-functions:piston>`                   |     7 / 20      |           `Piston()`            |

--- a/docs/test-functions/morris2006.md
+++ b/docs/test-functions/morris2006.md
@@ -218,8 +218,8 @@ such that the following conditions are satisfied:
 
 $$
 \begin{aligned}
-S_i \times \mathbb{V}[Y]  & = 1.0, & i = 1, \ldots, p \\
-S_i & = 0.0, & i = p + 1, \ldots, M,
+S_i \times \mathbb{V}[Y]  & = 1.0, & i & = 1, \ldots, p, \\
+S_i                       & = 0.0, & i &  = p + 1, \ldots, M,
 \end{aligned}
 $$
 
@@ -227,8 +227,8 @@ and
 
 $$
 \begin{aligned}
-ST_i \times \mathbb{V}[Y] & = 1.1 & i = 1, \ldots, p \\
-ST_i & = 0.0, & i = p + 1, \ldots, M,
+ST_i \times \mathbb{V}[Y] & = 1.1 & i & = 1, \ldots, p, \\
+ST_i & = 0.0, & i & = p + 1, \ldots, M,
 \end{aligned}
 $$
 

--- a/docs/test-functions/morris2006.md
+++ b/docs/test-functions/morris2006.md
@@ -1,0 +1,248 @@
+---
+jupytext:
+  formats: ipynb,md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.14.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+(test-functions:morris2006)=
+# Test Function from Morris et al. (2006)
+
+The test function from Morris et al. (2006) {cite}`Morris2006`
+(or  `Morris2006` for short) is an $M$-dimensional scalar-valued function used
+in the context of sensitivity analysis
+{cite}`Morris2006, Horiguchi2021, Sun2022`.
+
+The function features a parameter that controls the number of important input
+variables; the remaining variables, if any, are inert. Furthermore, the Sobol'
+main-effect and total-effect sensitivity indices are the same for each input
+variable.
+
+```{code-cell} ipython3
+import numpy as np
+import matplotlib.pyplot as plt
+import uqtestfuns as uqtf
+```
+
+The plots for one-dimensional and two-dimensional `Morris2006` function
+can be seen below.
+
+```{code-cell} ipython3
+:tags: [remove-input]
+
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+# --- Create 1D data
+my_fun_1d = uqtf.Morris2006(input_dimension=1)
+xx_1d = np.linspace(0, 1, 1000)[:, np.newaxis]
+yy_1d = my_fun_1d(xx_1d)
+
+# --- Create 2D data
+my_fun_2d = uqtf.Morris2006(input_dimension=2)
+mesh_2d = np.meshgrid(xx_1d, xx_1d)
+xx_2d = np.array(mesh_2d).T.reshape(-1, 2)
+yy_2d = my_fun_2d(xx_2d)
+
+# --- Create two-dimensional plots
+fig = plt.figure(figsize=(15, 5))
+
+# 1D
+axs_1 = plt.subplot(131)
+axs_1.plot(xx_1d, yy_1d, color="#8da0cb")
+axs_1.grid()
+axs_1.set_xlabel("$x$", fontsize=14)
+axs_1.set_ylabel("$\mathcal{M}(x)$", fontsize=14)
+axs_1.set_title("1D Morris2006")
+
+# Surface
+axs_2 = plt.subplot(132, projection='3d')
+axs_2.plot_surface(
+    mesh_2d[0],
+    mesh_2d[1],
+    yy_2d.reshape(1000, 1000).T,
+    cmap="plasma",
+    linewidth=0,
+    antialiased=False,
+    alpha=0.5
+)
+axs_2.set_xlabel("$x_1$", fontsize=14)
+axs_2.set_ylabel("$x_2$", fontsize=14)
+axs_2.set_zlabel("$\mathcal{M}(x_1, x_2)$", fontsize=14)
+axs_2.set_title("Surface plot of 2D Morris2006", fontsize=14)
+
+# Contour
+axs_3 = plt.subplot(133)
+cf = axs_3.contourf(
+    mesh_2d[0], mesh_2d[1], yy_2d.reshape(1000, 1000).T, cmap="plasma"
+)
+axs_3.set_xlabel("$x_1$", fontsize=14)
+axs_3.set_ylabel("$x_2$", fontsize=14)
+axs_3.set_title("Contour plot of 2D Morris2006", fontsize=14)
+divider = make_axes_locatable(axs_3)
+cax = divider.append_axes('right', size='5%', pad=0.05)
+fig.colorbar(cf, cax=cax, orientation='vertical')
+axs_3.axis('scaled')
+
+fig.tight_layout(pad=3.0)
+plt.gcf().set_dpi(150);
+```
+
+## Test function instance
+
+To create a default instance of the function, type:
+
+```{code-cell} ipython3
+my_testfun = uqtf.Morris2006()
+```
+
+Check if it has been correctly instantiated:
+
+```{code-cell} ipython3
+print(my_testfun)
+```
+
+By default, the input dimension is set to $2$[^default_dimension].
+To create an instance with another value of input dimension,
+pass an integer to the parameter `input_dimension` (the first parameter).
+For example, to create an instance of the function in 30 dimensions,
+type:
+
+```{code-cell} ipython3
+my_testfun = uqtf.Morris2006(input_dimension=30)
+```
+
+In the subsequent section, the function will be illustrated
+using 30 dimensions as it originally appeared in {cite}`Morris2006`.
+
+## Description
+
+The `Morris2006` function is defined as follows[^location]:
+
+$$
+\mathcal{M}(\boldsymbol{x}; p) = \alpha(p) \sum_{i = 1}^p x_p + \beta(p) \sum_{i = 1}^{p - 1} x_i \left( \sum_{j = i + 1}^p x_j \right),
+$$
+where
+
+$$
+\alpha(p) = \sqrt{12} - 6 \sqrt{0.1 (p - 1)}
+$$
+
+and
+
+$$
+\beta(p) = \frac{12}{\sqrt{10 (p - 1)}}.
+$$
+
+where $\boldsymbol{x} = \{ x_1, \ldots, x_M \}$ is the $M$-dimensional vector
+of input variables further defined below,
+and $p$ is the parameter of the function.
+
+```{important}
+The original formula for $\beta$ in {cite}`Morris2006` contains an error.
+The formula given, $12 \sqrt{0.1} \sqrt{p - 1}$, fails to meet the specified
+condition for the function, where the products of the main-effect
+and total-effect indices with the variance should yield values $1.0$ and $1.1$,
+respectively.
+```
+
+## Probabilistic input
+
+The probabilistic input model for the `Morris2006` function consists of $M$
+independent uniform random variables in $[0.0, 1.0]^M$. 
+
+For the selected input dimension, the input model is shown below.
+
+```{code-cell} ipython3
+:tags: [hide-input, "output_scroll"]
+
+print(my_testfun.prob_input)
+```
+
+## Parameters
+
+The parameter $p$ of the test function controls the number of important input
+variables; if this number is larger than the actual number of input dimensions,
+then all input variables are deemed important.
+
+The default parameter is shown below.
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+print(my_testfun.parameters)
+```
+
+````{note}
+You can replace the default value of the parameter by assigning a new value
+to it as follows:
+
+```python
+my_testfun.parameters["p"] = 5
+```
+````
+
+## Reference results
+
+This section provides several reference results of typical UQ analyses
+involving the test function.
+
+### Sample histogram
+
+Shown below is the histogram of the output based on $100'000$ random points:
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+np.random.seed(42)
+xx_test = my_testfun.prob_input.get_sample(100000)
+yy_test = my_testfun(xx_test)
+
+plt.hist(yy_test, bins="auto", color="#8da0cb");
+plt.grid();
+plt.ylabel("Counts [-]");
+plt.xlabel("$\mathcal{M}(\mathbf{X})$");
+plt.gcf().set_dpi(150);
+```
+
+### Sensitivity indices
+
+The values of $p$, $\alpha$ ,and $\beta$ in the above equation are chosen
+such that the following conditions are satisfied:
+
+$$
+\begin{aligned}
+S_i \times \mathbb{V}[Y]  & = 1.0, & i = 1, \ldots, p \\
+S_i & = 0.0, & i = p + 1, \ldots, M,
+\end{aligned}
+$$
+
+and
+
+$$
+\begin{aligned}
+ST_i \times \mathbb{V}[Y] & = 1.1 & i = 1, \ldots, p \\
+ST_i & = 0.0, & i = p + 1, \ldots, M,
+\end{aligned}
+$$
+
+where $S_i$ and $ST_i$ are the main-effect and total-effect indices for $i$-th
+input variable; and $\mathbb{V}[Y]$ is the output variance.
+
+## References
+
+```{bibliography}
+:style: unsrtalpha
+:filter: docname in docnames
+```
+
+[^location]: see Section 4, p. 3213 in {cite}`Morris2006`.
+
+[^default_dimension]: This default dimension applies to all variable dimension
+test functions. It will be used if the `input_dimension` argument is not given.

--- a/src/uqtestfuns/test_functions/__init__.py
+++ b/src/uqtestfuns/test_functions/__init__.py
@@ -26,6 +26,7 @@ from .oakley2002 import Oakley1D
 from .otl_circuit import OTLCircuit
 from .mclain import McLainS1, McLainS2, McLainS3, McLainS4, McLainS5
 from .moon3d import Moon3D
+from .morris2006 import Morris2006
 from .piston import Piston
 from .portfolio_3d import Portfolio3D
 from .rs_circular_bar import RSCircularBar
@@ -83,6 +84,7 @@ __all__ = [
     "McLainS4",
     "McLainS5",
     "Moon3D",
+    "Morris2006",
     "Piston",
     "Portfolio3D",
     "RSCircularBar",

--- a/src/uqtestfuns/test_functions/morris2006.py
+++ b/src/uqtestfuns/test_functions/morris2006.py
@@ -1,0 +1,128 @@
+"""
+This module implements the Morris function from Morris et al. (2006).
+
+The Morris function is an M-dimensional, scalar-valued function commonly used
+as a test function for sensitivity analysis.
+It was first appeared in [1] and it has been revisited multiple times in the
+literature in similar contexts, e.g., [2], [3].
+
+The function features a parameter that dictates the number of important
+input variables. The remaining input variables are inert. Furthermore,
+all sensitivity indices of the important variables have
+the same Sobol' sensitivity indices.
+
+References
+----------
+
+1. M. D. Morris, L. M. Moore, and M. D. McKay, “Sampling plans based on
+   balanced incomplete block designs for evaluating the importance of
+   computer model inputs,” Journal of Statistical Planning and Inference,
+   vol. 136, no. 9, pp. 3203–3220, 2006.
+   DOI: 10.1016/j.jspi.2005.01.001
+2. X. Sun, B. Croke, A. Jakeman, S. Roberts, "Benchmarking Active Subspace
+   methods of global sensitivity analysis against variance-based Sobol’
+   and Morris methods with established test functions," Environmental Modelling
+   & Software, vol. 149, p. 105310, 2022.
+   DOI: 10.1016/j.envsoft.2022.105310
+3. A. Horiguchi, M. T. Pratola, and T. J. Santner, “Assessing variable activity
+   for Bayesian regression trees,” Reliability Engineering & System Safety,
+   vol. 207, p. 107391, 2021,
+   DOI: 10.1016/j.ress.2020.107391
+"""
+
+import numpy as np
+
+from uqtestfuns.core.custom_typing import FunParamSpecs, ProbInputSpecs
+from uqtestfuns.core.uqtestfun_abc import UQTestFunVarDimABC
+
+__all__ = ["Morris2006"]
+
+
+AVAILABLE_INPUTS: ProbInputSpecs = {
+    "Morris2006": {
+        "function_id": "Morris2006",
+        "description": (
+            "Probabilistic input model for the M-dimensional function "
+            "from Morris et al. (2006)"
+        ),
+        "marginals": [
+            {
+                "name": "X",
+                "distribution": "uniform",
+                "parameters": [0.0, 1.0],
+                "description": None,
+            }
+        ],
+        "copulas": None,
+    },
+}
+
+
+AVAILABLE_PARAMETERS: FunParamSpecs = {
+    "Morris2006": {
+        "function_id": "Morris2006",
+        "description": (
+            "Parameter set for the M-dimensional function from "
+            "Morris et al. (2006); the parameter controls the number of"
+            "important input variables"
+        ),
+        "declared_parameters": [
+            {
+                "keyword": "p",
+                "value": 10,
+                "type": int,
+                "description": "# of important inputs"
+            }
+        ]
+    }
+}
+
+
+def evaluate(xx: np.ndarray, p: int) -> np.ndarray:
+    """Evaluate the Morris2006 test function.
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        M-Dimensional input values given by an N-by-M array where
+        N is the number of input values.
+    p : int
+        The number of important input variables. If p > M then p is set
+        equal to M.
+
+    Returns
+    -------
+    np.ndarray
+        The output of the test function evaluated on the input values.
+        The output is a 1-dimensional array of length N.
+    """
+    input_dim = xx.shape[1]
+    if p > input_dim:
+        p = input_dim
+
+    alpha = np.sqrt(12) - 6 * np.sqrt(0.1 * (p - 1))
+
+    term_1 = alpha * np.sum(xx[:, :p], axis=1)
+    if p == 1:
+        return term_1
+
+    beta = 12 / np.sqrt(10 * (p - 1))
+    term_2 = np.zeros(len(xx))
+    for i in range(p - 1):
+        term_2[:] += xx[:, i] * np.sum(xx[:, (i+1):p], axis=1)
+    term_2 *= beta
+
+    yy = term_1 + term_2
+
+    return yy
+
+
+class Morris2006(UQTestFunVarDimABC):
+    """An implementation of the M-dimensional Morris2006."""
+
+    _tags = ["sensitivity"]
+    _description = "Test function from Morris et al. (2006)"
+    _available_inputs = AVAILABLE_INPUTS
+    _available_parameters = AVAILABLE_PARAMETERS
+
+    evaluate = staticmethod(evaluate)  # type: ignore

--- a/src/uqtestfuns/test_functions/morris2006.py
+++ b/src/uqtestfuns/test_functions/morris2006.py
@@ -51,7 +51,7 @@ AVAILABLE_INPUTS: ProbInputSpecs = {
                 "distribution": "uniform",
                 "parameters": [0.0, 1.0],
                 "description": None,
-            }
+            },
         ],
         "copulas": None,
     },
@@ -71,9 +71,9 @@ AVAILABLE_PARAMETERS: FunParamSpecs = {
                 "keyword": "p",
                 "value": 10,
                 "type": int,
-                "description": "# of important inputs"
-            }
-        ]
+                "description": "# of important inputs",
+            },
+        ],
     }
 }
 
@@ -109,7 +109,8 @@ def evaluate(xx: np.ndarray, p: int) -> np.ndarray:
     beta = 12 / np.sqrt(10 * (p - 1))
     term_2 = np.zeros(len(xx))
     for i in range(p - 1):
-        term_2[:] += xx[:, i] * np.sum(xx[:, (i+1):p], axis=1)
+        ip1 = i + 1
+        term_2[:] += xx[:, i] * np.sum(xx[:, ip1:p], axis=1)
     term_2 *= beta
 
     yy = term_1 + term_2

--- a/tests/builtin_test_functions/test_morris2006.py
+++ b/tests/builtin_test_functions/test_morris2006.py
@@ -1,0 +1,72 @@
+"""
+Test module for the Morris2006 test function.
+
+Notes
+-----
+- The tests defined in this module deals with the correctness
+  of the evaluation of this particular test function.
+"""
+
+import numpy as np
+
+from uqtestfuns.test_functions import Morris2006
+
+
+def test_p_larger_than_m():
+    """Test if the parameter p is larger than the number of input dim."""
+    # Create an instance
+    fun = Morris2006(input_dimension=3)
+    fun.parameters["p"] = 3
+
+    # Generate sample
+    num_sample = 1000000
+    xx = fun.prob_input.get_sample(num_sample)
+
+    yy_1 = fun(xx)
+
+    # Replace the parameter value
+    fun.parameters["p"] = 4
+    yy_2 = fun(xx)
+
+    assert np.array_equal(yy_1, yy_2)
+
+
+def test_one_dimension():
+    """Test for one-dimensional function.
+
+    Notes
+    -----
+    - Normally Morris2006 function requires more than 1 input dimension,
+      but safeguard is in place to allow the computation of one-dimensional
+      Morris2006 function.
+    """
+    # Create an instance
+    fun = Morris2006(input_dimension=1)
+
+    # Generate sample
+    num_sample = 1000000
+    xx = fun.prob_input.get_sample(num_sample)
+
+    yy = fun(xx)
+
+    # The slope of the linear one-dimensional function is sqrt(12)
+    assert np.allclose(yy / xx[:, 0], np.sqrt(12))
+
+def test_inert_inputs():
+    """Test whether the remaining inputs of Morris2006 are indeed inert."""
+    # Construct two instances of test function
+    # Default parameter set to 10 inputs as important, the rest are inert
+    fun_1 = Morris2006(input_dimension=20)
+    fun_2 = Morris2006(input_dimension=30)
+
+    # Generate sample and compare both
+    num_sample = 1000000
+    xx_1 = fun_1.prob_input.get_sample(num_sample)
+    xx_2 = fun_2.prob_input.get_sample(num_sample)
+
+    yy_1 = fun_1(xx_1)
+    yy_2 = fun_2(xx_2)
+
+    # Assertions
+    assert np.allclose(np.mean(yy_1), np.mean(yy_2), rtol=1e-2)
+    assert np.allclose(np.var(yy_1), np.var(yy_2), rtol=1e-2)

--- a/tests/builtin_test_functions/test_morris2006.py
+++ b/tests/builtin_test_functions/test_morris2006.py
@@ -52,6 +52,7 @@ def test_one_dimension():
     # The slope of the linear one-dimensional function is sqrt(12)
     assert np.allclose(yy / xx[:, 0], np.sqrt(12))
 
+
 def test_inert_inputs():
     """Test whether the remaining inputs of Morris2006 are indeed inert."""
     # Construct two instances of test function


### PR DESCRIPTION
The M-dimensional test function from Morris et al. (2006) has been added to the codebase. The function is typically used in sensitivity analysis exerices.
The documentation has been updated accordingly.

This PR should resolve Issue #353.