### PR TITLE
Add a new use case reference for the Ackley function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- An additional use case reference for the Ackley function (as a metamodeling
+  test function).
 - The ten-dimensional inert function from Linkletter et al. (2006) with
   no active input variable whatsoever; the function was used in the context of
   sensitivity analysis.

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1054,4 +1054,15 @@ An orthogonal design in which the design matrix has uncorrelated columns is impo
   doi     = {10.1198/004017006000000228},
 }
 
+@Article{Kaintura2017,
+  author  = {Kaintura, A. and Spina, D. and Couckuyt, I. and Knockaert, L. and Bogaerts, W. and Dhaene, T.},
+  journal = {Engineering with Computers},
+  title   = {A {Kriging} and {Stochastic Collocation} ensemble for uncertainty quantification in engineering applications},
+  year    = {2017},
+  number  = {4},
+  pages   = {935--949},
+  volume  = {33},
+  doi     = {10.1007/s00366-017-0507-0},
+}
+
 @Comment{jabref-meta: databaseType:bibtex;}

--- a/docs/test-functions/ackley.md
+++ b/docs/test-functions/ackley.md
@@ -15,11 +15,14 @@ kernelspec:
 (test-functions:ackley)=
 # Ackley Function
 
-The Ackley function  is an $M$-dimensional scalar-valued function.
-The function was first introduced by Ackley {cite}`Ackley1987`
-as a test function for optimization algorithms.
-Originally presented as a two-dimensional function,
-it was later generalized by Bäck and Schwefel {cite}`Baeck1993`.
+The Ackley function is an $M$-dimensional scalar-valued function.
+Introduced by Ackley {cite}`Ackley1987` as a benchmark function for
+global optimization algorithms, the function was originally presented in
+two dimensions.
+Bäck and Schwefel {cite}`Baeck1993` later generalized the function to higher
+dimensions.
+More recently, it was employed as a test function for a metamodeling method
+in {cite}`Kaintura2017`.
 
 ```{code-cell} ipython3
 import numpy as np


### PR DESCRIPTION
The documentation for the Ackley function now includes the reference to the paper by Kaitura et al. (2017) that employed the function as a test function for a metamodeling method.

This PR should resolve Issue #406.