### PR TITLE
Add Genz product peak function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The M-dimensional product peak function from Genz (1984) for integration
+  exercises; one parameter set from the literature is included.
 - The M-dimensional corner peak function from Genz (1984) for integration
   and sensitivity analysis exercises.
 - The one-dimensional sine function from Currin et al. (1988) for metamodeling

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -96,6 +96,8 @@ parts:
             title: Gayton Hat
           - file: test-functions/genz-corner-peak
             title: Genz (Corner Peak)
+          - file: test-functions/genz-product-peak
+            title: Genz (Product Peak)
           - file: test-functions/gramacy-1d-sine
             title: Gramacy (2007) 1D Sine
           - file: test-functions/hyper-sphere

--- a/docs/fundamentals/integration.md
+++ b/docs/fundamentals/integration.md
@@ -18,15 +18,16 @@ kernelspec:
 The table below listed the available test functions typically used
 in the testing and comparison of numerical integration method.
 
-|                                    Name                                     | Input Dimension |     Constructor     |
-|:---------------------------------------------------------------------------:|:---------------:|:-------------------:|
-|        {ref}`Bratley et al. (1992) A <test-functions:bratley1992a>`         |        M        |  `Bratley1992a()`   |
-|        {ref}`Bratley et al. (1992) B <test-functions:bratley1992b>`         |        M        |  `Bratley1992b()`   |
-|        {ref}`Bratley et al. (1992) C <test-functions:bratley1992c>`         |        M        |  `Bratley1992c()`   |
-|        {ref}`Bratley et al. (1992) D <test-functions:bratley1992d>`         |        M        |  `Bratley1992d()`   |
-|         {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`         |        M        | `GenzCornerPeak()`  |
-|                  {ref}`Sobol'-G <test-functions:sobol-g>`                   |        M        |     `SobolG()`      |
-|            {ref}`Welch et al. (1992) <test-functions:welch1992>`            |       20        |    `Welch1992()`    |
+|                             Name                              | Input Dimension |     Constructor      |
+|:-------------------------------------------------------------:|:---------------:|:--------------------:|
+| {ref}`Bratley et al. (1992) A <test-functions:bratley1992a>`  |        M        |   `Bratley1992a()`   |
+| {ref}`Bratley et al. (1992) B <test-functions:bratley1992b>`  |        M        |   `Bratley1992b()`   |
+| {ref}`Bratley et al. (1992) C <test-functions:bratley1992c>`  |        M        |   `Bratley1992c()`   |
+| {ref}`Bratley et al. (1992) D <test-functions:bratley1992d>`  |        M        |   `Bratley1992d()`   |
+|  {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`  |        M        |  `GenzCornerPeak()`  |
+| {ref}`Genz (Product Peak) <test-functions:genz-product-peak>` |        M        | `GenzProductPeak()`  |
+|           {ref}`Sobol'-G <test-functions:sobol-g>`            |        M        |      `SobolG()`      |
+|     {ref}`Welch et al. (1992) <test-functions:welch1992>`     |       20        |    `Welch1992()`     |
 
 In a Python terminal, you can list all the available functions relevant
 for metamodeling applications using ``list_functions()`` and filter the results

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -999,4 +999,14 @@ An orthogonal design in which the design matrix has uncorrelated columns is impo
   location  = {Paris, France},
 }
 
+@Article{Jakeman2015,
+  author  = {Jakeman, J. D. and Eldred, M. S. and Sargsyan, K.},
+  journal = {Journal of Computational Physics},
+  title   = {Enhancingℓ1-minimization estimates of polynomial chaos expansions using basis selection},
+  year    = {2015},
+  pages   = {18--34},
+  volume  = {289},
+  doi     = {10.1016/j.jcp.2015.02.025},
+}
+
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/docs/test-functions/available.md
+++ b/docs/test-functions/available.md
@@ -51,6 +51,7 @@ regardless of their typical applications.
 |                 {ref}`Friedman (10D) <test-functions:friedman-10d>`                 |       10        |         `Friedman10D()`         |
 |                    {ref}`Gayton Hat <test-functions:gayton-hat>`                    |        2        |          `GaytonHat()`          |
 |             {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`             |        M        |       `GenzCornerPeak()`        |
+|            {ref}`Genz (Product Peak) <test-functions:genz-product-peak>`            |        M        |       `GenzProductPeak()`       |
 |           {ref}`Gramacy (2007) 1D Sine <test-functions:gramacy-1d-sine>`            |        1        |        `Gramacy1DSine()`        |
 |               {ref}`Hyper-sphere Bound <test-functions:hyper-sphere>`               |        2        |         `HyperSphere()`         |
 |                      {ref}`Ishigami <test-functions:ishigami>`                      |        3        |          `Ishigami()`           |

--- a/docs/test-functions/genz-product-peak.md
+++ b/docs/test-functions/genz-product-peak.md
@@ -12,8 +12,8 @@ kernelspec:
   name: python3
 ---
 
-(test-functions:genz-corner-peak)=
-# Genz Corner Peak Function
+(test-functions:genz-product-peak)=
+# Genz Product Peak Function
 
 ```{code-cell} ipython3
 import numpy as np
@@ -21,15 +21,11 @@ import matplotlib.pyplot as plt
 import uqtestfuns as uqtf
 ```
 
-The Genz corner peak function is an $M$-dimensional scalar-valued
+The Genz product peak function is an $M$-dimensional scalar-valued
 function commonly used to assess the accuracy of numerical
 integration routines.
 It is one of six functions introduced by Genz {cite}`Genz1984`;
 see the box below.
-
-The function was later featured in {cite}`Zhang2014` as a test function
-for a global sensitivity analysis method and in {cite}`Jakeman2015` for
-metamodeling applications.
 
 ```{note}
 Genz {cite}`Genz1984` introduced six challenging
@@ -37,9 +33,9 @@ parameterized $M$-dimensional functions
 designed to test the performance of numerical integration routines:
 
 - {ref}`Corner peak <test-functions:genz-product-peak>` features a prominent
-  peak in the center of the multidimensional space.
+  peak in the center of the multidimensional space. (_this function_)
 - {ref}`Corner peak <test-functions:genz-corner-peak>` features a prominent
-  peak in one corner of the multidimensional space. (_this function_)
+  peak in one corner of the multidimensional space.
 
 The functions are further characterized by offset (shift) and shape parameters.
 While the offset parameter has minimal impact on the integral's value,
@@ -47,7 +43,7 @@ the shape parameter significantly affects
 the difficulty of the integration problem.
 ```
 
-The plots for one-dimensional and two-dimensional Genz corner peak function
+The plots for one-dimensional and two-dimensional Genz product peak function
 with the default parameters can be seen below.
 
 ```{code-cell} ipython3
@@ -55,13 +51,13 @@ with the default parameters can be seen below.
 
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-# --- Create 1D data from Genz Corner Peak
-my_fun_1d = uqtf.GenzCornerPeak(input_dimension=1)
+# --- Create 1D data from Genz Product Peak
+my_fun_1d = uqtf.GenzProductPeak(input_dimension=1)
 xx_1d = np.linspace(0, 1, 1000)[:, np.newaxis]
 yy_1d = my_fun_1d(xx_1d)
 
-# --- Create 2D data from Genz Corner Peak
-my_fun_2d = uqtf.GenzCornerPeak(input_dimension=2)
+# --- Create 2D data from Genz Product Peak
+my_fun_2d = uqtf.GenzProductPeak(input_dimension=2)
 mesh_2d = np.meshgrid(xx_1d, xx_1d)
 xx_2d = np.array(mesh_2d).T.reshape(-1, 2)
 yy_2d = my_fun_2d(xx_2d)
@@ -75,7 +71,7 @@ axs_1.plot(xx_1d, yy_1d, color="#8da0cb")
 axs_1.grid()
 axs_1.set_xlabel("$x$", fontsize=14)
 axs_1.set_ylabel("$\mathcal{M}(x)$", fontsize=14)
-axs_1.set_title("1D Genz corner peak")
+axs_1.set_title("1D Genz product peak")
 
 # Surface
 axs_2 = plt.subplot(132, projection='3d')
@@ -91,7 +87,7 @@ axs_2.plot_surface(
 axs_2.set_xlabel("$x_1$", fontsize=14)
 axs_2.set_ylabel("$x_2$", fontsize=14)
 axs_2.set_zlabel("$\mathcal{M}(x_1, x_2)$", fontsize=14)
-axs_2.set_title("Surface plot of 2D Genz corner peak", fontsize=14)
+axs_2.set_title("Surface plot of 2D Genz product peak", fontsize=14)
 
 # Contour
 axs_3 = plt.subplot(133)
@@ -100,7 +96,7 @@ cf = axs_3.contourf(
 )
 axs_3.set_xlabel("$x_1$", fontsize=14)
 axs_3.set_ylabel("$x_2$", fontsize=14)
-axs_3.set_title("Contour plot of 2D Genz corner peak", fontsize=14)
+axs_3.set_title("Contour plot of 2D Genz product peak", fontsize=14)
 divider = make_axes_locatable(axs_3)
 cax = divider.append_axes('right', size='5%', pad=0.05)
 fig.colorbar(cf, cax=cax, orientation='vertical')
@@ -115,7 +111,7 @@ plt.gcf().set_dpi(150);
 To create a default instance of the test function:
 
 ```{code-cell} ipython3
-my_testfun = uqtf.GenzCornerPeak()
+my_testfun = uqtf.GenzProductPeak()
 ```
 
 Check if it has been correctly instantiated:
@@ -131,26 +127,27 @@ For example, to create an instance of the test function in six dimensions,
 type:
 
 ```python
-my_testfun = uqtf.GenzCornerPeak(input_dimension=6)
+my_testfun = uqtf.GenzProductPeak(input_dimension=6)
 ```
 
 ## Description
 
-The Genz corner peak function is defined as:
+The Genz product peak function is defined as:
 
 $$
-\mathcal{M}(\boldsymbol{x}; \boldsymbol{a}) = \left( 1 + \sum_{i = 1}^{M} a_i x_i \right)^{-(M + 1)}
+\mathcal{M}(\boldsymbol{x}; \boldsymbol{a}, \boldsymbol{b}) = \prod_{i = 1}^M \frac{1}{\left( a_i^{-2} + (x_i - b_i)^2 \right)}
 $$
 
 where $\boldsymbol{x} = \left( x_1, \ldots, x_M \right)$
-is the $M$-dimensional vector of input variables
-and $\boldsymbol{a} = \left( a_1, \ldots, a_M \right)$ is the $M$-dimensional
-vector of (fixed) shape parameters.
+is the $M$-dimensional vector of input variables;
+and $\boldsymbol{a} = \left( a_1, \ldots, a_M \right)$ 
+$\boldsymbol{b} = \left( b_1, \ldots, b_M \right)$ are $M$-dimensional
+vectors corresponding to the (fixed) shape and offset parameters, respectively.
 Further details about these parameters are provided below.
 
 ## Probabilistic input
 
-The input specification for the Genz corner peak function is shown below.
+The input specification for the Genz product peak function is shown below.
 
 ```{code-cell} ipython3
 :tags: [hide-input]
@@ -161,24 +158,15 @@ print(my_testfun.prob_input)
 ## Parameters
 
 The parameters of the Genz corner peak function consists
-of the vector of shape (scale) parameters $\boldsymbol{a}$,
-which determine the extent of the corner peaking.
+of the vector of shape parameters $\boldsymbol{a}$
+and the vector of offset parameters $\boldsymbol{b}$. 
+
+The shape parameters determines the extent of the product peaking;
 Larger values of $\boldsymbol{a}$
 increase the prominence of the peak,
 making the integration problem more challenging.
-
-The available parameters for the Genz corner peak function
-are shown in the table below.
-
-```{table} Available parameters of the Genz corner peak function
-:name: genz-corner-peak-parameters
-
-```
-| No. |                    $\boldsymbol{a}$                    |          Keyword          |             Source              |          Remark           |
-|:---:|:------------------------------------------------------:|:-------------------------:|:-------------------------------:|:-------------------------:|
-| 1.  |                $a_1 = \ldots = a_M = 5$                | `Genz1984` <br> (default) |        {cite}`Genz1984`         |            ---            |
-| 2.  | $a_i = 0.02 + 0.03 \times (i - 1),\, i = 1, \ldots, M$ |       `Zhang2014-1`       | {cite}`Zhang2014` (Section 4.4) | Originally, 3 dimensions  |
-| 3.  |       $a_i = 0.01 \times i,\, i = 1, \ldots, M$        |       `Zhang2014-2`       | {cite}`Zhang2014` (Section 4.4) | Originally, 10 dimensions |
+The offset parameters, on the other hand, does not affect significantly
+the difficulty of the problem and can be chosen randomly.
 
 The default parameter is shown below.
 
@@ -188,21 +176,11 @@ The default parameter is shown below.
 print(my_testfun.parameters)
 ```
 
-````{note}
-To create an instance of the Genz corner peak function with different built-in
-parameter values, pass the corresponding keyword to the parameter `parameters_id`.
-For example, to use the parameters from {cite}`Zhang2014`,
-type:
-
-```python
-my_testfun = uqtf.GenzCornerPeak(parameters_id="Zhang2014-1")
-```
-````
 
 ## Reference results
 
-This section provides several reference results of typical UQ analyses involving
-the test function.
+This section provides several reference results of typical UQ analyses
+involving the test function.
 
 ### Sample histogram
 
@@ -215,14 +193,12 @@ my_testfun.prob_input.reset_rng(42)
 xx_test = my_testfun.prob_input.get_sample(100000)
 yy_test = my_testfun(xx_test)
 
-plt.hist(yy_test, color="#8da0cb");
+plt.hist(yy_test, bins="auto", color="#8da0cb");
 plt.grid();
 plt.ylabel("Counts [-]");
 plt.xlabel("$\mathcal{M}(\mathbf{X})$");
 plt.gcf().set_dpi(150);
 ```
-
-Notice that the values are indeed mostly zeros.
 
 ## References
 

--- a/src/uqtestfuns/core/parameters.py
+++ b/src/uqtestfuns/core/parameters.py
@@ -252,7 +252,7 @@ class FunParams:
         # When a parameter is assigned, be more forgiving
         if not isinstance(value, type_):
             warnings.warn(
-                message="Expected {type_} but got {type(value)}",
+                message=f"Expected {type_} but got {type(value)}",
                 category=UserWarning,
                 stacklevel=2,
             )

--- a/src/uqtestfuns/test_functions/__init__.py
+++ b/src/uqtestfuns/test_functions/__init__.py
@@ -20,7 +20,7 @@ from .four_branch import FourBranch
 from .franke import Franke1, Franke2, Franke3, Franke4, Franke5, Franke6
 from .friedman import Friedman6D, Friedman10D
 from .gayton_hat import GaytonHat
-from .genz import GenzCornerPeak
+from .genz import GenzCornerPeak, GenzProductPeak
 from .gramacy2007 import Gramacy1DSine
 from .hyper_sphere import HyperSphere
 from .ishigami import Ishigami
@@ -81,6 +81,7 @@ __all__ = [
     "Friedman10D",
     "GaytonHat",
     "GenzCornerPeak",
+    "GenzProductPeak",
     "Gramacy1DSine",
     "HyperSphere",
     "Ishigami",

--- a/src/uqtestfuns/test_functions/genz.py
+++ b/src/uqtestfuns/test_functions/genz.py
@@ -212,7 +212,7 @@ def evaluate_product_peak(
         The output of the test function evaluated on the input values.
         The output is a 1-dimensional array of length N.
     """
-    yy = np.prod(1 / ((xx - bb)**2 + aa**(-2)), axis=1)
+    yy = np.prod(1 / ((xx - bb) ** 2 + aa ** (-2)), axis=1)
 
     return yy
 

--- a/tests/builtin_test_functions/test_coffee_cup.py
+++ b/tests/builtin_test_functions/test_coffee_cup.py
@@ -52,7 +52,7 @@ def test_parameter_nts(n_ts):
     assert fun.output_dimension == n_ts
 
 
-@pytest.mark.parametrize("temp_0", [50, 60, 70])
+@pytest.mark.parametrize("temp_0", [50.0, 60.0, 70.0])
 def test_parameter_temp0(temp_0):
     # Create an instance
     fun = CoffeeCup()


### PR DESCRIPTION
The M-dimensional product peak function from Genz (1984) for integration and sensitivity analysis applications is added to the code base.
One set of parameters from the literature is included. The documentation has been updated accordingly.

This PR should partially resolve Issue #291.