### PR TITLE
Add `replicate` factory method to `ProbInput` class

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+    nodejs: "20"
   jobs:
     pre_build:
       - "jupyter-book config sphinx docs/"

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ dev =
     types-tabulate
     types-setuptools
 docs =
-    jupyter-book
+    jupyter-book<2.0.0
     sphinx
     matplotlib>=3.7.0
     sphinx-proof

--- a/src/uqtestfuns/core/prob_input/probabilistic_input.py
+++ b/src/uqtestfuns/core/prob_input/probabilistic_input.py
@@ -12,6 +12,7 @@ import numpy as np
 import textwrap
 
 from numpy.random._generator import Generator
+from numpy.typing import ArrayLike
 from tabulate import tabulate
 from typing import Any, List, Optional, Sequence
 
@@ -61,6 +62,66 @@ class ProbInput:
         # Other properties
         self._rng_seed = rng_seed
         self._rng: Optional[Generator] = None
+
+    # Factory methods
+    @classmethod
+    def replicate(
+        cls,
+        input_dimension: int,
+        distribution: str,
+        parameters: ArrayLike,
+        base_name: str = "X",
+        *,
+        copulas: Any = None,
+        input_id: Optional[str] = None,
+        function_id: Optional[str] = None,
+        description: Optional[str] = None,
+        rng_seed: Optional[int] = None,
+    ) -> "ProbInput":
+        """Create a probabilistic input model with replicated marginals.
+
+        Parameters
+        -----------
+        input_dimension : int
+            The dimension of the probabilistic input.
+        distribution : str
+            The type of the probability distribution.
+        parameters : array_like
+           The parameters of the chosen probability distribution
+        base_name : str, optional
+            The base name of all the marginals. It will be spawned as
+            ``{base_name}{i + 1}`` where ``i`` is the index of the marginal
+            (1-indexed). If not specified, the value is "X".
+        copulas : Any
+            Copulas between univariate inputs that define dependence structure
+            (currently not used).
+        input_id: str, optional
+            The ID of the probabilistic input. If not specified,
+            the value is None.
+        function_id: str, optional
+            The ID of the function associated with the input. If not specified,
+            the value is None.
+        description: str, optional
+            The short description regarding the input model. If not specified,
+            the value is None.
+        rng_seed : int, optional.
+            The seed used to initialize the pseudo-random number generator.
+            If not specified, the value is taken from the system entropy.
+        """
+        marginals = []
+        for i in range(input_dimension):
+            name = f"{base_name}{i + 1}"
+            marginal = Marginal(distribution, parameters, name)
+            marginals.append(marginal)
+
+        return cls(
+            marginals,
+            copulas,
+            input_id,
+            function_id,
+            description,
+            rng_seed,
+        )
 
     @property
     def input_dimension(self) -> int:

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/beta.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/beta.py
@@ -27,7 +27,6 @@ from scipy.stats import beta
 from .utils import verify_param_nums, postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
-
 DISTRIBUTION_NAME = "beta"
 
 NUM_PARAMS = 4

--- a/src/uqtestfuns/meta/basis_functions.py
+++ b/src/uqtestfuns/meta/basis_functions.py
@@ -5,7 +5,6 @@ for the meta.
 
 import numpy as np
 
-
 __all__ = ["BASIS_BY_ID"]
 
 

--- a/src/uqtestfuns/meta/uqmetatestfun.py
+++ b/src/uqtestfuns/meta/uqmetatestfun.py
@@ -26,7 +26,6 @@ from .metaspec import UQMetaFunSpec, UQTestFunSpec
 from .basis_functions import BASIS_BY_ID
 from ..core import UQTestFun, ProbInput, Marginal
 
-
 __all__ = ["UQMetaTestFun", "default_coeffs_gen"]
 
 

--- a/src/uqtestfuns/test_functions/circular_pipe_crack.py
+++ b/src/uqtestfuns/test_functions/circular_pipe_crack.py
@@ -26,7 +26,6 @@ import numpy as np
 from uqtestfuns.core.custom_typing import ProbInputSpecs, FunParamSpecs
 from uqtestfuns.core.uqtestfun_abc import UQTestFunFixDimABC
 
-
 __all__ = ["CircularPipeCrack"]
 
 

--- a/src/uqtestfuns/test_functions/coffee_cup.py
+++ b/src/uqtestfuns/test_functions/coffee_cup.py
@@ -97,7 +97,7 @@ AVAILABLE_PARAMETERS: FunParamSpecs = {
 }
 
 
-def fun_ivp(t: float, temp: float, kappa: float, temp_amb: float) -> float:
+def fun_ivp(t: float, temp: float, kappa: float, temp_amb: float):
     """The right-hand side of the initial value problem.
 
     Parameters
@@ -111,7 +111,7 @@ def fun_ivp(t: float, temp: float, kappa: float, temp_amb: float) -> float:
     temp_amb : float
         Ambient temperature.
     """
