### PR TITLE
Add sensitivity analysis commentary and reference in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- A commentary on sensitivity analysis within the UQ framework in the docs.
 - A commentary on metamodeling within the UQ framework in the docs.
 - A better overview of UQ framework in the docs.
 - A new parameter set for the Sobol'-G function from Sun et al. (2022).

--- a/docs/fundamentals/optimization.md
+++ b/docs/fundamentals/optimization.md
@@ -12,6 +12,7 @@ kernelspec:
   name: python3
 ---
 
+(fundamentals:optimization)=
 # Test Functions for Optimization
 
 The table below listed the available test functions typically used

--- a/docs/fundamentals/reliability.md
+++ b/docs/fundamentals/reliability.md
@@ -85,7 +85,7 @@ the system is in safe state if the maximum temperature
 does not exceed the regulatory limit.
 ```
 
-_Reliability analysis_[^rare-event] concerns with estimating
+**Reliability analysis**[^rare-event] concerns with estimating
 the failure probability of a system with a given performance function $g$. 
 For a given joint probability density function (PDF) $f_{\boldsymbol{X}}$
 of the uncertain input variables $\boldsymbol{X} = \{ \boldsymbol{X}_p, \boldsymbol{X}_s \}$,

--- a/docs/fundamentals/sensitivity.md
+++ b/docs/fundamentals/sensitivity.md
@@ -43,8 +43,9 @@ in the comparison of sensitivity analysis methods.
 |       {ref}`Wing Weight <test-functions:wing-weight>`        |       10        |    `WingWeight()`    |
 
 In a Python terminal, you can list all the available functions relevant
-for metamodeling applications using ``list_functions()`` and filter the results
-using the ``tag`` parameter:
+for metamodeling applications using ``list_functions()``
+and filter the results  using the ``tag`` parameter
+(shown below in the HTML format):
 
 ```{code-cell} ipython3
 :tags: ["output_scroll"]
@@ -53,3 +54,44 @@ import uqtestfuns as uqtf
 
 uqtf.list_functions(tag="sensitivity", tablefmt="html")
 ```
+
+## About sensitivity analysis
+
+**Sensitivity analysis** is a class of model inference techniques
+whose overarching aim is to _understand the input-output relationship_
+of a complex (perhaps, even a black-box) computational model.
+Within the uncertainty quantification (UQ) framework
+(see {ref}`fundamentals:overview`), this aim is reframed as determining
+how the uncertainty of the model output(s) is affected
+by the uncertainty of the inputs.
+
+While understanding the input-output relationship is valuable on its own[^model-building],
+sensitivity analysis often focuses on more practical tasks, including:
+
+- **Identifying of input variables that primarily drives the output uncertainty**:
+  This knowledge enables _factor prioritization_, where efforts are concentrated
+  on reducing the uncertainty of the most influential inputs (if possible)
+  to significantly decrease the uncertainty of the outputs
+- **Identifying of non-influential input variables**:
+  This knowledge enables _factor fixing/screening_, where non-influential
+  inputs are fixed to arbitrary value without 
+  affecting significantly (or at all) the uncertainty of the outputs.
+  In essence, factor fixing reduces the dimensionality of the problem.
+
+Sensitivity analysis within the UQ framework are typically carried out in
+a black-box manner, relying solely on model evaluations at carefully
+selected input points.
+The goal is then to achieve the aforementioned tasks with as few model
+evaluations as possible.
+
+For detailed discussions on this topic, see {cite}`Saltelli2007, Iooss2015`.
+
+## References
+
+```{bibliography}
+:style: unsrtalpha
+:filter: docname in docnames
+```
+
+[^model-building]: especially during model building and the ensuing verification
+and validation activities.

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -921,4 +921,13 @@ An orthogonal design in which the design matrix has uncorrelated columns is impo
   doi       = {10.23919/eucap.2017.7928679},
 }
 
+@Book{Saltelli2007,
+  author    = {Saltelli, Andrea and Ratto, Marco and Andres, Terry and Campolongo, Francesca and Cariboni, Jessica and Gatelli, Debora and Saisana, Michaela and Tarantola, Stefano},
+  publisher = {Wiley},
+  title     = {Global sensitivity analysis. The primer},
+  year      = {2007},
+  isbn      = {9780470725184},
+  doi       = {10.1002/9780470725184},
+}
+
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/docs/test-functions/undamped-oscillator.md
+++ b/docs/test-functions/undamped-oscillator.md
@@ -87,7 +87,7 @@ The different specifications alter the failure probability of the system
 |:---:|:------------------:|:----------------------:|:----------------------------:|  
 | 1.  | $\mu_{F_1} = 1.00$ | `Gayton2003` (default) | {cite}`Gayton2003` (Table 9) |  
 | 2.  | $\mu_{F_1} = 0.60$ |     `Echard2013-1`     | {cite}`Echard2013` (Table 4) |
-| 3.  | $\mu_{F_1} = 0.45} |     `Echard2013-2`     | {cite}`Echard2013` (Table 4) |
+| 3.  | $\mu_{F_1} = 0.45$ |     `Echard2013-2`     | {cite}`Echard2013` (Table 4) |
 ```
 
 The default input is shown below.
@@ -148,7 +148,7 @@ are summarized in the tables below according to the chosen input specification.
 |   Adaptive Kriging + {term}`MCS` + U   |       $45$        | $2.851 \times 10^{-2}$ |          &#8212;          |   {cite}`Echard2011` (Table 6)    |
 :::
 
-:::{tab-item} Sobol1999-2
+:::{tab-item} Echard2013-1
 |            Method             |         $N$          |      $\hat{P}_f$      | $\mathrm{CoV}[\hat{P}_f]$ |            Source            |
 |:-----------------------------:|:--------------------:|:---------------------:|:-------------------------:|:----------------------------:|
 |          {term}`MCS`          | $1.8 \times 10^{8}$  | $9.09 \times 10^{-6}$ |         $2.47\%$          | {cite}`Echard2013` (Table 5) |
@@ -157,7 +157,7 @@ are summarized in the tables below according to the chosen input specification.
 | Adaptive Kriging + {term}`IS` |      $29 + 38$       | $9.13 \times 10^{-6}$ |         $2.29\%$          | {cite}`Echard2013` (Table 5) |
 :::
 
-:::{tab-item} Moon2012-1
+:::{tab-item} Echard2013-2
 |            Method             |         $N$          |      $\hat{P}_f$      | $\mathrm{CoV}[\hat{P}_f]$ |            Source            |
 |:-----------------------------:|:--------------------:|:---------------------:|:-------------------------:|:----------------------------:|
 |          {term}`MCS`          |  $9 \times 10^{8}$   | $1.55 \times 10^{-8}$ |         $2.68\%$          | {cite}`Echard2013` (Table 5) |


### PR DESCRIPTION
A short commentary on sensitivity analysis and its role within the UQ framework is added to the docs.
Additionally, minor formatting issues in multiple
documentation files have been corrected.

This PR should resolve Issue #203.