### PR TITLE
Update formatting of "Applications" in string representations

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Input Dimension  : 8 (fixed)
 Output Dimension : 1
 Parameterized    : False
 Description      : Borehole function from Harper and Gupta (1983)
-Applications     : ['metamodeling', 'sensitivity']
+Applications     : metamodeling, sensitivity
 ```
 
 The probabilistic input specification of this test function is built-in:

--- a/src/uqtestfuns/core/uqtestfun_abc.py
+++ b/src/uqtestfuns/core/uqtestfun_abc.py
@@ -293,13 +293,14 @@ class UQTestFunABC(UQTestFunBareABC, ABC):
             input_dimension = f"{self.input_dimension} (variable)"
         else:
             input_dimension = f"{self.input_dimension} (fixed)"
+        tags = ", ".join(self.tags)
         out = (
             f"Function ID      : {self.function_id}\n"
             f"Input Dimension  : {input_dimension}\n"
             f"Output Dimension : {self.output_dimension}\n"
             f"Parameterized    : {bool(self.parameters)}\n"
             f"Description      : {self.description}\n"
-            f"Applications     : {self.tags}"
+            f"Applications     : {tags}"
         )
 
         return out

--- a/tests/builtin_test_functions/test_test_functions.py
+++ b/tests/builtin_test_functions/test_test_functions.py
@@ -156,13 +156,14 @@ def test_str(builtin_testfun):
         input_dim = f"{my_fun.input_dimension} (variable)"
     else:
         input_dim = f"{my_fun.input_dimension} (fixed)"
+    tags = ", ".join(my_fun.tags)
     str_ref = (
         f"Function ID      : {my_fun.function_id}\n"
         f"Input Dimension  : {input_dim}\n"
         f"Output Dimension : {my_fun.output_dimension}\n"
         f"Parameterized    : {bool(my_fun.parameters)}\n"
         f"Description      : {my_fun.description}\n"
-        f"Applications     : {my_fun.tags}"
+        f"Applications     : {tags}"
     )
 
     assert my_fun.__str__() == str_ref


### PR DESCRIPTION
The list format has been replaced by a comma-separated string for "Application" in test functions string
representation.

This PR should resolve Issue #396.