### PR TITLE
Add the inert function from Linkletter et al. (2006)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The ten-dimensional inert function from Linkletter et al. (2006) with
+  no active input variable whatsoever; the function was used in the context of
+  sensitivity analysis.
 - The ten-dimensional sine function from Linkletter et al. (2006) featuring
   only two active input variables out of ten; the function was used in the
   context of metamodeling and sensitivity analysis.

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -128,6 +128,8 @@ parts:
             title: Lim et al. (2002) Polynomial
           - file: test-functions/linkletter-dec-coeffs
             title: Linkletter et al. (2006) Dec. Coeffs.
+          - file: test-functions/linkletter-inert
+            title: Linkletter et al. (2006) Inert
           - file: test-functions/linkletter-linear
             title: Linkletter et al. (2006) Linear
           - file: test-functions/linkletter-sine

--- a/docs/fundamentals/sensitivity.md
+++ b/docs/fundamentals/sensitivity.md
@@ -32,6 +32,7 @@ in the comparison of sensitivity analysis methods.
 |                {ref}`Genz (Discontinuous) <test-functions:genz-discontinuous>`                 |        M        |  `GenzDiscontinuous()`  |
 |                           {ref}`Ishigami <test-functions:ishigami>`                            |        3        |      `Ishigami()`       |
 | {ref}`Linkletter et al. (2006) Decreasing Coefficients <test-functions:linkletter-dec-coeffs>` |       10        | `LinkletterDecCoeffs()` |
+|            {ref}`Linkletter et al. (2006) Inert <test-functions:linkletter-inert>`             |       10        |   `LinkletterInert()`   |
 |           {ref}`Linkletter et al. (2006) Linear <test-functions:linkletter-linear>`            |       10        |  `LinkletterLinear()`   |
 |             {ref}`Linkletter et al. (2006) Sine <test-functions:linkletter-sine>`              |       10        |   `LinkletterSine()`    |
 |                         {ref}`Moon (2010) 3D <test-functions:moon3d>`                          |        3        |       `Moon3D()`        |

--- a/docs/test-functions/available.md
+++ b/docs/test-functions/available.md
@@ -67,6 +67,7 @@ regardless of their typical applications.
 |             {ref}`Lim et al. (2002) Non-Polynomial <test-functions:lim-non-poly>`              |        2        |         `LimNonPoly()`          |
 |                 {ref}`Lim et al. (2002) Polynomial <test-functions:lim-poly>`                  |        2        |           `LimPoly()`           |
 | {ref}`Linkletter et al. (2006) Decreasing Coefficients <test-functions:linkletter-dec-coeffs>` |       10        |     `LinkletterDecCoeffs()`     |
+|            {ref}`Linkletter et al. (2006) Inert <test-functions:linkletter-inert>`             |       10        |       `LinkletterInert()`       |
 |           {ref}`Linkletter et al. (2006) Linear <test-functions:linkletter-linear>`            |       10        |      `LinkletterLinear()`       |
 |             {ref}`Linkletter et al. (2006) Sine <test-functions:linkletter-sine>`              |       10        |       `LinkletterSine()`        |
 |                          {ref}`McLain S1 <test-functions:mclain-s1>`                           |        2        |          `McLainS1()`           |

--- a/docs/test-functions/linkletter-dec-coeffs.md
+++ b/docs/test-functions/linkletter-dec-coeffs.md
@@ -42,6 +42,8 @@ in the context of Gaussian process metamodeling:
 - {ref}`Sine <test-functions:linkletter-sine>` function features only two
   active input variables (out of 10); the effect of the two inputs on
   the output, however, is very different.
+- {ref}`Inert <test-functions:linkletter-inert>` function does not have any
+  active input variables; a constant zero is returned for any input values.
 ```
 
 

--- a/docs/test-functions/linkletter-inert.md
+++ b/docs/test-functions/linkletter-inert.md
@@ -12,8 +12,8 @@ kernelspec:
   name: python3
 ---
 
-(test-functions:linkletter-linear)=
-# Linear Function from Linkletter et al. (2006)
+(test-functions:linkletter-inert)=
+# Inert Function from Linkletter et al. (2006)
 
 ```{code-cell} ipython3
 import numpy as np
