### PR TITLE
Add the sine function from Linkletter et al. (2006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The ten-dimensional sine function from Linkletter et al. (2006) featuring
+  only two active input variables out of ten; the function was used in the
+  context of metamodeling and sensitivity analysis.
 - The ten-dimensional linear function with decreasing coefficients from
   Linkletter et al. (2006) featuring only eight active input variables out of
   ten; the function was used in the context of metamodeling and sensitivity

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -130,6 +130,8 @@ parts:
             title: Linkletter et al. (2006) Dec. Coeffs.
           - file: test-functions/linkletter-linear
             title: Linkletter et al. (2006) Linear
+          - file: test-functions/linkletter-sine
+            title: Linkletter et al. (2006) Sine
           - file: test-functions/mclain-s1
             title: McLain S1
           - file: test-functions/mclain-s2

--- a/docs/fundamentals/metamodeling.md
+++ b/docs/fundamentals/metamodeling.md
@@ -18,53 +18,54 @@ kernelspec:
 The table below listed the available test functions typically used
 in the comparison of metamodeling approaches.
 
-|                                              Name                                               | Input Dimension |       Constructor       |
-|:-----------------------------------------------------------------------------------------------:|:---------------:|:-----------------------:|
-|                              {ref}`Ackley <test-functions:ackley>`                              |        M        |       `Ackley()`        |
-|              {ref}`Alemazkoor & Meidani (2018) 2D <test-functions:alemazkoor-2d>`               |        2        |    `Alemazkoor2D()`     |
-|             {ref}`Alemazkoor & Meidani (2018) 20D <test-functions:alemazkoor-20d>`              |       20        |    `Alemazkoor20D()`    |
-|                            {ref}`Borehole <test-functions:borehole>`                            |        8        |      `Borehole()`       |
-|                    {ref}`Cheng and Sandu (2010) 2D <test-functions:cheng2d>`                    |        2        |        `Cheng2D`        |
-|                       {ref}`Coffee Cup Model <test-functions:coffee-cup>`                       |        2        |      `CoffeeCup()`      |
-|                  {ref}`Currin et al. (1988) Sine <test-functions:currin-sine>`                  |        1        |     `CurrinSine()`      |
-|                       {ref}`Damped Cosine <test-functions:damped-cosine>`                       |        1        |    `DampedCosine()`     |
-|                   {ref}`Damped Oscillator <test-functions:damped-oscillator>`                   |        7        |  `DampedOscillator()`   |
-|                  {ref}`Dette & Pepelyshev (2010) 8D <test-functions:dette-8d>`                  |        3        |       `Dette8D()`       |
-|              {ref}`Dette & Pepelyshev (2010) Curved <test-functions:dette-curved>`              |        3        |     `DetteCurved()`     |
-|             {ref}`Dette & Pepelyshev (2010) Exponential <test-functions:dette-exp>`             |        3        |      `DetteExp()`       |
-|                               {ref}`Flood <test-functions:flood>`                               |        8        |        `Flood()`        |
-|                    {ref}`Forrester et al. (2008) <test-functions:forrester>`                    |        1        |    `Forrester2008()`    |
-|                          {ref}`(1st) Franke <test-functions:franke-1>`                          |        2        |       `Franke1()`       |
-|                          {ref}`(2nd) Franke <test-functions:franke-2>`                          |        2        |       `Franke2()`       |
-|                          {ref}`(3rd) Franke <test-functions:franke-3>`                          |        2        |       `Franke3()`       |
-|                          {ref}`(4th) Franke <test-functions:franke-4>`                          |        2        |       `Franke4()`       |
-|                          {ref}`(5th) Franke <test-functions:franke-5>`                          |        2        |       `Franke5()`       |
-|                          {ref}`(6th) Franke <test-functions:franke-6>`                          |        2        |       `Franke6()`       |
-|                        {ref}`Friedman (6D) <test-functions:friedman-6d>`                        |        6        |     `Friedman6D()`      |
-|                       {ref}`Friedman (10D) <test-functions:friedman-10d>`                       |       10        |     `Friedman10D()`     |
-|                   {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`                   |        M        |   `GenzCornerPeak()`    |
-|                 {ref}`Gramacy (2007) 1D Sine <test-functions:gramacy-1d-sine>`                  |        1        |    `Gramacy1DSine()`    |
-|                     {ref}`Higdon (2002) Sine <test-functions:higdon-sine>`                      |        1        |     `HigdonSine()`      |
-|                {ref}`Holsclaw et al. (2013) Sine <test-functions:holsclaw-sine>`                |        1        |    `HolsclawSine()`     |
-|              {ref}`Lim et al. (2002) Non-Polynomial <test-functions:lim-non-poly>`              |        2        |     `LimNonPoly()`      |
-|                  {ref}`Lim et al. (2002) Polynomial <test-functions:lim-poly>`                  |        2        |       `LimPoly()`       |
-| {ref}`Linkletter et al. (2006) Decreasing Coefficients <test-functions:linkletter-dec-coeffs>`  |       10        | `LinkletterDecCoeffs()` |
-|            {ref}`Linkletter et al. (2006) Linear <test-functions:linkletter-linear>`            |       10        |  `LinkletterLinear()`   |
-|                           {ref}`McLain S1 <test-functions:mclain-s1>`                           |        2        |      `McLainS1()`       |
-|                           {ref}`McLain S2 <test-functions:mclain-s2>`                           |        2        |      `McLainS2()`       |
-|                           {ref}`McLain S3 <test-functions:mclain-s3>`                           |        2        |      `McLainS3()`       |
-|                           {ref}`McLain S4 <test-functions:mclain-s4>`                           |        2        |      `McLainS4()`       |
-|                           {ref}`McLain S5 <test-functions:mclain-s5>`                           |        2        |      `McLainS5()`       |
-|                  {ref}`Oakley & O'Hagan (2002) 1D <test-functions:oakley-1d>`                   |        1        |      `Oakley1D()`       |
-|                         {ref}`OTL Circuit <test-functions:otl-circuit>`                         |     6 / 20      |     `OTLCircuit()`      |
-|                        {ref}`Piston Simulation <test-functions:piston>`                         |     7 / 20      |       `Piston()`        |
-|                           {ref}`Robot Arm <test-functions:robot-arm>`                           |        8        |      `RobotArm()`       |
-|                       {ref}`Solar Cell Model <test-functions:solar-cell>`                       |        5        |      `SolarCell()`      |
-|                              {ref}`Sulfur <test-functions:sulfur>`                              |        9        |       `Sulfur()`        |
-|                 {ref}`Undamped Oscillator <test-functions:undamped-oscillator>`                 |        6        | `UndampedOscillator()`  |
-|                   {ref}`Webster et al. (1996) 2D <test-functions:webster-2d>`                   |        2        |      `Webster2D()`      |
-|                      {ref}`Welch et al. (1992) <test-functions:welch1992>`                      |       20        |      `Welch1992()`      |
-|                         {ref}`Wing Weight <test-functions:wing-weight>`                         |       10        |     `WingWeight()`      |
+|                                              Name                                              | Input Dimension |       Constructor       |
+|:----------------------------------------------------------------------------------------------:|:---------------:|:-----------------------:|
+|                             {ref}`Ackley <test-functions:ackley>`                              |        M        |       `Ackley()`        |
+|              {ref}`Alemazkoor & Meidani (2018) 2D <test-functions:alemazkoor-2d>`              |        2        |    `Alemazkoor2D()`     |
+|             {ref}`Alemazkoor & Meidani (2018) 20D <test-functions:alemazkoor-20d>`             |       20        |    `Alemazkoor20D()`    |
+|                           {ref}`Borehole <test-functions:borehole>`                            |        8        |      `Borehole()`       |
+|                   {ref}`Cheng and Sandu (2010) 2D <test-functions:cheng2d>`                    |        2        |        `Cheng2D`        |
+|                      {ref}`Coffee Cup Model <test-functions:coffee-cup>`                       |        2        |      `CoffeeCup()`      |
+|                 {ref}`Currin et al. (1988) Sine <test-functions:currin-sine>`                  |        1        |     `CurrinSine()`      |
+|                      {ref}`Damped Cosine <test-functions:damped-cosine>`                       |        1        |    `DampedCosine()`     |
+|                  {ref}`Damped Oscillator <test-functions:damped-oscillator>`                   |        7        |  `DampedOscillator()`   |
+|                 {ref}`Dette & Pepelyshev (2010) 8D <test-functions:dette-8d>`                  |        3        |       `Dette8D()`       |
+|             {ref}`Dette & Pepelyshev (2010) Curved <test-functions:dette-curved>`              |        3        |     `DetteCurved()`     |
+|            {ref}`Dette & Pepelyshev (2010) Exponential <test-functions:dette-exp>`             |        3        |      `DetteExp()`       |
+|                              {ref}`Flood <test-functions:flood>`                               |        8        |        `Flood()`        |
+|                   {ref}`Forrester et al. (2008) <test-functions:forrester>`                    |        1        |    `Forrester2008()`    |
+|                         {ref}`(1st) Franke <test-functions:franke-1>`                          |        2        |       `Franke1()`       |
+|                         {ref}`(2nd) Franke <test-functions:franke-2>`                          |        2        |       `Franke2()`       |
+|                         {ref}`(3rd) Franke <test-functions:franke-3>`                          |        2        |       `Franke3()`       |
+|                         {ref}`(4th) Franke <test-functions:franke-4>`                          |        2        |       `Franke4()`       |
+|                         {ref}`(5th) Franke <test-functions:franke-5>`                          |        2        |       `Franke5()`       |
+|                         {ref}`(6th) Franke <test-functions:franke-6>`                          |        2        |       `Franke6()`       |
+|                       {ref}`Friedman (6D) <test-functions:friedman-6d>`                        |        6        |     `Friedman6D()`      |
+|                      {ref}`Friedman (10D) <test-functions:friedman-10d>`                       |       10        |     `Friedman10D()`     |
+|                  {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`                   |        M        |   `GenzCornerPeak()`    |
+|                 {ref}`Gramacy (2007) 1D Sine <test-functions:gramacy-1d-sine>`                 |        1        |    `Gramacy1DSine()`    |
+|                     {ref}`Higdon (2002) Sine <test-functions:higdon-sine>`                     |        1        |     `HigdonSine()`      |
+|               {ref}`Holsclaw et al. (2013) Sine <test-functions:holsclaw-sine>`                |        1        |    `HolsclawSine()`     |
+|             {ref}`Lim et al. (2002) Non-Polynomial <test-functions:lim-non-poly>`              |        2        |     `LimNonPoly()`      |
+|                 {ref}`Lim et al. (2002) Polynomial <test-functions:lim-poly>`                  |        2        |       `LimPoly()`       |
+| {ref}`Linkletter et al. (2006) Decreasing Coefficients <test-functions:linkletter-dec-coeffs>` |       10        | `LinkletterDecCoeffs()` |
+|           {ref}`Linkletter et al. (2006) Linear <test-functions:linkletter-linear>`            |       10        |  `LinkletterLinear()`   |
+|             {ref}`Linkletter et al. (2006) Sine <test-functions:linkletter-sine>`              |       10        |   `LinkletterSine()`    |
+|                          {ref}`McLain S1 <test-functions:mclain-s1>`                           |        2        |      `McLainS1()`       |
+|                          {ref}`McLain S2 <test-functions:mclain-s2>`                           |        2        |      `McLainS2()`       |
+|                          {ref}`McLain S3 <test-functions:mclain-s3>`                           |        2        |      `McLainS3()`       |
+|                          {ref}`McLain S4 <test-functions:mclain-s4>`                           |        2        |      `McLainS4()`       |
+|                          {ref}`McLain S5 <test-functions:mclain-s5>`                           |        2        |      `McLainS5()`       |
+|                  {ref}`Oakley & O'Hagan (2002) 1D <test-functions:oakley-1d>`                  |        1        |      `Oakley1D()`       |
+|                        {ref}`OTL Circuit <test-functions:otl-circuit>`                         |     6 / 20      |     `OTLCircuit()`      |
+|                        {ref}`Piston Simulation <test-functions:piston>`                        |     7 / 20      |       `Piston()`        |
+|                          {ref}`Robot Arm <test-functions:robot-arm>`                           |        8        |      `RobotArm()`       |
+|                      {ref}`Solar Cell Model <test-functions:solar-cell>`                       |        5        |      `SolarCell()`      |
+|                             {ref}`Sulfur <test-functions:sulfur>`                              |        9        |       `Sulfur()`        |
+|                {ref}`Undamped Oscillator <test-functions:undamped-oscillator>`                 |        6        | `UndampedOscillator()`  |
+|                  {ref}`Webster et al. (1996) 2D <test-functions:webster-2d>`                   |        2        |      `Webster2D()`      |
+|                     {ref}`Welch et al. (1992) <test-functions:welch1992>`                      |       20        |      `Welch1992()`      |
+|                        {ref}`Wing Weight <test-functions:wing-weight>`                         |       10        |     `WingWeight()`      |
 
 In a Python terminal, you can list all the available functions relevant
 for metamodeling applications using ``list_functions()``

--- a/docs/fundamentals/sensitivity.md
+++ b/docs/fundamentals/sensitivity.md
@@ -18,34 +18,35 @@ kernelspec:
 The table below listed the available test functions typically used
 in the comparison of sensitivity analysis methods.
 
-|                                              Name                                               | Input Dimension |       Constructor        |
-|:-----------------------------------------------------------------------------------------------:|:---------------:|:------------------------:|
-|                            {ref}`Borehole <test-functions:borehole>`                            |        8        |       `Borehole()`       |
-|                  {ref}`Bratley et al. (1992) A <test-functions:bratley1992a>`                   |        M        |     `Bratley1992a()`     |
-|                  {ref}`Bratley et al. (1992) B <test-functions:bratley1992b>`                   |        M        |     `Bratley1992b()`     |
-|                  {ref}`Bratley et al. (1992) C <test-functions:bratley1992c>`                   |        M        |     `Bratley1992c()`     |
-|                  {ref}`Bratley et al. (1992) D <test-functions:bratley1992d>`                   |        M        |     `Bratley1992d()`     |
-|                   {ref}`Damped Oscillator <test-functions:damped-oscillator>`                   |        7        |   `DampedOscillator()`   |
-|                               {ref}`Flood <test-functions:flood>`                               |        8        |        `Flood()`         |
-|                        {ref}`Friedman (6D) <test-functions:friedman-6d>`                        |        6        |      `Friedman6D()`      |
-|                   {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`                   |        M        |    `GenzCornerPeak()`    |
-|                 {ref}`Genz (Discontinuous) <test-functions:genz-discontinuous>`                 |        M        |  `GenzDiscontinuous()`   |
-|                            {ref}`Ishigami <test-functions:ishigami>`                            |        3        |       `Ishigami()`       |
-| {ref}`Linkletter et al. (2006) Decreasing Coefficients <test-functions:linkletter-dec-coeffs>`  |       10        | `LinkletterDecCoeffs()`  |
-|            {ref}`Linkletter et al. (2006) Linear <test-functions:linkletter-linear>`            |       10        |   `LinkletterLinear()`   |
-|                          {ref}`Moon (2010) 3D <test-functions:moon3d>`                          |        3        |        `Moon3D()`        |
-|                     {ref}`Morris et al. (2006) <test-functions:morris2006>`                     |        M        |      `Morris2006()`      |
-|                         {ref}`OTL Circuit <test-functions:otl-circuit>`                         |     6 / 20      |      `OTLCircuit()`      |
-|                        {ref}`Piston Simulation <test-functions:piston>`                         |     7 / 20      |        `Piston()`        |
-|                   {ref}`Simple Portfolio Model <test-functions:portfolio-3d>`                   |        3        |     `Portfolio3D()`      |
-|                     {ref}`SaltelliLinear <test-functions:saltelli-linear>`                      |        M        |    `SaltelliLinear()`    |
-|                            {ref}`Sobol'-G <test-functions:sobol-g>`                             |        M        |        `SobolG()`        |
-|                         {ref}`Sobol'-G* <test-functions:sobol-g-star>`                          |        M        |      `SobolGStar()`      |
-|                      {ref}`Sobol'-Levitan <test-functions:sobol-levitan>`                       |        M        |     `SobolLevitan()`     |
-|                       {ref}`Solar Cell Model <test-functions:solar-cell>`                       |        5        |      `SolarCell()`       |
-|                              {ref}`Sulfur <test-functions:sulfur>`                              |        9        |        `Sulfur()`        |
-|                      {ref}`Welch et al. (1992) <test-functions:welch1992>`                      |       20        |      `Welch1992()`       |
-|                         {ref}`Wing Weight <test-functions:wing-weight>`                         |       10        |      `WingWeight()`      |
+|                                              Name                                              | Input Dimension |       Constructor       |
+|:----------------------------------------------------------------------------------------------:|:---------------:|:-----------------------:|
+|                           {ref}`Borehole <test-functions:borehole>`                            |        8        |      `Borehole()`       |
+|                  {ref}`Bratley et al. (1992) A <test-functions:bratley1992a>`                  |        M        |    `Bratley1992a()`     |
+|                  {ref}`Bratley et al. (1992) B <test-functions:bratley1992b>`                  |        M        |    `Bratley1992b()`     |
+|                  {ref}`Bratley et al. (1992) C <test-functions:bratley1992c>`                  |        M        |    `Bratley1992c()`     |
+|                  {ref}`Bratley et al. (1992) D <test-functions:bratley1992d>`                  |        M        |    `Bratley1992d()`     |
+|                  {ref}`Damped Oscillator <test-functions:damped-oscillator>`                   |        7        |  `DampedOscillator()`   |
+|                              {ref}`Flood <test-functions:flood>`                               |        8        |        `Flood()`        |
+|                       {ref}`Friedman (6D) <test-functions:friedman-6d>`                        |        6        |     `Friedman6D()`      |
+|                  {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`                   |        M        |   `GenzCornerPeak()`    |
+|                {ref}`Genz (Discontinuous) <test-functions:genz-discontinuous>`                 |        M        |  `GenzDiscontinuous()`  |
+|                           {ref}`Ishigami <test-functions:ishigami>`                            |        3        |      `Ishigami()`       |
+| {ref}`Linkletter et al. (2006) Decreasing Coefficients <test-functions:linkletter-dec-coeffs>` |       10        | `LinkletterDecCoeffs()` |
+|           {ref}`Linkletter et al. (2006) Linear <test-functions:linkletter-linear>`            |       10        |  `LinkletterLinear()`   |
+|             {ref}`Linkletter et al. (2006) Sine <test-functions:linkletter-sine>`              |       10        |   `LinkletterSine()`    |
+|                         {ref}`Moon (2010) 3D <test-functions:moon3d>`                          |        3        |       `Moon3D()`        |
+|                    {ref}`Morris et al. (2006) <test-functions:morris2006>`                     |        M        |     `Morris2006()`      |
+|                        {ref}`OTL Circuit <test-functions:otl-circuit>`                         |     6 / 20      |     `OTLCircuit()`      |
+|                        {ref}`Piston Simulation <test-functions:piston>`                        |     7 / 20      |       `Piston()`        |
+|                  {ref}`Simple Portfolio Model <test-functions:portfolio-3d>`                   |        3        |     `Portfolio3D()`     |
+|                     {ref}`SaltelliLinear <test-functions:saltelli-linear>`                     |        M        |   `SaltelliLinear()`    |
+|                            {ref}`Sobol'-G <test-functions:sobol-g>`                            |        M        |       `SobolG()`        |
+|                         {ref}`Sobol'-G* <test-functions:sobol-g-star>`                         |        M        |     `SobolGStar()`      |
+|                      {ref}`Sobol'-Levitan <test-functions:sobol-levitan>`                      |        M        |    `SobolLevitan()`     |
+|                      {ref}`Solar Cell Model <test-functions:solar-cell>`                       |        5        |      `SolarCell()`      |
+|                             {ref}`Sulfur <test-functions:sulfur>`                              |        9        |       `Sulfur()`        |
+|                     {ref}`Welch et al. (1992) <test-functions:welch1992>`                      |       20        |      `Welch1992()`      |
+|                        {ref}`Wing Weight <test-functions:wing-weight>`                         |       10        |     `WingWeight()`      |
 
 In a Python terminal, you can list all the available functions relevant
 for metamodeling applications using ``list_functions()``

--- a/docs/test-functions/available.md
+++ b/docs/test-functions/available.md
@@ -68,6 +68,7 @@ regardless of their typical applications.
 |                 {ref}`Lim et al. (2002) Polynomial <test-functions:lim-poly>`                  |        2        |           `LimPoly()`           |
 | {ref}`Linkletter et al. (2006) Decreasing Coefficients <test-functions:linkletter-dec-coeffs>` |       10        |     `LinkletterDecCoeffs()`     |
 |           {ref}`Linkletter et al. (2006) Linear <test-functions:linkletter-linear>`            |       10        |      `LinkletterLinear()`       |
+|             {ref}`Linkletter et al. (2006) Sine <test-functions:linkletter-sine>`              |       10        |       `LinkletterSine()`        |
 |                          {ref}`McLain S1 <test-functions:mclain-s1>`                           |        2        |          `McLainS1()`           |
 |                          {ref}`McLain S2 <test-functions:mclain-s2>`                           |        2        |          `McLainS2()`           |
 |                          {ref}`McLain S3 <test-functions:mclain-s3>`                           |        2        |          `McLainS3()`           |

--- a/docs/test-functions/linkletter-dec-coeffs.md
+++ b/docs/test-functions/linkletter-dec-coeffs.md
@@ -21,12 +21,12 @@ import matplotlib.pyplot as plt
 import uqtestfuns as uqtf
 ```
 
-The linear function is a ten-dimensional, scalar-valued function whose
+The function is a ten-dimensional, scalar-valued function whose
 coefficients are decreasing. Only the first eight input variables are active,
 while the rest is inert.
 The function was used in {cite}`Linkletter2006` to demonstrate a variable
 selection method (i.e., sensitivity analysis)
-in the context of Gaussian process metamodeling:
+in the context of Gaussian process metamodeling.
 
 ```{note}
 Linkletter et al. {cite}`Linkletter2006` introduced four ten-dimensional
@@ -39,6 +39,9 @@ in the context of Gaussian process metamodeling:
 - {ref}`Linear with decreasing coefficients <test-functions:linkletter-dec-coeffs>`
   function features a slightly more complex linear function with eight active
   input variables (out of 10). (_this function_)
+- {ref}`Sine <test-functions:linkletter-sine>` function features only two
+  active input variables (out of 10); the effect of the two inputs on
+  the output, however, is very different.
 ```
 
 

--- a/docs/test-functions/linkletter-sine.md
+++ b/docs/test-functions/linkletter-sine.md
@@ -12,8 +12,8 @@ kernelspec:
   name: python3
 ---
 
-(test-functions:linkletter-linear)=
-# Linear Function from Linkletter et al. (2006)
+(test-functions:linkletter-sine)=
+# Sine Function from Linkletter et al. (2006)
 
 ```{code-cell} ipython3
 import numpy as np
@@ -22,7 +22,7 @@ import uqtestfuns as uqtf
 ```
 
 The function is a ten-dimensional, scalar-valued function.
-Only the first four input variables are active, while the rest is inert.
+Only the first two input variables are active, while the rest is inert.
 The function was used in {cite}`Linkletter2006` to demonstrate a variable
 selection method (i.e., sensitivity analysis)
 in the context of Gaussian process metamodeling.
@@ -35,13 +35,66 @@ in the context of Gaussian process metamodeling:
 
 - {ref}`Linear <test-functions:linkletter-linear>` function features
   a simple function with four active input variables (out of 10).
-  (_this function_)
 - {ref}`Linear with decreasing coefficients <test-functions:linkletter-dec-coeffs>`
   function features a slightly more complex linear function with eight active
   input variables (out of 10).
 - {ref}`Sine <test-functions:linkletter-sine>` function features only two
   active input variables (out of 10); the effect of the two inputs on
-  the output, however, is very different.
+  the output, however, is very different. (_this function_).
+```
+
+Because the function is effectively two dimensional, the surface and contour
+plots are shown below.
+
+```{code-cell} ipython3
+:tags: [remove-input]
+
+from mpl_toolkits.axes_grid1 import make_axes_locatable
+
+my_fun = uqtf.LinkletterSine()
+
+# --- Create 2D data
+xx_1d = np.linspace(0.0, 1.0, 1000)[:, np.newaxis]
+mesh_2d = np.meshgrid(xx_1d, xx_1d)
+xx_2d = np.array(mesh_2d).T.reshape(-1, 2)
+xx = my_fun.prob_input.get_sample(len(xx_2d))
+xx[:,:2] = xx_2d
+yy_2d = my_fun(xx)
+
+# --- Create two-dimensional plots
+fig = plt.figure(figsize=(10, 5))
+
+# Surface
+axs_1 = plt.subplot(121, projection='3d')
+axs_1.plot_surface(
+    mesh_2d[0],
+    mesh_2d[1],
+    yy_2d.reshape(1000,1000).T,
+    linewidth=0,
+    cmap="plasma",
+    antialiased=False,
+    alpha=0.5
+)
+axs_1.set_xlabel("$x_1$", fontsize=14)
+axs_1.set_ylabel("$x_2$", fontsize=14)
+axs_1.set_zlabel("$\mathcal{M}(x_1, x_2)$", fontsize=14)
+axs_1.set_title("Surface plot of LinkletterSine", fontsize=14)
+
+# Contour
+axs_2 = plt.subplot(122)
+cf = axs_2.contourf(
+    mesh_2d[0], mesh_2d[1], yy_2d.reshape(1000, 1000).T, cmap="plasma", levels=10,
+)
+axs_2.set_xlabel("$x_1$", fontsize=14)
+axs_2.set_ylabel("$x_2$", fontsize=14)
+axs_2.set_title("Contour plot of LinkletterSine", fontsize=14)
+divider = make_axes_locatable(axs_2)
+cax = divider.append_axes('right', size='5%', pad=0.05)
+fig.colorbar(cf, cax=cax, orientation='vertical')
+axs_2.axis('scaled')
+
+fig.tight_layout(pad=4.0)
+plt.gcf().set_dpi(75);
 ```
 
 
@@ -50,7 +103,7 @@ in the context of Gaussian process metamodeling:
 To create a default instance of the test function:
 
 ```{code-cell} ipython3
-my_testfun = uqtf.LinkletterLinear()
+my_testfun = uqtf.LinkletterSine()
 ```
 
 Check if it has been correctly instantiated:
@@ -64,12 +117,12 @@ print(my_testfun)
 The test function is defined as[^location]:
 
 $$
-\mathcal{M}(\boldsymbol{x}) = 0.2 \sum_{i = 1}^4 x_i,
+\mathcal{M}(\boldsymbol{x}) = \sin{(x_1)} + \sin{(5 x_2)},
 $$
 
 where $\boldsymbol{x} = \left( x_1, \ldots x_{10} \right)$
 is the ten-dimensional vector of input variables further defined below.
-Notice that only four out of ten input variables are active.
+Notice that only two out of ten input variables are active.
 
 ```{note}
 In the original paper, the function was added with an independent identically
@@ -126,4 +179,4 @@ plt.gcf().set_dpi(150);
 :filter: docname in docnames
 ```
 
-[^location]: see Eq. (5), Example 1, in {cite}`Linkletter2006`.
+[^location]: see Eq. (7), Example 3, in {cite}`Linkletter2006`.

--- a/src/uqtestfuns/test_functions/__init__.py
+++ b/src/uqtestfuns/test_functions/__init__.py
@@ -35,7 +35,7 @@ from .holsclaw_sine import HolsclawSine
 from .hyper_sphere import HyperSphere
 from .ishigami import Ishigami
 from .lim import LimPoly, LimNonPoly
-from .linkletter import LinkletterLinear, LinkletterDecCoeffs
+from .linkletter import LinkletterLinear, LinkletterDecCoeffs, LinkletterSine
 from .oakley2002 import Oakley1D
 from .otl_circuit import OTLCircuit
 from .mclain import McLainS1, McLainS2, McLainS3, McLainS4, McLainS5
@@ -107,6 +107,7 @@ __all__ = [
     "LimPoly",
     "LinkletterDecCoeffs",
     "LinkletterLinear",
+    "LinkletterSine",
     "Oakley1D",
     "OTLCircuit",
     "McLainS1",

--- a/src/uqtestfuns/test_functions/linkletter.py
+++ b/src/uqtestfuns/test_functions/linkletter.py
@@ -8,8 +8,9 @@ All functions are defined in ten dimensions but some of them are inactive.
 
 Available functions are:
 
-- Linear function with four active input variables..
+- Linear function with four active input variables.
 - Linear function with decreasing coefficients, eight active input variables.
+- Sine function with two active input variables.
 
 References
 ----------
@@ -22,10 +23,21 @@ References
 
 import numpy as np
 
-from uqtestfuns.core.custom_typing import ProbInputSpecs
+from uqtestfuns.core.custom_typing import MarginalSpecs, ProbInputSpecs
 from uqtestfuns.core.uqtestfun_abc import UQTestFunFixDimABC
 
-__all__ = ["LinkletterLinear", "LinkletterDecCoeffs"]
+
+MARGINALS_LINKLETTER2006: MarginalSpecs = [
+    {
+        "name": f"x_{i + 1}",
+        "distribution": "uniform",
+        "parameters": [0, 1],
+        "description": None,
+    }
+    for i in range(10)
+]
+
+__all__ = ["LinkletterLinear", "LinkletterDecCoeffs", "LinkletterSine"]
 
 
 def evaluate_linear(xx: np.ndarray) -> np.ndarray:
@@ -42,6 +54,10 @@ def evaluate_linear(xx: np.ndarray) -> np.ndarray:
     np.ndarray
         The output of the test function evaluated on the input values.
         The output is a 1-dimensional array of length N.
+
+    Notes
+    -----
+    - Only the first four input variables are active; the rest is inactive.
     """
     yy = 0.2 * np.sum(xx[:, :4], axis=1)
 
@@ -62,6 +78,10 @@ def evaluate_dec_coeffs(xx: np.ndarray) -> np.ndarray:
     np.ndarray
         The output of the test function evaluated on the input values.
         The output is a 1-dimensional array of length N.
+
+    Notes
+    -----
+    - Only the first eight input variables are active; the rest is inactive.
     """
     exps = np.arange(8)  # 8 input variables are active
     coeffs = 0.2 / 2**exps
@@ -71,11 +91,37 @@ def evaluate_dec_coeffs(xx: np.ndarray) -> np.ndarray:
     return yy
 
 
+def evaluate_sine(xx: np.ndarray) -> np.ndarray:
+    """Evaluate the sine function from Linkletter et al. (2006).
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        M-Dimensional input values given by an N-by-10 array where
+        N is the number of input values.
+
+    Returns
+    -------
+    np.ndarray
+        The output of the test function evaluated on the input values.
+        The output is a 1-dimensional array of length N.
+
+    Notes
+    -----
+    - Only the first two input variables are active; the rest is inactive.
+    """
+    yy = np.sin(xx[:, 0]) + np.sin(5 * xx[:, 1])
+
+    return yy
+
+
 class LinkletterLinear(UQTestFunFixDimABC):
     """A concrete implementation of the linear function."""
 
     _tags = ["metamodeling", "sensitivity"]
-    _description = "Linear function from Linkletter et al. (2006)"
+    _description = (
+        "Linear function with 4 active inputs from Linkletter et al. (2006)"
+    )
     _available_inputs: ProbInputSpecs = {
         "Linkletter2006": {
             "function_id": "LinkletterLinear",
@@ -83,15 +129,7 @@ class LinkletterLinear(UQTestFunFixDimABC):
                 "Input specification for the linear test function Eq. (5)"
                 "from Linkletter et al. (2006)"
             ),
-            "marginals": [
-                {
-                    "name": f"x_{i + 1}",
-                    "distribution": "uniform",
-                    "parameters": [0, 1],
-                    "description": None,
-                }
-                for i in range(10)
-            ],
+            "marginals": MARGINALS_LINKLETTER2006,
             "copulas": None,
         },
     }
@@ -105,8 +143,8 @@ class LinkletterDecCoeffs(UQTestFunFixDimABC):
 
     _tags = ["metamodeling", "sensitivity"]
     _description = (
-        "Linear function with decreasing coefficients from Linkletter et al. "
-        "(2006)"
+        "Linear function with decreasing coefficients (8 active inputs) "
+        "from Linkletter et al. (2006)"
     )
     _available_inputs: ProbInputSpecs = {
         "Linkletter2006": {
@@ -115,18 +153,33 @@ class LinkletterDecCoeffs(UQTestFunFixDimABC):
                 "Input specification for the linear test function with "
                 "decreasing coefficients Eq. (6) from Linkletter et al. (2006)"
             ),
-            "marginals": [
-                {
-                    "name": f"x_{i + 1}",
-                    "distribution": "uniform",
-                    "parameters": [0, 1],
-                    "description": None,
-                }
-                for i in range(10)
-            ],
+            "marginals": MARGINALS_LINKLETTER2006,
             "copulas": None,
         },
     }
     _available_parameters = None
 
     evaluate = staticmethod(evaluate_dec_coeffs)  # type: ignore
+
+
+class LinkletterSine(UQTestFunFixDimABC):
+    """A concrete implementation of the sine function."""
+
+    _tags = ["metamodeling", "sensitivity"]
+    _description = (
+        "Sine function with 2 active inputs from Linkletter et al. (2006)"
+    )
+    _available_inputs: ProbInputSpecs = {
+        "Linkletter2006": {
+            "function_id": "LinkletterSine",
+            "description": (
+                "Input specification for the sine test function with Eq. (7)"
+                "from Linkletter et al. (2006)"
+            ),
+            "marginals": MARGINALS_LINKLETTER2006,
+            "copulas": None,
+        },
+    }
+    _available_parameters = None
+
+    evaluate = staticmethod(evaluate_sine)  # type: ignore


### PR DESCRIPTION
This commit introduces the ten-dimensional sine function from Linkletter et al. (2006). The function features only two active variables and was used in the context of sensitivity (screening) analysis.

The documentation has been updated accordingly.

This PR should resolve Issue #329.
