### PR TITLE
Add citing instructions in docs and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Update the README with JOSS badge and instruction how to cite the paper and
+  package.
 - A commentary on sensitivity analysis within the UQ framework in the docs.
 - A commentary on metamodeling within the UQ framework in the docs.
 - A better overview of UQ framework in the docs.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # UQTestFuns
+[![DOI](https://joss.theoj.org/papers/10.21105/joss.05671/status.svg)](https://doi.org/10.21105/joss.05671)
 [![DOI](http://img.shields.io/badge/DOI-10.5281/zenodo.10047512-blue.svg?style=flat-square)](https://doi.org/10.5281/zenodo.10047512)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat-square)](https://github.com/psf/black)
 [![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg?style=flat-square)](https://www.python.org/downloads/release/python-370/)
@@ -89,7 +90,7 @@ Marginals       :
   7      L        uniform          [1120. 1680.]                length of the borehole [m]
   8      Kw       uniform         [ 9985. 12045.]     hydraulic conductivity of the borehole [m/year]
 
-Copulas         : None
+Copulas         : Independence
 ```
 
 A sample of input values can be generated from the input model:
@@ -155,6 +156,49 @@ and the documentation (including new reference results) are welcomed!
 Please consider the [Contribution Guidelines](CONTRIBUTING.MD) first,
 before making a pull request. 
 
+## Citing UQTestFuns
+
+If you use this package in your research or projects, please consider citing
+both the associated paper and the Zenodo archive (for the specific version
+used).
+
+### Citing the paper (JOSS)
+
+The citation of the paper associated with this package is:
+
+```bibtex
+@article{Wicaksono2023,
+  author    = {Wicaksono, Damar and Hecht, Michael},
+  title     = {{UQTestFuns}: A {Python3} library of uncertainty quantification ({UQ}) test functions},
+  journal   = {Journal of Open Source Software},
+  year      = {2023},
+  volume    = {8},
+  number    = {90},
+  doi       = {10.21105/joss.05671},
+}
+```
+
+### Citing a specific version (Zenodo)
+
+To ensure reproducibility, cite the exact version of the package you used.
+Each release is archived on Zenodo with a unique DOI; find and use the DOI
+for the version you used at [Zenodo].
+
+The citation for the current public version is:
+
+```bibtex
+@software{UQTestFuns_0_4_1,
+  author       = {Wicaksono, Damar and Hecht, Michael},
+  title        = {{UQTestFuns: A Python3 Library of Uncertainty Quantification (UQ) Test Functions}},
+  month        = oct,
+  year         = 2023,
+  publisher    = {Zenodo},
+  version      = {v0.4.1},
+  doi          = {10.5281/zenodo.10047512},
+  url          = {https://doi.org/10.5281/zenodo.10047512}
+}
+```
+
 ## Credits and contributors
 
 <!--Credits and contributors-->
@@ -176,3 +220,5 @@ led by Michael Hecht ([HZDR/CASUS](https://www.casus.science/)) at CASUS.
 
 <!--License-->
 UQTestFuns is released under the [MIT License](LICENSE).
+
+[Zenodo]: https://zenodo.org/search?q=parent.id%3A7701903&f=allversions%3Atrue&l=list&p=1&s=10&sort=version

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -18,6 +18,7 @@ parts:
           - file: getting-started/tutorial-custom-functions
             title: Custom Test Functions
       - file: getting-started/about-uq-test-functions
+      - file: getting-started/citing
   - caption: Test Functions
     chapters:
       - file: fundamentals/overview

--- a/docs/getting-started/citing.md
+++ b/docs/getting-started/citing.md
@@ -1,0 +1,40 @@
+# Citing UQTestFuns
+
+If you use this package in your research or projects, please consider citing
+both the associated paper and the Zenodo archive (for the specific version
+used).
+
+The citation of the paper associated with this package is:
+
+```bibtex
+@article{Wicaksono2023,
+  author    = {Wicaksono, Damar and Hecht, Michael},
+  title     = {{UQTestFuns}: A {Python3} library of uncertainty quantification ({UQ}) test functions},
+  journal   = {Journal of Open Source Software},
+  year      = {2023},
+  volume    = {8},
+  number    = {90},
+  doi       = {10.21105/joss.05671},
+}
+```
+
+To ensure reproducibility, cite the exact version of the package you used.
+Each release is archived on Zenodo with a unique DOI; find and use the DOI
+for the version you used at [Zenodo].
+
+The citation for the current public version is:
+
+```bibtex
+@software{UQTestFuns_0_4_1,
+  author       = {Wicaksono, Damar and Hecht, Michael},
+  title        = {{UQTestFuns: A Python3 Library of Uncertainty Quantification (UQ) Test Functions}},
+  month        = oct,
+  year         = 2023,
+  publisher    = {Zenodo},
+  version      = {v0.4.1},
+  doi          = {10.5281/zenodo.10047512},
+  url          = {https://doi.org/10.5281/zenodo.10047512}
+}
+```
+
+[Zenodo]: https://zenodo.org/search?q=parent.id%3A7701903&f=allversions%3Atrue&l=list&p=1&s=10&sort=version


### PR DESCRIPTION
Added citation instructions for referencing the associated paper and specific versions of UQTestFuns.
Furthermore, JOSS badge is now included in README.

This PR should resolve Issue #316.