@@ -22,7 +22,7 @@ import uqtestfuns as uqtf
 ```
 
 The function is a ten-dimensional, scalar-valued function.
-Only the first four input variables are active, while the rest is inert.
+None of the input variables are active, while the rest is inert.
 The function was used in {cite}`Linkletter2006` to demonstrate a variable
 selection method (i.e., sensitivity analysis)
 in the context of Gaussian process metamodeling.
@@ -35,7 +35,6 @@ in the context of Gaussian process metamodeling:
 
 - {ref}`Linear <test-functions:linkletter-linear>` function features
   a simple function with four active input variables (out of 10).
-  (_this function_)
 - {ref}`Linear with decreasing coefficients <test-functions:linkletter-dec-coeffs>`
   function features a slightly more complex linear function with eight active
   input variables (out of 10).
@@ -44,15 +43,15 @@ in the context of Gaussian process metamodeling:
   the output, however, is very different.
 - {ref}`Inert <test-functions:linkletter-inert>` function does not have any
   active input variables; a constant zero is returned for any input values.
+  (_this function_)
 ```
-
 
 ## Test function instance
 
 To create a default instance of the test function:
 
 ```{code-cell} ipython3
-my_testfun = uqtf.LinkletterLinear()
+my_testfun = uqtf.LinkletterSine()
 ```
 
 Check if it has been correctly instantiated:
@@ -66,17 +65,18 @@ print(my_testfun)
 The test function is defined as[^location]:
 
 $$
-\mathcal{M}(\boldsymbol{x}) = 0.2 \sum_{i = 1}^4 x_i,
+\mathcal{M}(\boldsymbol{x}) = 0,
 $$
 
 where $\boldsymbol{x} = \left( x_1, \ldots x_{10} \right)$
 is the ten-dimensional vector of input variables further defined below.
-Notice that only four out of ten input variables are active.
+Notice that none of the ten input variables are active.
 
 ```{note}
 In the original paper, the function was added with an independent identically
 distributed (i.i.d) noise from $\mathcal{N}(0, \sigma)$
-with a standard deviation $\sigma = 0.05$.
+with a standard deviation $\sigma = 0.05$. The response of this function
+is basically just a random noise.
 
 Furthermore, also in the original paper, a batch of data is generated from
 the function and then standardized to have mean $0.0$ and standard deviation
@@ -97,30 +97,6 @@ The probabilistic input model for the test function is shown below.
 print(my_testfun.prob_input)
 ```
 
-## Reference results
-
-This section provides several reference results of typical UQ analyses involving
-the test function.
-
-### Sample histogram
-
-Shown below is the histogram of the output based on $100'000$ random points:
-
-```{code-cell} ipython3
-:tags: [hide-input]
-
-my_testfun.prob_input.reset_rng(42)
-xx_test = my_testfun.prob_input.get_sample(100000)
-yy_test = my_testfun(xx_test)
-
-plt.hist(yy_test, bins="auto", color="#8da0cb");
-plt.grid();
-plt.ylabel("Counts [-]");
-plt.xlabel("$\mathcal{M}(X)$");
-plt.gcf().tight_layout(pad=3.0)
-plt.gcf().set_dpi(150);
-```
-
 ## References
 
 ```{bibliography}
@@ -128,4 +104,4 @@ plt.gcf().set_dpi(150);
 :filter: docname in docnames
 ```
 
-[^location]: see Eq. (5), Example 1, in {cite}`Linkletter2006`.
+[^location]: see Example 2, in {cite}`Linkletter2006`.

--- a/docs/test-functions/linkletter-sine.md
+++ b/docs/test-functions/linkletter-sine.md
@@ -41,6 +41,8 @@ in the context of Gaussian process metamodeling:
 - {ref}`Sine <test-functions:linkletter-sine>` function features only two
   active input variables (out of 10); the effect of the two inputs on
   the output, however, is very different. (_this function_).
