### PR TITLE
Fix RNG seed handling in ProbInput class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 
+- Assigning an integer value to `rng_seed` property of `ProbInput` now
+  correctly reset the RNG with the assigned seed number.
 - The fifth input variable of the Friedman is now active instead of the sixth.
   Only the first five input variables of the Friedman functions are active.
 - The argument `input_dimension` to filter the output of `list_functions()`

--- a/src/uqtestfuns/core/prob_input/probabilistic_input.py
+++ b/src/uqtestfuns/core/prob_input/probabilistic_input.py
@@ -85,7 +85,7 @@ class ProbInput:
     @rng_seed.setter
     def rng_seed(self, value: Optional[int]):
         """Set/reset the seed for RNG."""
-        self.reset_rng(self._rng_seed)
+        self.reset_rng(value)
 
     def transform_sample(self, xx: np.ndarray, other: ProbInput):
         """Transform a sample from the distribution to another."""

--- a/tests/core/prob_input/test_prob_input.py
+++ b/tests/core/prob_input/test_prob_input.py
@@ -214,7 +214,7 @@ def test_set_rng_seed(input_dimension):
     marginals = create_random_marginals(input_dimension)
 
     # Create two instances with an identical seed number
-    my_input = ProbInput(marginals, rng_seed=42)
+    my_input = ProbInput(marginals)
 
     # Generate sample points
     xx_1 = my_input.get_sample(1000)
@@ -224,6 +224,8 @@ def test_set_rng_seed(input_dimension):
     assert not np.allclose(xx_1, xx_2)
 
     # Reset the RNG and generate new sample points
+    my_input.rng_seed = 42
+    xx_1 = my_input.get_sample(1000)
     my_input.rng_seed = 42
     xx_2 = my_input.get_sample(1000)
 


### PR DESCRIPTION
Assigning an integer value to `rng_seed`
property of `ProbInput` class will correctly reset the RNG with the assigned seed value.

This PR should resolve Issue #424.