### PR TITLE
Rename `Gramacy1DSine` to `GramacySine`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for metamodeling exercise.
 - The 8-dimensional robot arm function for metamodeling exercises.
 
+## Changed
+
+- The function `Gramacy1DSine` has been renamed to `GramacySine` for
+  conciseness and consistency with the other sine-based functions.
+
 ## Fixed
 
 - The fifth input variable of the Friedman is now active instead of the sixth.

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -112,8 +112,8 @@ parts:
             title: Genz (Oscillatory)
           - file: test-functions/genz-product-peak
             title: Genz (Product Peak)
-          - file: test-functions/gramacy-1d-sine
-            title: Gramacy (2007) 1D Sine
+          - file: test-functions/gramacy-sine
+            title: Gramacy (2007) Sine
           - file: test-functions/higdon-sine
             title: Higdon (2002) Sine
           - file: test-functions/holsclaw-sine

--- a/docs/fundamentals/metamodeling.md
+++ b/docs/fundamentals/metamodeling.md
@@ -43,7 +43,7 @@ in the comparison of metamodeling approaches.
 |                       {ref}`Friedman (6D) <test-functions:friedman-6d>`                        |        6        |     `Friedman6D()`      |
 |                      {ref}`Friedman (10D) <test-functions:friedman-10d>`                       |       10        |     `Friedman10D()`     |
 |                  {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`                   |        M        |   `GenzCornerPeak()`    |
-|                 {ref}`Gramacy (2007) 1D Sine <test-functions:gramacy-1d-sine>`                 |        1        |    `Gramacy1DSine()`    |
+|                    {ref}`Gramacy (2007) Sine <test-functions:gramacy-sine>`                    |        1        |     `GramacySine()`     |
 |                     {ref}`Higdon (2002) Sine <test-functions:higdon-sine>`                     |        1        |     `HigdonSine()`      |
 |               {ref}`Holsclaw et al. (2013) Sine <test-functions:holsclaw-sine>`                |        1        |    `HolsclawSine()`     |
 |             {ref}`Lim et al. (2002) Non-Polynomial <test-functions:lim-non-poly>`              |        2        |     `LimNonPoly()`      |

--- a/docs/test-functions/available.md
+++ b/docs/test-functions/available.md
@@ -59,7 +59,7 @@ regardless of their typical applications.
 |                     {ref}`Genz (Gaussian) <test-functions:genz-gaussian>`                      |        M        |        `GenzGaussian()`         |
 |                  {ref}`Genz (Oscillatory) <test-functions:genz-oscillatory>`                   |        M        |       `GenzOscillatory()`       |
 |                 {ref}`Genz (Product Peak) <test-functions:genz-product-peak>`                  |        M        |       `GenzProductPeak()`       |
-|                 {ref}`Gramacy (2007) 1D Sine <test-functions:gramacy-1d-sine>`                 |        1        |        `Gramacy1DSine()`        |
+|                    {ref}`Gramacy (2007) Sine <test-functions:gramacy-sine>`                    |        1        |         `GramacySine()`         |
 |                     {ref}`Higdon (2002) Sine <test-functions:higdon-sine>`                     |        1        |         `HigdonSine()`          |
 |               {ref}`Holsclaw et al. (2013) Sine <test-functions:holsclaw-sine>`                |        1        |        `HolsclawSine()`         |
 |                    {ref}`Hyper-sphere Bound <test-functions:hyper-sphere>`                     |        2        |         `HyperSphere()`         |

--- a/docs/test-functions/gramacy-sine.md
+++ b/docs/test-functions/gramacy-sine.md
@@ -12,8 +12,8 @@ kernelspec:
   name: python3
 ---
 
-(test-functions:gramacy-1d-sine)=
-# Gramacy (2007) One-dimensional (1D) Sine Function
+(test-functions:gramacy-sine)=
+# Gramacy (2007) Sine Function
 
 ```{code-cell} ipython3
 import numpy as np
@@ -21,10 +21,11 @@ import matplotlib.pyplot as plt
 import uqtestfuns as uqtf
 ```
 
-The Gramacy (2007) one-dimensional (1D) sine function 
-(or `Gramacy1DSine` function for short)
-is a scalar-valued function that features two regimes: one part is a mixture
-of sines and cosines, and another part is a linear function.
+The Gramacy (2007) sine function 
+(or `GramacySine` function for short)
+is a one-dimensional, scalar-valued function that features two regimes:
+one part is a mixture of sines and cosines,
+and another part is a linear function.
 The function was introduced in {cite}`Gramacy2007` in the context of 
 metamodeling with non-stationary Gaussian processes.
 
@@ -33,13 +34,16 @@ A plot of the function is shown below for $x \in [0, 20]$.
 ```{code-cell} ipython3
 :tags: [remove-input]
 
-my_testfun = uqtf.Gramacy1DSine()
+my_testfun = uqtf.GramacySine()
 
 xx = np.linspace(0, 20, 100)[:, np.newaxis]
 yy = my_testfun(xx)
+rng = np.random.default_rng(42)
+yy_train = yy + rng.normal(0, 0.1, size=100)
 
 # --- Create the plot
 plt.plot(xx, yy, color="#8da0cb")
+plt.scatter(xx, yy_train, color="#8da0cb")
 plt.grid()
 plt.xlabel("$x$")
 plt.ylabel("$\mathcal{M}(x)$")
@@ -54,6 +58,8 @@ the change of regime.
 In the original paper, the response of the function is disturbed by an 
 independent identically distributed (i.i.d) Gaussian noise 
 $\varepsilon \sim \mathcal{N}(0, \sigma_n=0.1)$.
+The training data is generated from 100 equispaced points in $[0., 20.]$;
+these points are shown in the above plot.
 ```
 
 ## Test function instance
@@ -61,7 +67,7 @@ $\varepsilon \sim \mathcal{N}(0, \sigma_n=0.1)$.
 To create a default instance of the test function:
 
 ```{code-cell} ipython3
-my_testfun = uqtf.Gramacy1DSine()
+my_testfun = uqtf.GramacySine()
 ```
 
 Check if it has been correctly instantiated:

--- a/src/uqtestfuns/test_functions/__init__.py
+++ b/src/uqtestfuns/test_functions/__init__.py
@@ -29,7 +29,7 @@ from .genz import (
     GenzOscillatory,
     GenzProductPeak,
 )
-from .gramacy2007 import Gramacy1DSine
+from .gramacy2007 import GramacySine
 from .higdon_sine import HigdonSine
 from .holsclaw_sine import HolsclawSine
 from .hyper_sphere import HyperSphere
@@ -103,7 +103,7 @@ __all__ = [
     "GenzGaussian",
     "GenzOscillatory",
     "GenzProductPeak",
-    "Gramacy1DSine",
+    "GramacySine",
     "HigdonSine",
     "HolsclawSine",
     "HyperSphere",

--- a/src/uqtestfuns/test_functions/gramacy2007.py
+++ b/src/uqtestfuns/test_functions/gramacy2007.py
@@ -23,7 +23,7 @@ import numpy as np
 from uqtestfuns.core.custom_typing import ProbInputSpecs
 from uqtestfuns.core.uqtestfun_abc import UQTestFunFixDimABC
 
-__all__ = ["Gramacy1DSine"]
+__all__ = ["GramacySine"]
 
 
 AVAILABLE_INPUTS: ProbInputSpecs = {
@@ -76,7 +76,7 @@ def evaluate_1dsine(xx: np.ndarray) -> np.ndarray:
     return yy
 
 
-class Gramacy1DSine(UQTestFunFixDimABC):
+class GramacySine(UQTestFunFixDimABC):
     """A concrete implementation of the 1D Gramacy (2007) Sine function."""
 
     _tags = ["metamodeling"]


### PR DESCRIPTION
The function `Gramacy1DSine` has been renamed to `GramacySine` for conciseness and consistency with other sine-based test functions. The documentation has been updated accordingly.

This PR should resolve Issue #421.