### PR TITLE
Add a commentary on metamodeling in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A commentary on metamodeling within the UQ framework in the docs.
+- A better overview of UQ framework in the docs.
 - A new parameter set for the Sobol'-G function from Sun et al. (2022).
 - The 6-dimensional undamped non-linear oscillator function for reliability
   analysis exercises.

--- a/docs/fundamentals/metamodeling.md
+++ b/docs/fundamentals/metamodeling.md
@@ -55,8 +55,9 @@ in the comparison of metamodeling approaches.
 |            {ref}`Wing Weight <test-functions:wing-weight>`             |       10        |     `WingWeight()`      |
 
 In a Python terminal, you can list all the available functions relevant
-for metamodeling applications using ``list_functions()`` and filter the results
-using the ``tag`` parameter:
+for metamodeling applications using ``list_functions()``
+and filter the results using the ``tag`` parameter
+(shown below in the HTML format):
 
 ```{code-cell} ipython3
 :tags: ["output_scroll"]
@@ -64,4 +65,30 @@ using the ``tag`` parameter:
 import uqtestfuns as uqtf
 
 uqtf.list_functions(tag="metamodeling", tablefmt="html")
+```
+
+## About metamodeling
+
+In practice, the computational model $\mathcal{M}$ (see {ref}`fundamentals:overview`)
+is typically complex.
+Since an uncertainty quantification (UQ) analysis usually require numerous
+evaluations of $\mathcal{M}$ ($\sim 10^2$---$10^6$ or more!), the process
+may become computationally intractable if $\mathcal{M}$ is expensive to evaluate.
+
+To address this challenge, many UQ analyses employ a metamodel (surrogate model).
+Constructed on a limited number of model $\mathcal{M}$ evaluations,
+such a metamodel should be able to capture the most important aspects
+of the input/output mapping while being significantly cheaper to evaluate.
+This metamodel can then replace $\mathcal{M}$ in the analysis,
+providing a significant reduction in computational cost without
+sacrificing the accuracy of the analysis much.
+
+While not a goal of UQ analyse per se, metamodeling is nowadays an indispensable
+component of the UQ framework {cite}`Sudret2012, Sudret2017`.
+
+## References
+
+```{bibliography}
+:style: unsrtalpha
+:filter: docname in docnames
 ```

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -910,4 +910,15 @@ An orthogonal design in which the design matrix has uncorrelated columns is impo
   abstract = {This thesis is a contribution to the resolution of the reliability-based design optimization problem. This probabilistic design approach is aimed at considering the uncertainty attached to the system of interest in order to provide optimal and safe solutions. The safety level is quantified in the form of a probability of failure. Then, the optimization problem consists in ensuring that this failure probability remains less than a threshold specified by the stakeholders. The resolution of this problem requires a high number of calls to the limit-state design function underlying the reliability analysis. Hence it becomes cumbersome when the limit-state function involves an expensive-to-evaluate numerical model (e.g. a finite element model). In this context, this manuscript proposes a surrogate-based strategy where the limit-state function is progressively replaced by a Kriging meta-model. A special interest has been given to quantifying, reducing and eventually eliminating the error introduced by the use of this meta-model instead of the original model. The proposed methodology is applied to the design of geometrically imperfect shells prone to buckling.},
 }
 
+@InProceedings{Sudret2017,
+  author    = {Sudret, Bruno and Marelli, Stefano and Wiart, Joe},
+  booktitle = {2017 11th European Conference on Antennas and Propagation (EUCAP)},
+  title     = {Surrogate models for uncertainty quantification: An overview},
+  year      = {2017},
+  month     = mar,
+  pages     = {793--797},
+  publisher = {IEEE},
+  doi       = {10.23919/eucap.2017.7928679},
+}
+
 @Comment{jabref-meta: databaseType:bibtex;}


### PR DESCRIPTION
A short commentary on the role of metamodeling within the UQ framework is added to the docs.
Added a new reference related to that commentary.

This PR should resolve Issue #242.