### PR TITLE
Add `RealVariable` class to represent continuous design variables

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,8 @@ jobs:
     name: Check code formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4.0.0
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install tox
@@ -20,8 +20,8 @@ jobs:
     name: Check code linting
     runs-on: ubuntu-latest
     steps:
-       - uses: actions/checkout@v3
-       - uses: actions/setup-python@v4.0.0
+       - uses: actions/checkout@v4
+       - uses: actions/setup-python@v5
          with:
             python-version: "3.10"
        - name: Install tox
@@ -32,8 +32,8 @@ jobs:
     name: Static type checking
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4.0.0
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install tox
@@ -42,7 +42,7 @@ jobs:
         run: tox -e typecheck
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python:
@@ -59,7 +59,7 @@ jobs:
           - version: "3.13"
             toxenv: "py313"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4.0.0
         with:
           python-version: ${{ matrix.python.version }}
@@ -71,8 +71,8 @@ jobs:
     name: Test (on Python 3.10) w/ coverage to CodeCov
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4.0.0
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install tox
@@ -82,35 +82,38 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
   build_wheels:
-    name: Build wheels on Ubuntu 20.04
-    runs-on: ubuntu-20.04
+    name: Build wheels on Ubuntu latest
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4.0.0
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install build
         run: python -m pip install build
       - name: Build wheels
         run: python -m build --wheel
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./dist/*.whl
+          name: wheel
+
   build_sdist:
-    name: Build source distribution on Ubuntu 20.04
-    runs-on: ubuntu-20.04
+    name: Build source distribution on Ubuntu latest
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4.0.0
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install build
         run: python -m pip install build
       - name: Build wheels
         run: python -m build --sdist
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           path: ./dist/*.tar.gz
+          name: sdist
   publish:
     name: Publish package
     if: startsWith(github.event.ref, 'refs/tags/v')

--- a/src/uqtestfuns/__init__.py
+++ b/src/uqtestfuns/__init__.py
@@ -14,7 +14,7 @@ from .core import (
 )
 from .core import UQTestFun
 from .core import FunParams
-
+from .core import RealVariable
 
 from . import test_functions
 from .test_functions import *  # noqa
@@ -40,6 +40,7 @@ __all__ = [
     "UQTestFunFixDimABC",
     "UQTestFunVarDimABC",
     "UQTestFun",
+    "RealVariable",
     "test_functions",
     "UQMetaFunSpec",
     "UQMetaTestFun",

--- a/src/uqtestfuns/core/__init__.py
+++ b/src/uqtestfuns/core/__init__.py
@@ -2,6 +2,7 @@
 The core subpackage of uqtestfuns.
 """
 
+from .design_vars.real_variable import RealVariable
 from .parameters import FunParams
 from .prob_input.marginal import Marginal
 from .prob_input.probabilistic_input import ProbInput
@@ -17,6 +18,7 @@ __all__ = [
     "Marginal",
     "ProbInput",
     "FunParams",
+    "RealVariable",
     "UQTestFunBareABC",
     "UQTestFunABC",
     "UQTestFunFixDimABC",

--- a/src/uqtestfuns/core/design_vars/__init__.py
+++ b/src/uqtestfuns/core/design_vars/__init__.py
@@ -1,0 +1,3 @@
+"""
+Sub-package to model design variables in design optimization test functions.
+"""

--- a/src/uqtestfuns/core/design_vars/design_variable_abc.py
+++ b/src/uqtestfuns/core/design_vars/design_variable_abc.py
@@ -1,0 +1,70 @@
+"""
+Module with an abstract class for defining a design variable.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from abc import ABC, abstractmethod
+from typing import Optional
+
+__all__ = ["DesignVariableABC"]
+
+
+class DesignVariableABC(ABC):
+
+    _rng: Optional[np.random.Generator] = None
+    _rng_seed: Optional[int] = None
+
+    @property
+    @abstractmethod
+    def bounds(self):
+        """The bounds of the design variable."""
+        pass
+
+    @abstractmethod
+    def is_valid(self, xx):
+        """Verify if the given value is valid."""
+        pass
+
+    @abstractmethod
+    def get_sample(self, sample_size: int) -> np.ndarray:
+        """Get a random sample of design variable values.
+
+        Parameters
+        ----------
+        sample_size : int
+            The number of sample points to generate.
+
+        Returns
+        -------
+        np.ndarray
+            The generated sample in an :math:`N`-by-:math:`M` array
+            where :math:`N` and :math:`M` are the sample size
+            and the number of input dimensions, respectively.
+        """
+        pass
+
+    @abstractmethod
+    def transform_to(self, xx, lower: float, upper: float):
+        """Transform sample values from internal bounds to target bounds."""
+        pass
+
+    @abstractmethod
+    def transform_from(self, xx, lower: float, upper: float):
+        """Transform sample values from a set of target bounds."""
+        pass
+
+    def reset_rng(self, rng_seed: Optional[int] = None):
+        """Reset the random number generator.
+
+        Parameters
+        ----------
+        rng_seed : Optional[int]
+            The seed for the random number generator. If None, internal
+            state is used.
+        """
+        rng = np.random.default_rng(rng_seed)
+        self._rng = rng
+        self._rng_seed = rng_seed

--- a/src/uqtestfuns/core/design_vars/design_variable_abc.py
+++ b/src/uqtestfuns/core/design_vars/design_variable_abc.py
@@ -19,17 +19,17 @@ class DesignVariableABC(ABC):
 
     @property
     @abstractmethod
-    def bounds(self):
+    def bounds(self):  # pragma: no cover
         """The bounds of the design variable."""
         pass
 
     @abstractmethod
-    def is_valid(self, xx):
+    def is_valid(self, xx):  # pragma: no cover
         """Verify if the given value is valid."""
         pass
 
     @abstractmethod
-    def get_sample(self, sample_size: int) -> np.ndarray:
+    def get_sample(self, sample_size: int) -> np.ndarray:  # pragma: no cover
         """Get a random sample of design variable values.
 
         Parameters
@@ -47,12 +47,17 @@ class DesignVariableABC(ABC):
         pass
 
     @abstractmethod
-    def transform_to(self, xx, lower: float, upper: float):
+    def transform_to(self, xx, lower: float, upper: float):  # pragma: no cover
         """Transform sample values from internal bounds to target bounds."""
         pass
 
     @abstractmethod
-    def transform_from(self, xx, lower: float, upper: float):
+    def transform_from(
+        self,
+        xx,
+        lower: float,
+        upper: float,
+    ):  # pragma: no cover
         """Transform sample values from a set of target bounds."""
         pass
 

--- a/src/uqtestfuns/core/design_vars/design_variables.py
+++ b/src/uqtestfuns/core/design_vars/design_variables.py
@@ -1,0 +1,3 @@
+"""
+Module with an abstract for defining design variables.
+"""

--- a/src/uqtestfuns/core/design_vars/real_variable.py
+++ b/src/uqtestfuns/core/design_vars/real_variable.py
@@ -1,0 +1,210 @@
+"""
+Module with concrete implementation of real (continuous) design variables.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from numpy.random._generator import Generator
+from typing import Optional, Union
+
+from .design_variable_abc import DesignVariableABC
+
+
+class RealVariable(DesignVariableABC):
+    """Class representing a real (continuous) bounded design variable.
+
+    Parameters
+    ----------
+    lower : float
+        The lower bound of the continuous design variable.
+    upper : float
+        The upper bound of the continuous design variable.
+    name : str, optional
+        The name of the design variable. If not specified, the value is None.
+    description : str, optional
+        The short description of the design variable. If not specified,
+        the value is None.
+    rng_seed : int, optional
+        The seed number to initialize an internal random number generator.
+    """
+
+    def __init__(
+        self,
+        lower: float,
+        upper: float,
+        name: str = None,
+        description: str = None,
+        rng_seed: Optional[int] = None,
+    ) -> None:
+
+        _verify_bounds(lower, upper)
+        self._lower = float(lower)
+        self._upper = float(upper)
+        self.name: Optional[str] = name
+        self.description: Optional[str] = description
+        self._rng_seed = rng_seed
+        self._rng: Optional[Generator] = None
+
+    @property
+    def bounds(self) -> tuple[float, float]:
+        return self._lower, self._upper
+
+    @property
+    def rng(self) -> Generator:
+        if self._rng is None:
+            self._rng = np.random.default_rng(self._rng_seed)
+        return self._rng
+
+    @property
+    def rng_seed(self) -> Optional[int]:
+        return self._rng_seed
+
+    @rng_seed.setter
+    def rng_seed(self, value: Optional[int]):
+        self.reset_rng(value)
+
+    def get_sample(self, sample_size: int) -> np.ndarray:
+        """Get a random sample of design variable values.
+
+        Parameters
+        ----------
+        sample_size : int
+            The number of sample points to generate.
+
+        Returns
+        -------
+        np.ndarray
+            The generated sample in an array of length :math:`N`.
+        """
+        lower, upper = self.bounds
+        xx = self.rng.uniform(lower, upper, size=sample_size)
+
+        return xx
+
+    def is_valid(
+        self,
+        xx: Union[float, np.ndarray],
+    ) -> Union[bool, np.ndarray]:
+        """Check if the given value is valid.
+
+        Parameters
+        ----------
+        xx : Union[float, np.ndarray]
+            The value to be checked; it can be a scalar or an array.
+        """
+        return np.logical_and(xx >= self._lower, xx <= self._upper)
+
+    def transform_to(
+        self,
+        xx: Union[float, np.ndarray],
+        lower: float,
+        upper: float,
+    ) -> Union[float, np.ndarray]:
+        """Transform sample values from specified bounds to target bounds.
+
+        Parameters
+        ----------
+        xx : Union[float, np.ndarray]
+            The sample values to be transformed.
+        lower : float
+            The lower target bound.
+        upper : float
+            The upper target bound.
+
+        Returns
+        -------
+        Union[float, np.ndarray]
+            The transformed sample values.
+        """
+        _verify_bounds(lower, upper)
+        if not np.all(self.is_valid(xx)):
+            raise ValueError("The given sample is not valid!")
+
+        origin_lower, origin_upper = self.bounds
+        origin_diff = origin_upper - origin_lower
+
+        return lower + (upper - lower) / origin_diff * (xx - origin_lower)
+
+    def transform_from(
+        self,
+        xx: Union[float, np.ndarray],
+        lower: float,
+        upper: float,
+    ) -> Union[float, np.ndarray]:
+        """Transform sample values from a set of origin bounds.
+
+        Parameters
+        ----------
+        xx : Union[float, np.ndarray]
+            The sample values to be transformed.
+        lower : float
+            The lower origin bound.
+        upper : float
+            The upper origin bound.
+
+        Returns
+        -------
+        Union[float, np.ndarray]
+            The transformed sample values.
+        """
+        _verify_bounds(lower, upper)
+        var_temp = RealVariable(lower, upper)
+        if not np.all(var_temp.is_valid(xx)):
+            raise ValueError("The given sample is not valid!")
+
+        target_lower, target_upper = self.bounds
+        target_diff = target_upper - target_lower
+
+        return target_lower + target_diff / (upper - lower) * (xx - lower)
+
+    def __repr__(self):
+        """Return the unambiguous string representation of the instance."""
+        class_name = self.__class__.__name__
+        # Get the value of the constructor arguments
+        attrs = {
+            "lower": self._lower,
+            "upper": self._upper,
+            "name": self.name,
+            "description": self.description,
+            "rng_seed": self._rng_seed,
+        }
+        attrs_str = ", ".join(f"{k}={v!r}" for k, v in attrs.items())
+
+        return f"{class_name}({attrs_str})"
+
+    def __str__(self):
+        """Return human-readable string representation of the instance."""
+        table = "Continuous Design Variable\n"
+        table += f"Lower Bound : {self._lower}\n"
+        table += f"Upper Bound : {self._upper}\n"
+        table += f"Name        : {self.name}\n"
+
+        # Parse the description column
+        if self.description is None or self.description == "":
+            description = "-"
+        else:
+            description = self.description
+        table += f"Description : {description}"
+
+        return table
+
+
+def _verify_bounds(lower: float, upper: float):
+    """Verify if the given bounds are valid.
+
+    Parameters
+    ----------
+    lower : float
+        The lower bound.
+    upper : float
+        The upper bound.
+
+    Raises
+    ------
+    ValueError
+        If the lower bound is greater than or equal to the upper bound.
+    """
+    if lower >= upper:
+        raise ValueError("Lower bound must be smaller than upper bound.")

--- a/src/uqtestfuns/core/design_vars/real_variable.py
+++ b/src/uqtestfuns/core/design_vars/real_variable.py
@@ -34,8 +34,8 @@ class RealVariable(DesignVariableABC):
         self,
         lower: float,
         upper: float,
-        name: str = None,
-        description: str = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
         rng_seed: Optional[int] = None,
     ) -> None:
 

--- a/src/uqtestfuns/core/uqtestfun_abc.py
+++ b/src/uqtestfuns/core/uqtestfun_abc.py
@@ -459,7 +459,7 @@ class UQTestFunFixDimABC(UQTestFunABC, ABC):
 
         return ProbInput(**input_data)
 
-    def _create_fun_params(self, parameters_id: Optional[str]) -> FunParams:
+    def _create_fun_params(self, parameters_id: str) -> FunParams:
         """Create an instance of function parameters.
 
         Parameters
@@ -600,7 +600,7 @@ class UQTestFunVarDimABC(UQTestFunABC, ABC):
 
     def _create_fun_params(
         self,
-        parameters_id: Optional[str],
+        parameters_id: str,
         input_dim: int,
     ) -> FunParams:
         """Create an instance of function parameters.

--- a/src/uqtestfuns/test_functions/portfolio_3d.py
+++ b/src/uqtestfuns/test_functions/portfolio_3d.py
@@ -31,19 +31,19 @@ MARGINALS_SALTELLI2004: MarginalSpecs = [
         "name": "Ps",
         "distribution": "normal",
         "parameters": [0.0, 4.0],
-        "description": "Hedged portfolio 's' [\N{euro sign}]",
+        "description": "Hedged portfolio 's' [\N{EURO SIGN}]",
     },
     {
         "name": "Pt",
         "distribution": "normal",
         "parameters": [0.0, 2.0],
-        "description": "Hedged portfolio 't' [\N{euro sign}]",
+        "description": "Hedged portfolio 't' [\N{EURO SIGN}]",
     },
     {
         "name": "Pj",
         "distribution": "normal",
         "parameters": [0.0, 1.0],
-        "description": "Hedged portfolio 'j' [\N{euro sign}]",
+        "description": "Hedged portfolio 'j' [\N{EURO SIGN}]",
     },
 ]
 

--- a/tests/core/design_variables/test_realvariable.py
+++ b/tests/core/design_variables/test_realvariable.py
@@ -1,6 +1,7 @@
 """
 Test module for RealVariable class.
 """
+
 import numpy as np
 import pytest
 import random
@@ -23,7 +24,7 @@ def realvar_fixture():
 class TestInit:
     """Collection of tests for initialization."""
 
-    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("lower", [0.0, 1.0, 2.0])
     @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
     def test_init(self, lower, upper):
         """Test default construction."""
@@ -33,7 +34,7 @@ class TestInit:
         assert lb == lower
         assert ub == upper
 
-    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("lower", [0.0, 1.0, 2.0])
     @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
     @pytest.mark.parametrize("name_desc", ["a", "b", "c"])
     def test_init_with_name_and_description(self, lower, upper, name_desc):
@@ -47,8 +48,8 @@ class TestInit:
         assert my_realvar.name == name_desc
         assert my_realvar.description == name_desc
 
-    @pytest.mark.parametrize("lower", [5., 6., 7.])
-    @pytest.mark.parametrize("upper", [4., 3., 5.])
+    @pytest.mark.parametrize("lower", [5.0, 6.0, 7.0])
+    @pytest.mark.parametrize("upper", [4.0, 3.0, 5.0])
     def test_init_invalid_bounds(self, lower, upper):
         """Test construction with invalid bounds."""
 
@@ -198,7 +199,7 @@ class TestGetSample:
         with pytest.raises(ValueError):
             _ = realvar_fixture.get_sample(-1)
 
-    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("lower", [0.0, 1.0, 2.0])
     @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
     def test_different_seeds(self, lower, upper):
         """Test initialization with different seeds."""
@@ -215,7 +216,7 @@ class TestGetSample:
 class TestTransformTo:
     """Collection of tests for the transform_to() method."""
 
-    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("lower", [0.0, 1.0, 2.0])
     @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
     def test_transform_to_scalar(self, realvar_fixture, lower, upper):
         """Test the transformation of a scalar value."""
@@ -229,7 +230,7 @@ class TestTransformTo:
         assert not np.all(realvar_2.is_valid(xx_ori))
         assert np.all(realvar_2.is_valid(xx_tra))
 
-    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("lower", [0.0, 1.0, 2.0])
     @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
     def test_transform_to_array(self, realvar_fixture, lower, upper):
         """Test the transformation of an array of values."""
@@ -243,8 +244,8 @@ class TestTransformTo:
         assert not np.all(realvar_2.is_valid(xx_ori))
         assert np.all(realvar_2.is_valid(xx_tra))
 
-    @pytest.mark.parametrize("lower", [5., 6., 7.])
-    @pytest.mark.parametrize("upper", [4., 3., 5.])
+    @pytest.mark.parametrize("lower", [5.0, 6.0, 7.0])
+    @pytest.mark.parametrize("upper", [4.0, 3.0, 5.0])
     def test_invalid_bounds(self, realvar_fixture, lower, upper):
         """Test transformation with invalid bounds."""
         xx_ori = realvar_fixture.get_sample(100)
@@ -252,17 +253,16 @@ class TestTransformTo:
         with pytest.raises(ValueError):
             _ = realvar_fixture.transform_to(xx_ori, lower, upper)
 
-    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
-    @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
-    def test_invalid_sample(self, realvar_fixture, lower, upper):
-        """Test the failure of transformation with invalid sample."""
-        lower_ori, _ = realvar_fixture.bounds
+    def test_invalid_sample(self, realvar_fixture):
+        """Test the failure of transformation with an invalid sample."""
+        lower_ori, upper_ori = realvar_fixture.bounds
         xx_ori = np.random.uniform(lower_ori - 2, lower_ori - 1, size=(100,))
 
         with pytest.raises(ValueError):
-            _ = realvar_fixture.transform_to(xx_ori, lower, upper)
+            # Inconsistent bounds
+            _ = realvar_fixture.transform_to(xx_ori, lower_ori, upper_ori)
 
-    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("lower", [0.0, 1.0, 2.0])
     @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
     def test_back_and_forth(self, realvar_fixture, lower, upper):
         """Test the back and forth transformation."""
@@ -278,7 +278,7 @@ class TestTransformTo:
 class TestTransformFrom:
     """Collection of tests for the transform_from() method."""
 
-    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("lower", [0.0, 1.0, 2.0])
     @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
     def test_transform_from_scalar(self, realvar_fixture, lower, upper):
         """Test the transformation of a scalar value."""
@@ -292,7 +292,7 @@ class TestTransformFrom:
         assert not np.all(realvar_2.is_valid(xx_ori))
         assert np.all(realvar_2.is_valid(xx_tra))
 
-    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("lower", [0.0, 1.0, 2.0])
     @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
     def test_transform_from_array(self, realvar_fixture, lower, upper):
         """Test the transformation of an array of values."""
@@ -306,8 +306,8 @@ class TestTransformFrom:
         assert not np.all(realvar_2.is_valid(xx_ori))
         assert np.all(realvar_2.is_valid(xx_tra))
 
-    @pytest.mark.parametrize("lower", [5., 6., 7.])
-    @pytest.mark.parametrize("upper", [4., 3., 5.])
+    @pytest.mark.parametrize("lower", [5.0, 6.0, 7.0])
+    @pytest.mark.parametrize("upper", [4.0, 3.0, 5.0])
     def test_invalid_bounds(self, realvar_fixture, lower, upper):
         """Test transformation with invalid bounds."""
         xx_target = realvar_fixture.get_sample(100)
@@ -315,11 +315,9 @@ class TestTransformFrom:
         with pytest.raises(ValueError):
             _ = realvar_fixture.transform_from(xx_target, lower, upper)
 
-    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
-    @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
-    def test_invalid_sample(self, realvar_fixture, lower, upper):
-        """Test the failure of transformation with invalid sample."""
-        lower_target, _ = realvar_fixture.bounds
+    def test_invalid_sample(self, realvar_fixture):
+        """Test the failure of transformation with an invalid sample."""
+        lower_target, upper_target = realvar_fixture.bounds
         xx_target = np.random.uniform(
             lower_target - 2,
             lower_target - 1,
@@ -327,9 +325,14 @@ class TestTransformFrom:
         )
 
         with pytest.raises(ValueError):
-            _ = realvar_fixture.transform_from(xx_target, lower, upper)
+            # Inconsistent bounds
+            _ = realvar_fixture.transform_from(
+                xx_target,
+                lower_target,
+                upper_target,
+            )
 
-    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("lower", [0.0, 1.0, 2.0])
     @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
     def test_back_and_forth(self, realvar_fixture, lower, upper):
         """Test the back and forth transformation."""

--- a/tests/core/design_variables/test_realvariable.py
+++ b/tests/core/design_variables/test_realvariable.py
@@ -1,0 +1,389 @@
+"""
+Test module for RealVariable class.
+"""
+import numpy as np
+import pytest
+import random
+
+from uqtestfuns import RealVariable
+
+
+@pytest.fixture
+def realvar_fixture():
+    # Generate the bounds randomly
+    lower = random.uniform(1.0, 100.0)
+    upper = random.uniform(lower, 100.0)
+
+    # Create an instance
+    my_realvar = RealVariable(lower, upper)
+
+    return my_realvar
+
+
+class TestInit:
+    """Collection of tests for initialization."""
+
+    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
+    def test_init(self, lower, upper):
+        """Test default construction."""
+        my_realvar = RealVariable(lower, upper)
+
+        lb, ub = my_realvar.bounds
+        assert lb == lower
+        assert ub == upper
+
+    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
+    @pytest.mark.parametrize("name_desc", ["a", "b", "c"])
+    def test_init_with_name_and_description(self, lower, upper, name_desc):
+        """Test construction with specified name and description."""
+        my_realvar = RealVariable(lower, upper, name_desc, name_desc)
+
+        lb, ub = my_realvar.bounds
+        assert lb == lower
+        assert ub == upper
+
+        assert my_realvar.name == name_desc
+        assert my_realvar.description == name_desc
+
+    @pytest.mark.parametrize("lower", [5., 6., 7.])
+    @pytest.mark.parametrize("upper", [4., 3., 5.])
+    def test_init_invalid_bounds(self, lower, upper):
+        """Test construction with invalid bounds."""
+
+        with pytest.raises(ValueError):
+            _ = RealVariable(lower, upper)
+
+    def test_type(self, realvar_fixture):
+        """Test the types of lower and upper bounds."""
+        lower, upper = realvar_fixture.bounds
+        assert isinstance(realvar_fixture.bounds, tuple)
+        assert isinstance(lower, float)
+        assert isinstance(upper, float)
+
+    def test_rng(self, realvar_fixture):
+        """Test rng property."""
+        # First call, an RNG is created
+        rng_1 = realvar_fixture.rng
+        assert isinstance(rng_1, np.random.Generator)
+
+        # Second call, the cached RNG is accessed
+        rng_2 = realvar_fixture.rng
+        assert rng_1 is rng_2
+
+
+class TestIsValid:
+    """Collection of tests for is_valid() method."""
+
+    def test_is_valid_scalar(self, realvar_fixture):
+        """Test checking validity of a scalar."""
+        # Get the bounds
+        lower, upper = realvar_fixture.bounds
+
+        # Generate a random value from within the bound
+        val = random.uniform(lower, upper)
+
+        # Assertion
+        assert realvar_fixture.is_valid(val)
+
+    def test_is_valid_array(self, realvar_fixture):
+        """Test checking the validity of values in an array."""
+        # Get the bounds
+        lower, upper = realvar_fixture.bounds
+
+        # Generate an array of random values from within the bound
+        vals = np.random.uniform(lower, upper, (10,))
+
+        # Assertion
+        assert np.all(realvar_fixture.is_valid(vals))
+
+        # Generate an array of random values from within the bound
+        vals = np.random.uniform(lower, upper, (10, 10))
+
+        # Assertion
+        assert np.all(realvar_fixture.is_valid(vals))
+
+    def test_boundary_scalar(self, realvar_fixture):
+        """Test checking the validity of boundary values given as a scalar."""
+        # Get the bounds
+        lower, upper = realvar_fixture.bounds
+
+        # Assertions
+        assert realvar_fixture.is_valid(lower)
+        assert realvar_fixture.is_valid(upper)
+
+    def test_boundary_array(self, realvar_fixture):
+        """Test checking the validity of boundary values given as an array."""
+        # Get the bounds
+        lower, upper = realvar_fixture.bounds
+        lower = np.ones(10) * lower
+        upper = np.ones(10) * upper
+
+        # Assertions
+        assert np.all(realvar_fixture.is_valid(lower))
+        assert np.all(realvar_fixture.is_valid(upper))
+
+    def test_invalid_bounds(self, realvar_fixture):
+        """Test checking the validity of invalid values given as a scalar."""
+        # Get the bounds
+        lower, upper = realvar_fixture.bounds
+
+        # Assertions
+        assert not realvar_fixture.is_valid(lower - 1)
+        assert not realvar_fixture.is_valid(upper + 1)
+
+    def test_invalid_array(self, realvar_fixture):
+        """Test checking the validity of invalid values given as an array."""
+        # Get the bounds
+        lower, upper = realvar_fixture.bounds
+
+        # Create arrays with out of bound values
+        lower = np.random.uniform(lower - 2, lower - 1, size=(100,))
+        upper = np.random.uniform(upper + 1, upper + 2, size=(100,))
+
+        # Assertions
+        assert not np.all(realvar_fixture.is_valid(lower))
+        assert not np.all(realvar_fixture.is_valid(upper))
+
+    def test_inf_validity(self, realvar_fixture):
+        """Test checking the validity of infinity value."""
+        assert not realvar_fixture.is_valid(np.inf)
+        assert not realvar_fixture.is_valid(-np.inf)
+
+    def test_nan_validity(self, realvar_fixture):
+        """Test checking the validity of nan value."""
+        assert not realvar_fixture.is_valid(np.nan)
+
+
+class TestGetSample:
+    """Collection of tests for get_sample() method."""
+
+    @pytest.mark.parametrize("sample_size", [1, 10, 100, 1000])
+    def test_sample_size(self, realvar_fixture, sample_size):
+        """Test generating different sample sizes."""
+        xx = realvar_fixture.get_sample(sample_size)
+
+        # Assertion
+        assert len(xx) == sample_size
+
+    @pytest.mark.parametrize("sample_size", [1, 10, 100, 1000])
+    def test_sample_validity(self, realvar_fixture, sample_size):
+        """Test checking the validity of generated samples."""
+        xx = realvar_fixture.get_sample(sample_size)
+
+        # Assertions
+        assert np.all(realvar_fixture.is_valid(xx))
+
+    @pytest.mark.parametrize("rng_seed", [0, 42, 100])
+    def test_reproducibility(self, rng_seed):
+        """Test reproducibility of the generated samples."""
+        realvar_1 = RealVariable(10, 20, rng_seed=rng_seed)
+        realvar_2 = RealVariable(10, 20, rng_seed=rng_seed)
+
+        xx_1 = realvar_1.get_sample(100)
+        xx_2 = realvar_2.get_sample(100)
+
+        # Assertions
+        assert np.all(xx_1 == xx_2)
+
+    @pytest.mark.parametrize("sample_size", [np.inf, np.nan])
+    def test_invalid_sample_size_type(self, realvar_fixture, sample_size):
+        """Test the failure of generating samples with invalid size type."""
+        with pytest.raises(TypeError):
+            _ = realvar_fixture.get_sample(sample_size)
+
+    def test_invalid_sample_size_value(self, realvar_fixture):
+        """Test the failure of generating samples with invalid size value."""
+        with pytest.raises(ValueError):
+            _ = realvar_fixture.get_sample(-1)
+
+    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
+    def test_different_seeds(self, lower, upper):
+        """Test initialization with different seeds."""
+        realvar_1 = RealVariable(lower, upper, rng_seed=0)
+        realvar_2 = RealVariable(lower, upper, rng_seed=1)
+
+        xx_1 = realvar_1.get_sample(100)
+        xx_2 = realvar_2.get_sample(100)
+
+        # Assertion
+        assert not np.all(xx_1 == xx_2)
+
+
+class TestTransformTo:
+    """Collection of tests for the transform_to() method."""
+
+    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
+    def test_transform_to_scalar(self, realvar_fixture, lower, upper):
+        """Test the transformation of a scalar value."""
+        realvar_1 = realvar_fixture
+        realvar_2 = RealVariable(lower, upper)
+
+        xx_ori = np.random.uniform(*realvar_1.bounds)
+        xx_tra = realvar_1.transform_to(xx_ori, lower, upper)
+
+        # Assertion
+        assert not np.all(realvar_2.is_valid(xx_ori))
+        assert np.all(realvar_2.is_valid(xx_tra))
+
+    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
+    def test_transform_to_array(self, realvar_fixture, lower, upper):
+        """Test the transformation of an array of values."""
+        realvar_1 = realvar_fixture
+        realvar_2 = RealVariable(lower, upper)
+
+        xx_ori = realvar_1.get_sample(100)
+        xx_tra = realvar_1.transform_to(xx_ori, lower, upper)
+
+        # Assertion
+        assert not np.all(realvar_2.is_valid(xx_ori))
+        assert np.all(realvar_2.is_valid(xx_tra))
+
+    @pytest.mark.parametrize("lower", [5., 6., 7.])
+    @pytest.mark.parametrize("upper", [4., 3., 5.])
+    def test_invalid_bounds(self, realvar_fixture, lower, upper):
+        """Test transformation with invalid bounds."""
+        xx_ori = realvar_fixture.get_sample(100)
+
+        with pytest.raises(ValueError):
+            _ = realvar_fixture.transform_to(xx_ori, lower, upper)
+
+    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
+    def test_invalid_sample(self, realvar_fixture, lower, upper):
+        """Test the failure of transformation with invalid sample."""
+        lower_ori, _ = realvar_fixture.bounds
+        xx_ori = np.random.uniform(lower_ori - 2, lower_ori - 1, size=(100,))
+
+        with pytest.raises(ValueError):
+            _ = realvar_fixture.transform_to(xx_ori, lower, upper)
+
+    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
+    def test_back_and_forth(self, realvar_fixture, lower, upper):
+        """Test the back and forth transformation."""
+        xx_origin = realvar_fixture.get_sample(100)
+        xx_target = realvar_fixture.transform_to(xx_origin, lower, upper)
+        xx_origin_2 = realvar_fixture.transform_from(xx_target, lower, upper)
+
+        # Assertions
+        assert np.all(realvar_fixture.is_valid(xx_origin_2))
+        assert np.allclose(xx_origin, xx_origin_2)
+
+
+class TestTransformFrom:
+    """Collection of tests for the transform_from() method."""
+
+    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
+    def test_transform_from_scalar(self, realvar_fixture, lower, upper):
+        """Test the transformation of a scalar value."""
+        realvar_1 = realvar_fixture
+        realvar_2 = RealVariable(lower, upper)
+
+        xx_ori = np.random.uniform(*realvar_1.bounds)
+        xx_tra = realvar_2.transform_from(xx_ori, *realvar_1.bounds)
+
+        # Assertion
+        assert not np.all(realvar_2.is_valid(xx_ori))
+        assert np.all(realvar_2.is_valid(xx_tra))
+
+    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
+    def test_transform_from_array(self, realvar_fixture, lower, upper):
+        """Test the transformation of an array of values."""
+        realvar_1 = realvar_fixture
+        realvar_2 = RealVariable(lower, upper)
+
+        xx_ori = realvar_1.get_sample(100)
+        xx_tra = realvar_2.transform_from(xx_ori, *realvar_1.bounds)
+
+        # Assertion
+        assert not np.all(realvar_2.is_valid(xx_ori))
+        assert np.all(realvar_2.is_valid(xx_tra))
+
+    @pytest.mark.parametrize("lower", [5., 6., 7.])
+    @pytest.mark.parametrize("upper", [4., 3., 5.])
+    def test_invalid_bounds(self, realvar_fixture, lower, upper):
+        """Test transformation with invalid bounds."""
+        xx_target = realvar_fixture.get_sample(100)
+
+        with pytest.raises(ValueError):
+            _ = realvar_fixture.transform_from(xx_target, lower, upper)
+
+    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
+    def test_invalid_sample(self, realvar_fixture, lower, upper):
+        """Test the failure of transformation with invalid sample."""
+        lower_target, _ = realvar_fixture.bounds
+        xx_target = np.random.uniform(
+            lower_target - 2,
+            lower_target - 1,
+            size=(100,),
+        )
+
+        with pytest.raises(ValueError):
+            _ = realvar_fixture.transform_from(xx_target, lower, upper)
+
+    @pytest.mark.parametrize("lower", [0., 1.0, 2.0])
+    @pytest.mark.parametrize("upper", [3.0, 4.0, 5.0])
+    def test_back_and_forth(self, realvar_fixture, lower, upper):
+        """Test the back and forth transformation."""
+        realvar_1 = realvar_fixture
+        realvar_2 = RealVariable(lower, upper)
+
+        # Create a target sample
+        xx_target_1 = realvar_2.get_sample(100)
+        xx_origin = realvar_1.transform_from(xx_target_1, lower, upper)
+        xx_target_2 = realvar_1.transform_to(xx_origin, lower, upper)
+
+        # Assertions
+        assert np.all(realvar_2.is_valid(xx_target_2))
+        assert np.allclose(xx_target_1, xx_target_2)
+
+
+def test_repr(realvar_fixture):
+    """Test __repr__ method of an instance."""
+    # Create a string
+    my_repr = repr(realvar_fixture)
+
+    # Assertion
+    assert isinstance(my_repr, str)
+
+
+def test_str(realvar_fixture):
+    """Test __str__ method of an instance."""
+    # Create a string
+    my_str = str(realvar_fixture)
+
+    # Assertion
+    assert isinstance(my_str, str)
+
+
+@pytest.mark.parametrize("name_desc", ["a", "b", "c"])
+def test_str_with_name_and_description(realvar_fixture, name_desc):
+    """Test construction with specified name and description."""
+    # Create a string
+    realvar_fixture.name = name_desc
+    realvar_fixture.description = name_desc
+    my_str = str(realvar_fixture)
+
+    # Assertion
+    assert isinstance(my_str, str)
+
+
+@pytest.mark.parametrize("rng_seed", [0, 1, 2, 3])
+def test_reset_rng(realvar_fixture, rng_seed):
+    """Test resetting the RNG of an instance."""
+    realvar_fixture.reset_rng(rng_seed)
+    xx_1 = realvar_fixture.get_sample(100)
+
+    realvar_fixture.rng_seed = rng_seed
+    xx_2 = realvar_fixture.get_sample(100)
+
+    assert np.all(xx_1 == xx_2)
+    assert realvar_fixture.rng_seed == rng_seed


### PR DESCRIPTION
`RealVariable` has been introduced in the code base to represent continuous bounded design variables.
Furthermore, it is a concrete implementation of an abstract class `DesignVariableABC`.

The relevant test cases have been added.

This issue should resolve Issues #449 and #448.