### PR TITLE
Add Linkletter et al. (2006) linear test function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The ten-dimensional linear function from Linkletter et al. (2006) featuring
+  only four active input variables out of ten; the function was used
+  in the context of metamodeling and sensitivity analysis.
 - The eight-dimensional function from Dette and Pepelyshev (2010) featuring
   curved and logarithm terms for metamodeling exercises.
 - The three-dimensional highly-curved function from Dette and Pepelyshev (2010)

--- a/docs/fundamentals/metamodeling.md
+++ b/docs/fundamentals/metamodeling.md
@@ -18,51 +18,52 @@ kernelspec:
 The table below listed the available test functions typically used
 in the comparison of metamodeling approaches.
 
-|                                  Name                                   | Input Dimension |      Constructor       |
-|:-----------------------------------------------------------------------:|:---------------:|:----------------------:|
-|                  {ref}`Ackley <test-functions:ackley>`                  |        M        |       `Ackley()`       |
-|  {ref}`Alemazkoor & Meidani (2018) 2D <test-functions:alemazkoor-2d>`   |        2        |    `Alemazkoor2D()`    |
-| {ref}`Alemazkoor & Meidani (2018) 20D <test-functions:alemazkoor-20d>`  |       20        |   `Alemazkoor20D()`    |
-|                {ref}`Borehole <test-functions:borehole>`                |        8        |      `Borehole()`      |
-|        {ref}`Cheng and Sandu (2010) 2D <test-functions:cheng2d>`        |        2        |       `Cheng2D`        |
-|           {ref}`Coffee Cup Model <test-functions:coffee-cup>`           |        2        |     `CoffeeCup()`      |
-|      {ref}`Currin et al. (1988) Sine <test-functions:currin-sine>`      |        1        |     `CurrinSine()`     |
-|           {ref}`Damped Cosine <test-functions:damped-cosine>`           |        1        |    `DampedCosine()`    |
-|       {ref}`Damped Oscillator <test-functions:damped-oscillator>`       |        7        |  `DampedOscillator()`  |
-|      {ref}`Dette & Pepelyshev (2010) 8D <test-functions:dette-8d>`      |        3        |      `Dette8D()`       |
-|  {ref}`Dette & Pepelyshev (2010) Curved <test-functions:dette-curved>`  |        3        |    `DetteCurved()`     |
-| {ref}`Dette & Pepelyshev (2010) Exponential <test-functions:dette-exp>` |        3        |      `DetteExp()`      |
-|                   {ref}`Flood <test-functions:flood>`                   |        8        |       `Flood()`        |
-|        {ref}`Forrester et al. (2008) <test-functions:forrester>`        |        1        |   `Forrester2008()`    |
-|              {ref}`(1st) Franke <test-functions:franke-1>`              |        2        |      `Franke1()`       |
-|              {ref}`(2nd) Franke <test-functions:franke-2>`              |        2        |      `Franke2()`       |
-|              {ref}`(3rd) Franke <test-functions:franke-3>`              |        2        |      `Franke3()`       |
-|              {ref}`(4th) Franke <test-functions:franke-4>`              |        2        |      `Franke4()`       |
-|              {ref}`(5th) Franke <test-functions:franke-5>`              |        2        |      `Franke5()`       |
-|              {ref}`(6th) Franke <test-functions:franke-6>`              |        2        |      `Franke6()`       |
-|            {ref}`Friedman (6D) <test-functions:friedman-6d>`            |        6        |     `Friedman6D()`     |
-|           {ref}`Friedman (10D) <test-functions:friedman-10d>`           |       10        |    `Friedman10D()`     |
-|       {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`       |        M        |   `GenzCornerPeak()`   |
-|     {ref}`Gramacy (2007) 1D Sine <test-functions:gramacy-1d-sine>`      |        1        |   `Gramacy1DSine()`    |
-|         {ref}`Higdon (2002) Sine <test-functions:higdon-sine>`          |        1        |     `HigdonSine()`     |
-|    {ref}`Holsclaw et al. (2013) Sine <test-functions:holsclaw-sine>`    |        1        |    `HolsclawSine()`    |
-|  {ref}`Lim et al. (2002) Non-Polynomial <test-functions:lim-non-poly>`  |        2        |     `LimNonPoly()`     |
-|      {ref}`Lim et al. (2002) Polynomial <test-functions:lim-poly>`      |        2        |      `LimPoly()`       |
-|               {ref}`McLain S1 <test-functions:mclain-s1>`               |        2        |      `McLainS1()`      |
-|               {ref}`McLain S2 <test-functions:mclain-s2>`               |        2        |      `McLainS2()`      |
-|               {ref}`McLain S3 <test-functions:mclain-s3>`               |        2        |      `McLainS3()`      |
-|               {ref}`McLain S4 <test-functions:mclain-s4>`               |        2        |      `McLainS4()`      |
-|               {ref}`McLain S5 <test-functions:mclain-s5>`               |        2        |      `McLainS5()`      |
-|      {ref}`Oakley & O'Hagan (2002) 1D <test-functions:oakley-1d>`       |        1        |      `Oakley1D()`      |
-|             {ref}`OTL Circuit <test-functions:otl-circuit>`             |     6 / 20      |     `OTLCircuit()`     |
-|            {ref}`Piston Simulation <test-functions:piston>`             |     7 / 20      |       `Piston()`       |
-|               {ref}`Robot Arm <test-functions:robot-arm>`               |        8        |      `RobotArm()`      |
-|           {ref}`Solar Cell Model <test-functions:solar-cell>`           |        5        |     `SolarCell()`      |
-|                  {ref}`Sulfur <test-functions:sulfur>`                  |        9        |       `Sulfur()`       |
-|     {ref}`Undamped Oscillator <test-functions:undamped-oscillator>`     |        6        | `UndampedOscillator()` |
-|       {ref}`Webster et al. (1996) 2D <test-functions:webster-2d>`       |        2        |     `Webster2D()`      |
-|          {ref}`Welch et al. (1992) <test-functions:welch1992>`          |       20        |     `Welch1992()`      |
-|             {ref}`Wing Weight <test-functions:wing-weight>`             |       10        |     `WingWeight()`     |
+|                                   Name                                    | Input Dimension |      Constructor       |
+|:-------------------------------------------------------------------------:|:---------------:|:----------------------:|
+|                   {ref}`Ackley <test-functions:ackley>`                   |        M        |       `Ackley()`       |
+|   {ref}`Alemazkoor & Meidani (2018) 2D <test-functions:alemazkoor-2d>`    |        2        |    `Alemazkoor2D()`    |
+|  {ref}`Alemazkoor & Meidani (2018) 20D <test-functions:alemazkoor-20d>`   |       20        |   `Alemazkoor20D()`    |
+|                 {ref}`Borehole <test-functions:borehole>`                 |        8        |      `Borehole()`      |
+|         {ref}`Cheng and Sandu (2010) 2D <test-functions:cheng2d>`         |        2        |       `Cheng2D`        |
+|            {ref}`Coffee Cup Model <test-functions:coffee-cup>`            |        2        |     `CoffeeCup()`      |
+|       {ref}`Currin et al. (1988) Sine <test-functions:currin-sine>`       |        1        |     `CurrinSine()`     |
+|            {ref}`Damped Cosine <test-functions:damped-cosine>`            |        1        |    `DampedCosine()`    |
+|        {ref}`Damped Oscillator <test-functions:damped-oscillator>`        |        7        |  `DampedOscillator()`  |
+|       {ref}`Dette & Pepelyshev (2010) 8D <test-functions:dette-8d>`       |        3        |      `Dette8D()`       |
+|   {ref}`Dette & Pepelyshev (2010) Curved <test-functions:dette-curved>`   |        3        |    `DetteCurved()`     |
+|  {ref}`Dette & Pepelyshev (2010) Exponential <test-functions:dette-exp>`  |        3        |      `DetteExp()`      |
+|                    {ref}`Flood <test-functions:flood>`                    |        8        |       `Flood()`        |
+|         {ref}`Forrester et al. (2008) <test-functions:forrester>`         |        1        |   `Forrester2008()`    |
+|               {ref}`(1st) Franke <test-functions:franke-1>`               |        2        |      `Franke1()`       |
+|               {ref}`(2nd) Franke <test-functions:franke-2>`               |        2        |      `Franke2()`       |
+|               {ref}`(3rd) Franke <test-functions:franke-3>`               |        2        |      `Franke3()`       |
+|               {ref}`(4th) Franke <test-functions:franke-4>`               |        2        |      `Franke4()`       |
+|               {ref}`(5th) Franke <test-functions:franke-5>`               |        2        |      `Franke5()`       |
+|               {ref}`(6th) Franke <test-functions:franke-6>`               |        2        |      `Franke6()`       |
+|             {ref}`Friedman (6D) <test-functions:friedman-6d>`             |        6        |     `Friedman6D()`     |
+|            {ref}`Friedman (10D) <test-functions:friedman-10d>`            |       10        |    `Friedman10D()`     |
+|        {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`        |        M        |   `GenzCornerPeak()`   |
+|      {ref}`Gramacy (2007) 1D Sine <test-functions:gramacy-1d-sine>`       |        1        |   `Gramacy1DSine()`    |
+|          {ref}`Higdon (2002) Sine <test-functions:higdon-sine>`           |        1        |     `HigdonSine()`     |
+|     {ref}`Holsclaw et al. (2013) Sine <test-functions:holsclaw-sine>`     |        1        |    `HolsclawSine()`    |
+|   {ref}`Lim et al. (2002) Non-Polynomial <test-functions:lim-non-poly>`   |        2        |     `LimNonPoly()`     |
+|       {ref}`Lim et al. (2002) Polynomial <test-functions:lim-poly>`       |        2        |      `LimPoly()`       |
+| {ref}`Linkletter et al. (2006) Linear <test-functions:linkletter-linear>` |       10        |  `LinkletterLinear()`  |
+|                {ref}`McLain S1 <test-functions:mclain-s1>`                |        2        |      `McLainS1()`      |
+|                {ref}`McLain S2 <test-functions:mclain-s2>`                |        2        |      `McLainS2()`      |
+|                {ref}`McLain S3 <test-functions:mclain-s3>`                |        2        |      `McLainS3()`      |
+|                {ref}`McLain S4 <test-functions:mclain-s4>`                |        2        |      `McLainS4()`      |
+|                {ref}`McLain S5 <test-functions:mclain-s5>`                |        2        |      `McLainS5()`      |
+|       {ref}`Oakley & O'Hagan (2002) 1D <test-functions:oakley-1d>`        |        1        |      `Oakley1D()`      |
+|              {ref}`OTL Circuit <test-functions:otl-circuit>`              |     6 / 20      |     `OTLCircuit()`     |
+|             {ref}`Piston Simulation <test-functions:piston>`              |     7 / 20      |       `Piston()`       |
+|                {ref}`Robot Arm <test-functions:robot-arm>`                |        8        |      `RobotArm()`      |
+|            {ref}`Solar Cell Model <test-functions:solar-cell>`            |        5        |     `SolarCell()`      |
+|                   {ref}`Sulfur <test-functions:sulfur>`                   |        9        |       `Sulfur()`       |
+|      {ref}`Undamped Oscillator <test-functions:undamped-oscillator>`      |        6        | `UndampedOscillator()` |
+|        {ref}`Webster et al. (1996) 2D <test-functions:webster-2d>`        |        2        |     `Webster2D()`      |
+|           {ref}`Welch et al. (1992) <test-functions:welch1992>`           |       20        |     `Welch1992()`      |
+|              {ref}`Wing Weight <test-functions:wing-weight>`              |       10        |     `WingWeight()`     |
 
 In a Python terminal, you can list all the available functions relevant
 for metamodeling applications using ``list_functions()``

--- a/docs/fundamentals/sensitivity.md
+++ b/docs/fundamentals/sensitivity.md
@@ -18,32 +18,33 @@ kernelspec:
 The table below listed the available test functions typically used
 in the comparison of sensitivity analysis methods.
 
-|                               Name                               | Input Dimension |      Constructor       |
-|:----------------------------------------------------------------:|:---------------:|:----------------------:|
-|            {ref}`Borehole <test-functions:borehole>`             |        8        |      `Borehole()`      |
-|   {ref}`Bratley et al. (1992) A <test-functions:bratley1992a>`   |        M        |    `Bratley1992a()`    |
-|   {ref}`Bratley et al. (1992) B <test-functions:bratley1992b>`   |        M        |    `Bratley1992b()`    |
-|   {ref}`Bratley et al. (1992) C <test-functions:bratley1992c>`   |        M        |    `Bratley1992c()`    |
-|   {ref}`Bratley et al. (1992) D <test-functions:bratley1992d>`   |        M        |    `Bratley1992d()`    |
-|   {ref}`Damped Oscillator <test-functions:damped-oscillator>`    |        7        |  `DampedOscillator()`  |
-|               {ref}`Flood <test-functions:flood>`                |        8        |       `Flood()`        |
-|        {ref}`Friedman (6D) <test-functions:friedman-6d>`         |        6        |     `Friedman6D()`     |
-|   {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`    |        M        |   `GenzCornerPeak()`   |
-| {ref}`Genz (Discontinuous) <test-functions:genz-discontinuous>`  |        M        | `GenzDiscontinuous()`  |
-|            {ref}`Ishigami <test-functions:ishigami>`             |        3        |      `Ishigami()`      |
-|          {ref}`Moon (2010) 3D <test-functions:moon3d>`           |        3        |       `Moon3D()`       |
-|     {ref}`Morris et al. (2006) <test-functions:morris2006>`      |        M        |     `Morris2006()`     |
-|         {ref}`OTL Circuit <test-functions:otl-circuit>`          |     6 / 20      |     `OTLCircuit()`     |
-|         {ref}`Piston Simulation <test-functions:piston>`         |     7 / 20      |       `Piston()`       |
-|   {ref}`Simple Portfolio Model <test-functions:portfolio-3d>`    |        3        |    `Portfolio3D()`     |
-|      {ref}`SaltelliLinear <test-functions:saltelli-linear>`      |        M        |   `SaltelliLinear()`   |
-|             {ref}`Sobol'-G <test-functions:sobol-g>`             |        M        |       `SobolG()`       |
-|          {ref}`Sobol'-G* <test-functions:sobol-g-star>`          |        M        |     `SobolGStar()`     |
-|       {ref}`Sobol'-Levitan <test-functions:sobol-levitan>`       |        M        |    `SobolLevitan()`    |
-|       {ref}`Solar Cell Model <test-functions:solar-cell>`        |        5        |     `SolarCell()`      |
-|              {ref}`Sulfur <test-functions:sulfur>`               |        9        |       `Sulfur()`       |
-|      {ref}`Welch et al. (1992) <test-functions:welch1992>`       |       20        |     `Welch1992()`      |
-|         {ref}`Wing Weight <test-functions:wing-weight>`          |       10        |     `WingWeight()`     |
+|                                    Name                                    | Input Dimension |      Constructor       |
+|:--------------------------------------------------------------------------:|:---------------:|:----------------------:|
+|                 {ref}`Borehole <test-functions:borehole>`                  |        8        |      `Borehole()`      |
+|        {ref}`Bratley et al. (1992) A <test-functions:bratley1992a>`        |        M        |    `Bratley1992a()`    |
+|        {ref}`Bratley et al. (1992) B <test-functions:bratley1992b>`        |        M        |    `Bratley1992b()`    |
+|        {ref}`Bratley et al. (1992) C <test-functions:bratley1992c>`        |        M        |    `Bratley1992c()`    |
+|        {ref}`Bratley et al. (1992) D <test-functions:bratley1992d>`        |        M        |    `Bratley1992d()`    |
+|        {ref}`Damped Oscillator <test-functions:damped-oscillator>`         |        7        |  `DampedOscillator()`  |
+|                    {ref}`Flood <test-functions:flood>`                     |        8        |       `Flood()`        |
+|             {ref}`Friedman (6D) <test-functions:friedman-6d>`              |        6        |     `Friedman6D()`     |
+|        {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`         |        M        |   `GenzCornerPeak()`   |
+|      {ref}`Genz (Discontinuous) <test-functions:genz-discontinuous>`       |        M        | `GenzDiscontinuous()`  |
+|                 {ref}`Ishigami <test-functions:ishigami>`                  |        3        |      `Ishigami()`      |
+| {ref}`Linkletter et al. (2006) Linear <test-functions:linkletter-linear>`  |       10        |  `LinkletterLinear()`  |
+|               {ref}`Moon (2010) 3D <test-functions:moon3d>`                |        3        |       `Moon3D()`       |
+|          {ref}`Morris et al. (2006) <test-functions:morris2006>`           |        M        |     `Morris2006()`     |
+|              {ref}`OTL Circuit <test-functions:otl-circuit>`               |     6 / 20      |     `OTLCircuit()`     |
+|              {ref}`Piston Simulation <test-functions:piston>`              |     7 / 20      |       `Piston()`       |
+|        {ref}`Simple Portfolio Model <test-functions:portfolio-3d>`         |        3        |    `Portfolio3D()`     |
+|           {ref}`SaltelliLinear <test-functions:saltelli-linear>`           |        M        |   `SaltelliLinear()`   |
+|                  {ref}`Sobol'-G <test-functions:sobol-g>`                  |        M        |       `SobolG()`       |
+|               {ref}`Sobol'-G* <test-functions:sobol-g-star>`               |        M        |     `SobolGStar()`     |
+|            {ref}`Sobol'-Levitan <test-functions:sobol-levitan>`            |        M        |    `SobolLevitan()`    |
+|            {ref}`Solar Cell Model <test-functions:solar-cell>`             |        5        |     `SolarCell()`      |
+|                   {ref}`Sulfur <test-functions:sulfur>`                    |        9        |       `Sulfur()`       |
+|           {ref}`Welch et al. (1992) <test-functions:welch1992>`            |       20        |     `Welch1992()`      |
+|              {ref}`Wing Weight <test-functions:wing-weight>`               |       10        |     `WingWeight()`     |
 
 In a Python terminal, you can list all the available functions relevant
 for metamodeling applications using ``list_functions()``

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1043,4 +1043,15 @@ An orthogonal design in which the design matrix has uncorrelated columns is impo
   doi     = {10.1198/tech.2010.09157},
 }
 
+@Article{Linkletter2006,
+  author  = {Linkletter, Crystal and Bingham, Derek and Hengartner, Nicholas and Higdon, David and Ye, Kenny Q.},
+  journal = {Technometrics},
+  title   = {Variable selection for {Gaussian} process models in computer experiments},
+  year    = {2006},
+  number  = {4},
+  pages   = {478--490},
+  volume  = {48},
+  doi     = {10.1198/004017006000000228},
+}
+
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/docs/test-functions/available.md
+++ b/docs/test-functions/available.md
@@ -66,6 +66,7 @@ regardless of their typical applications.
 |                      {ref}`Ishigami <test-functions:ishigami>`                      |        3        |          `Ishigami()`           |
 |        {ref}`Lim et al. (2002) Non-Polynomial <test-functions:lim-non-poly>`        |        2        |         `LimNonPoly()`          |
 |            {ref}`Lim et al. (2002) Polynomial <test-functions:lim-poly>`            |        2        |           `LimPoly()`           |
+|      {ref}`Linkletter et al. (2006) Linear <test-functions:linkletter-linear>`      |       10        |      `LinkletterLinear()`       |
 |                     {ref}`McLain S1 <test-functions:mclain-s1>`                     |        2        |          `McLainS1()`           |
 |                     {ref}`McLain S2 <test-functions:mclain-s2>`                     |        2        |          `McLainS2()`           |
 |                     {ref}`McLain S3 <test-functions:mclain-s3>`                     |        2        |          `McLainS3()`           |

--- a/docs/test-functions/linkletter-linear.md
+++ b/docs/test-functions/linkletter-linear.md
@@ -1,0 +1,115 @@
+---
+jupytext:
+  formats: ipynb,md:myst
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.14.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+(test-functions:linkletter-linear)=
+# Linear Function from Linkletter et al. (2006)
+
+```{code-cell} ipython3
+import numpy as np
+import matplotlib.pyplot as plt
+import uqtestfuns as uqtf
+```
+
+The linear function is a ten-dimensional, scalar-valued function.
+Only the first four input variables are active, while the rest is inert.
+The function was used in {cite}`Linkletter2006` to demonstrate a variable
+selection method (i.e., sensitivity analysis)
+in the context of Gaussian process metamodeling:
+
+```{note}
+Linkletter et al. {cite}`Linkletter2006` introduced four ten-dimensional
+analytical test functions with some of the input variables inert.
+They are used to demonstrate a variable selection method (i.e., screening)
+in the context of Gaussian process metamodeling:
+
+- {ref}`Linear <test-functions:linkletter-linear>` function features
+  a simple function with four active input variables (out of 10).
+  (_this function_)
+```
+
+
+## Test function instance
+
+To create a default instance of the test function:
+
+```{code-cell} ipython3
+my_testfun = uqtf.LinkletterLinear()
+```
+
+Check if it has been correctly instantiated:
+
+```{code-cell} ipython3
+print(my_testfun)
+```
+
+## Description
+
+The test function is defined as[^location]:
+
+$$
+\mathcal{M}(\boldsymbol{x}) = 0.2 (x_1 + x_2 + x_3 + x_4),
+$$
+
+where $\boldsymbol{x} = \left( x_1, \ldots x_{10} \right)$
+is the ten-dimensional vector of input variables further defined below.
+Notice that only four out of ten input variables are active.
+
+```{note}
+In the original paper, the function was added with an independent identically
+distributed (i.i.d) noise from $\mathcal{N}(0, \sigma)$
+with a standard deviation $\sigma = 0.05$.
+```
+
+## Probabilistic input
+
+The probabilistic input model for the test function is shown below.
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+print(my_testfun.prob_input)
+```
+
+## Reference results
+
+This section provides several reference results of typical UQ analyses involving
+the test function.
+
+### Sample histogram
+
+Shown below is the histogram of the output based on $100'000$ random points:
+
+```{code-cell} ipython3
+:tags: [hide-input]
+
+my_testfun.prob_input.reset_rng(42)
+xx_test = my_testfun.prob_input.get_sample(100000)
+yy_test = my_testfun(xx_test)
+
+plt.hist(yy_test, bins="auto", color="#8da0cb");
+plt.grid();
+plt.ylabel("Counts [-]");
+plt.xlabel("$\mathcal{M}(X)$");
+plt.gcf().tight_layout(pad=3.0)
+plt.gcf().set_dpi(150);
+```
+
+## References
+
+```{bibliography}
+:style: unsrtalpha
+:filter: docname in docnames
+```
+
+[^location]: see Eq. (5), Example 1, in {cite}`Linkletter2006`.

--- a/src/uqtestfuns/test_functions/__init__.py
+++ b/src/uqtestfuns/test_functions/__init__.py
@@ -35,6 +35,7 @@ from .holsclaw_sine import HolsclawSine
 from .hyper_sphere import HyperSphere
 from .ishigami import Ishigami
 from .lim import LimPoly, LimNonPoly
+from .linkletter import LinkletterLinear
 from .oakley2002 import Oakley1D
 from .otl_circuit import OTLCircuit
 from .mclain import McLainS1, McLainS2, McLainS3, McLainS4, McLainS5
@@ -104,6 +105,7 @@ __all__ = [
     "Ishigami",
     "LimNonPoly",
     "LimPoly",
+    "LinkletterLinear",
     "Oakley1D",
     "OTLCircuit",
     "McLainS1",

--- a/src/uqtestfuns/test_functions/linkletter.py
+++ b/src/uqtestfuns/test_functions/linkletter.py
@@ -1,0 +1,76 @@
+"""
+Module with an implementation of the functions from Linkletter et al. (2006)
+
+The paper by Linkletter et al. (2006) [1] contains four analytical test
+functions used for sensitivity analysis in the context of variable selection
+in Gaussian process metamodeling.
+All functions are defined in ten dimensions but some of them are inactive.
+
+Available functions are:
+
+- Linear function with four active input variables (out of 10).
+
+References
+----------
+
+1. C. Linkletter, D. Bingham, N. Hengartner, D. Higdon, and K. Q. Ye,
+   “Variable Selection for Gaussian Process Models in Computer Experiments,”
+   Technometrics, vol. 48, no. 4, pp. 478–490, 2006.
+   DOI: 10.1198/004017006000000228.
+"""
+
+import numpy as np
+
+from uqtestfuns.core.custom_typing import ProbInputSpecs
+from uqtestfuns.core.uqtestfun_abc import UQTestFunFixDimABC
+
+__all__ = ["LinkletterLinear"]
+
+
+def evaluate_linear(xx: np.ndarray) -> np.ndarray:
+    """Evaluate the linear  function from Linkletter et al. (2006).
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        M-Dimensional input values given by an N-by-10 array where
+        N is the number of input values.
+
+    Returns
+    -------
+    np.ndarray
+        The output of the test function evaluated on the input values.
+        The output is a 1-dimensional array of length N.
+    """
+    yy = 0.2 * np.sum(xx[:, :4], axis=1)
+
+    return yy
+
+
+class LinkletterLinear(UQTestFunFixDimABC):
+    """A concrete implementation of the linear function."""
+
+    _tags = ["metamodeling", "sensitivity"]
+    _description = "Linear function from Linkletter et al. (2006)"
+    _available_inputs: ProbInputSpecs = {
+        "Linkletter2006": {
+            "function_id": "LinkletterLinear",
+            "description": (
+                "Input specification for the linear test function Eq. (5)"
+                "from Linkletter et al. (2006)"
+            ),
+            "marginals": [
+                {
+                    "name": f"x_{i + 1}",
+                    "distribution": "uniform",
+                    "parameters": [0, 1],
+                    "description": None,
+                }
+                for i in range(10)
+            ],
+            "copulas": None,
+        },
+    }
+    _available_parameters = None
+
+    evaluate = staticmethod(evaluate_linear)  # type: ignore


### PR DESCRIPTION
Implemented the ten-dimensional linear test function from Linkletter et al. (2006), which features
four (out of ten) active input variables.

This function is used in the context of
sensitivity analysis (screening) and metamodeling. The documentation has been updated accordingly.

This PR should resolve Issue #327.