+- {ref}`Inert <test-functions:linkletter-inert>` function does not have any
+  active input variables; a constant zero is returned for any input values.  
 ```
 
 Because the function is effectively two dimensional, the surface and contour

--- a/src/uqtestfuns/test_functions/__init__.py
+++ b/src/uqtestfuns/test_functions/__init__.py
@@ -35,7 +35,12 @@ from .holsclaw_sine import HolsclawSine
 from .hyper_sphere import HyperSphere
 from .ishigami import Ishigami
 from .lim import LimPoly, LimNonPoly
-from .linkletter import LinkletterLinear, LinkletterDecCoeffs, LinkletterSine
+from .linkletter import (
+    LinkletterDecCoeffs,
+    LinkletterInert,
+    LinkletterLinear,
+    LinkletterSine,
+)
 from .oakley2002 import Oakley1D
 from .otl_circuit import OTLCircuit
 from .mclain import McLainS1, McLainS2, McLainS3, McLainS4, McLainS5
@@ -106,6 +111,7 @@ __all__ = [
     "LimNonPoly",
     "LimPoly",
     "LinkletterDecCoeffs",
+    "LinkletterInert",
     "LinkletterLinear",
     "LinkletterSine",
     "Oakley1D",

--- a/src/uqtestfuns/test_functions/linkletter.py
+++ b/src/uqtestfuns/test_functions/linkletter.py
@@ -11,6 +11,7 @@ Available functions are:
 - Linear function with four active input variables.
 - Linear function with decreasing coefficients, eight active input variables.
 - Sine function with two active input variables.
+- Inert function without any active input variables.
 
 References
 ----------
@@ -37,7 +38,12 @@ MARGINALS_LINKLETTER2006: MarginalSpecs = [
     for i in range(10)
 ]
 
-__all__ = ["LinkletterLinear", "LinkletterDecCoeffs", "LinkletterSine"]
+__all__ = [
+    "LinkletterLinear",
+    "LinkletterDecCoeffs",
+    "LinkletterInert",
+    "LinkletterSine",
+]
 
 
 def evaluate_linear(xx: np.ndarray) -> np.ndarray:
@@ -115,6 +121,30 @@ def evaluate_sine(xx: np.ndarray) -> np.ndarray:
     return yy
 
 
+def evaluate_inert(xx: np.ndarray) -> np.ndarray:
+    """Evaluate the inert function from Linkletter et al. (2006).
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        M-Dimensional input values given by an N-by-10 array where
+        N is the number of input values.
+
+    Returns
+    -------
+    np.ndarray
+        The output of the test function evaluated on the input values.
+        The output is a 1-dimensional array of length N.
+
+    Notes
+    -----
+    - None of the input variables is active; the function always returns 0.
+    """
+    yy = np.zeros(xx.shape[0])
+
+    return yy
+
+
 class LinkletterLinear(UQTestFunFixDimABC):
     """A concrete implementation of the linear function."""
 
@@ -173,8 +203,8 @@ class LinkletterSine(UQTestFunFixDimABC):
         "Linkletter2006": {
             "function_id": "LinkletterSine",
             "description": (
-                "Input specification for the sine test function with Eq. (7)"
-                "from Linkletter et al. (2006)"
+                "Input specification for the sine test function Eq. (7) with "
+                "two active inputs from Linkletter et al. (2006)"
             ),
             "marginals": MARGINALS_LINKLETTER2006,
             "copulas": None,
@@ -183,3 +213,26 @@ class LinkletterSine(UQTestFunFixDimABC):
     _available_parameters = None
 
     evaluate = staticmethod(evaluate_sine)  # type: ignore
+
+
+class LinkletterInert(UQTestFunFixDimABC):
+    """A concrete implementation of the inert function."""
+
+    _tags = ["sensitivity"]
+    _description = (
+        "Inert function with 10 inactive inputs from Linkletter et al. (2006)"
+    )
+    _available_inputs: ProbInputSpecs = {
+        "Linkletter2006": {
+            "function_id": "LinkletterInert",
+            "description": (
+                "Input specification for the inert test function "
+                "from Linkletter et al. (2006)"
+            ),
+            "marginals": MARGINALS_LINKLETTER2006,
+            "copulas": None,
+        },
+    }
+    _available_parameters = None
+
+    evaluate = staticmethod(evaluate_inert)  # type: ignore


### PR DESCRIPTION
Introduced a ten-dimensional inert function from Linkletter et al. (2006) with no active input variables, always returning zero.
The function was used in a variable selection method in metamodeling (basically, sensitivity analysis).

The documentation has been updated accordingly.

This PR should resolve Issue #433.