-    return float(-1 * kappa * (temp - temp_amb))
+    return -1 * kappa * (temp - temp_amb)
 
 
 def evaluate(

--- a/src/uqtestfuns/test_functions/linkletter.py
+++ b/src/uqtestfuns/test_functions/linkletter.py
@@ -27,7 +27,6 @@ import numpy as np
 from uqtestfuns.core.custom_typing import MarginalSpecs, ProbInputSpecs
 from uqtestfuns.core.uqtestfun_abc import UQTestFunFixDimABC
 
-
 MARGINALS_LINKLETTER2006: MarginalSpecs = [
     {
         "name": f"x_{i + 1}",

--- a/src/uqtestfuns/test_functions/portfolio_3d.py
+++ b/src/uqtestfuns/test_functions/portfolio_3d.py
@@ -22,7 +22,6 @@ from uqtestfuns.core.custom_typing import (
 )
 from uqtestfuns.core.uqtestfun_abc import UQTestFunFixDimABC
 
-
 __all__ = ["Portfolio3D"]
 
 

--- a/src/uqtestfuns/test_functions/rs_circular_bar.py
+++ b/src/uqtestfuns/test_functions/rs_circular_bar.py
@@ -17,7 +17,6 @@ import numpy as np
 from uqtestfuns.core.custom_typing import ProbInputSpecs, FunParamSpecs
 from uqtestfuns.core.uqtestfun_abc import UQTestFunFixDimABC
 
-
 __all__ = ["RSCircularBar"]
 
 

--- a/src/uqtestfuns/test_functions/solar_cell.py
+++ b/src/uqtestfuns/test_functions/solar_cell.py
@@ -233,7 +233,7 @@ def compute_power_max(
         )
 
         pp_max[idx] = -1 * res.fun  # Negated back for the maximum value
-        vv_max[idx] = res.x
+        vv_max[idx] = res.x[0]
 
     return pp_max, vv_max
 

--- a/src/uqtestfuns/test_functions/undamped_oscillator.py
+++ b/src/uqtestfuns/test_functions/undamped_oscillator.py
@@ -45,7 +45,6 @@ import numpy as np
 from uqtestfuns.core.custom_typing import ProbInputSpecs
 from uqtestfuns.core.uqtestfun_abc import UQTestFunFixDimABC
 
-
 __all__ = ["UndampedOscillator"]
 
 

--- a/tests/core/design_variables/test_realvariable.py
+++ b/tests/core/design_variables/test_realvariable.py
@@ -12,7 +12,7 @@ from uqtestfuns import RealVariable
 @pytest.fixture
 def realvar_fixture():
     # Generate the bounds randomly
-    lower = random.uniform(1.0, 100.0)
+    lower = random.uniform(50, 100.0)
     upper = random.uniform(lower, 100.0)
 
     # Create an instance

--- a/tests/core/prob_input/test_prob_input.py
+++ b/tests/core/prob_input/test_prob_input.py
@@ -233,6 +233,35 @@ def test_set_rng_seed(input_dimension):
     assert np.allclose(xx_1, xx_2)
 
 
+@pytest.mark.parametrize("input_dimension", [1, 2, 10, 100])
+def test_replicate(input_dimension):
+    """Test creating a probabilistic input with replicated marginals."""
+    marginal = create_random_marginals(1)[0]
+
+    distribution = marginal.distribution
+    parameters = marginal.parameters
+
+    # Create a new probabilistic input with replicated marginals
+    prob_input = ProbInput.replicate(input_dimension, distribution, parameters)
+
+    # Assertions
+    assert prob_input.input_dimension == input_dimension
+    # Distributions are the same for all replicated marginals
+    assert np.all(
+        [distribution == mgl.distribution for mgl in prob_input.marginals]
+    )
+    # Parameters are the same for all replicated marginals
+    assert np.all(
+        [parameters == mgl.parameters for mgl in prob_input.marginals]
+    )
+    # Base name convention
+    assert np.all(
+        [f"X{i+1}" == mgl.name for i, mgl in enumerate(prob_input.marginals)]
+    )
+    # Description is None for replicated marginals
+    assert np.all([mgl.description is None for mgl in prob_input.marginals])
+
+
 # def test_get_cdf_values():
 #     """Test the CDF values from an instance of UnivariateInput."""
 #     name = create_random_alphanumeric(10)

--- a/tests/core/prob_input/test_univariate_input.py
+++ b/tests/core/prob_input/test_univariate_input.py
@@ -12,7 +12,6 @@ from uqtestfuns.core.prob_input.marginal import Marginal
 from uqtestfuns.core.prob_input.utils import SUPPORTED_MARGINALS
 from conftest import create_random_alphanumeric
 
-
 MARGINALS = list(SUPPORTED_MARGINALS.keys())
 
 

--- a/tests/core/prob_input/test_univariate_trunc_gumbel.py
+++ b/tests/core/prob_input/test_univariate_trunc_gumbel.py
@@ -12,7 +12,6 @@ from uqtestfuns.core.prob_input.marginal import Marginal
 from uqtestfuns.global_settings import ARRAY_FLOAT
 from conftest import create_random_alphanumeric
 
-
 DISTRIBUTION_NAME = "trunc-gumbel"
 
 

--- a/tests/core/prob_input/test_univariate_trunc_normal.py
+++ b/tests/core/prob_input/test_univariate_trunc_normal.py
@@ -11,7 +11,6 @@ from uqtestfuns.core.prob_input.marginal import Marginal
 from uqtestfuns.global_settings import ARRAY_FLOAT
 from conftest import create_random_alphanumeric
 
-
 DISTRIBUTION_NAME = "trunc-normal"
 
 


### PR DESCRIPTION
The `replicate` class method enables creating probabilistic input models with replicated marginals. Unit tests were added to ensure correctness.

Ref: #452
Resolves: #454