### PR TITLE
feat(registry): Add Registry class with YAML-based discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A `Registry` class that auto-scans `test_functions/` at import time,
+  parsing YAML specification files into lightweight registry entries
+  for function discovery without importing any Python modules eagerly.
+- New `ProbInput.replicate()` classmethod for constructing probabilistic
+  inputs with identical marginals across all dimensions; used internally
+  by the YAML-driven factory for variable-dimension test functions.
+
 ## [0.6.0] - 2025-01-21
 
 UQTestFuns now includes 75 test functions.

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ install_requires =
    numpy>=1.13.3
    scipy>=1.7.3
    tabulate>=0.8.10
+   pyyaml>=5.1
    importlib-metadata>=1.0; python_version < "3.8"
    typing_extensions; python_version > "3.7"
 
@@ -49,6 +50,7 @@ dev =
     flake8
     flake8-bugbear
     mypy
+    types-PyYAML
     types-tabulate
     types-setuptools
 docs =
@@ -105,6 +107,7 @@ deps =
    mypy
    types-tabulate
    types-setuptools
+   types-PyYAML
 commands = mypy --ignore-missing-imports {posargs:src tests}
 
 [mypy]

--- a/src/uqtestfuns/__init__.py
+++ b/src/uqtestfuns/__init__.py
@@ -24,6 +24,8 @@ from .meta import UQMetaTestFun
 
 from .helpers import list_functions
 
+from . import api
+
 if sys.version_info >= (3, 8):
     from importlib import metadata
 else:  # pragma: no cover
@@ -45,4 +47,5 @@ __all__ = [
     "UQMetaFunSpec",
     "UQMetaTestFun",
     "list_functions",
+    "api",
 ]

--- a/src/uqtestfuns/api.py
+++ b/src/uqtestfuns/api.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Union
+
+from tabulate import tabulate as tbl
+
+from uqtestfuns.core.registry.registry_entry import UQTestFunInfo
+from uqtestfuns.core.registry import _registry
+
+SUPPORTED_TAGS = (
+    "sensitivity",
+    "optimization",
+    "metamodeling",
+    "reliability",
+    "integration",
+)
+
+
+def list_functions(
+    input_dimension: Optional[Union[str, int]] = None,
+    output_dimension: Optional[int] = None,
+    parameterized: Optional[bool] = None,
+    tag: Optional[str] = None,
+    tabulate: bool = True,
+    tablefmt: str = "grid",
+    *,
+    entries: Dict[str, UQTestFunInfo] = _registry.entries,
+) -> Optional[Union[List[str], str]]:
+    """List available test functions from a registry entries dictionary."""
+
+    if tag is not None and tag not in SUPPORTED_TAGS:
+        raise ValueError(
+            f"Tag {tag!r} is not supported. Choose from {SUPPORTED_TAGS}."
+        )
+
+    # Filter entries
+    filtered: Dict[str, UQTestFunInfo] = {}
+    for name, entry in entries.items():
+        if entry.variable_dimension:
+            dim_str = "M"
+        else:
+            dim_str = str(entry.input_dimension)
+        if input_dimension is not None:
+            if dim_str != str(input_dimension).upper():
+                continue
+        if output_dimension is not None:
+            if entry.output_dimension != output_dimension:
+                continue
+        if parameterized is not None:
+            if bool(entry.available_parameter_ids) != parameterized:
+                continue
+        if tag is not None:
+            if tag not in entry.tags:
+                continue
+        filtered[name] = entry
+
+    if not tabulate:
+        return sorted(name + "()" for name in filtered)
+
+    if not filtered:
+        return None
+
+    # Build table rows
+    headers = ["No.", "Constructor"]
+    show_input_dim = input_dimension is None
+    show_output_dim = output_dimension is not None
+    show_param = parameterized is not None
+    show_tags = tag is None
+
+    if show_input_dim:
+        headers.append("# Input")
+    if show_output_dim:
+        headers.append("# Output")
+    if show_param:
+        headers.append("Param.")
+    if show_tags:
+        headers.append("Application")
+    headers.append("Description")
+
+    rows = []
+    for i, name in enumerate(sorted(filtered)):
+        entry = filtered[name]
+        row = [i + 1, name + "()"]
+        if show_input_dim:
+            if entry.variable_dimension:
+                dim_str = "M"
+            else:
+                dim_str = str(entry.input_dimension)
+            row.append(dim_str)
+        if show_output_dim:
+            row.append(entry.output_dimension)
+        if show_param:
+            row.append(bool(entry.available_parameter_ids))
+        if show_tags:
+            row.append(", ".join(entry.tags))
+        row.append(entry.description)
+        rows.append(row)
+
+    table = tbl(
+        rows,
+        headers=headers,
+        tablefmt=tablefmt,
+        maxcolwidths=[None, None] + [20] * (len(headers) - 3) + [30],
+    )
+
+    if tablefmt == "html":
+        return table
+
+    print(table)
+
+    return None

--- a/src/uqtestfuns/core/registry/__init__.py
+++ b/src/uqtestfuns/core/registry/__init__.py
@@ -1,0 +1,9 @@
+"""
+Registry sub-package of UQTestFuns.
+"""
+
+from .registry import DEFAULT_ROOT, PKG_ROOT, Registry
+
+# Singleton registry
+_registry = Registry()
+_registry.scan(DEFAULT_ROOT, PKG_ROOT)

--- a/src/uqtestfuns/core/registry/registry.py
+++ b/src/uqtestfuns/core/registry/registry.py
@@ -1,0 +1,132 @@
+"""Registry system for UQ test function metadata.
+
+This module provides the Registry class which manages a collection of UQ
+(Uncertainty Quantification) test function specifications. The registry loads
+and stores metadata about test functions from YAML specification files,
+providing a centralized catalog for function discovery, introspection, and
+instantiation.
+
+The Registry class acts as a container that:
+
+- Scans directories for YAML specification files
+- Parses and validates test function metadata
+- Provides dictionary-like access to function information
+- Prevents duplicate function registrations
+"""
+
+from pathlib import Path
+from typing import Dict
+
+from .registry_entry import UQTestFunInfo
+from .spec_parser import parse_info, SpecValidationError
+
+DEFAULT_ROOT = Path(__file__).parent.parent.parent / "test_functions"
+
+PKG_ROOT = Path(__file__)
+while PKG_ROOT.name != "uqtestfuns":
+    PKG_ROOT = PKG_ROOT.parent
+
+
+class Registry:
+    """A registry for UQ test function metadata.
+
+    The Registry class manages a collection of UQ test function specifications
+    loaded from YAML files. It provides dictionary-like access to function
+    metadata and supports scanning directories for test function
+    specifications.
+
+    Attributes
+    ----------
+    _entries : Dict[str, UQTestFunInfo]
+        Internal dictionary mapping function names to their metadata.
+    """
+
+    def __init__(self):
+        """Initialize an empty Registry."""
+        self._entries: Dict[str, UQTestFunInfo] = {}
+
+    def scan(self, root: Path, pkg_root: Path):
+        """Scan a directory for test function specification files.
+
+        Loads all YAML files in the given directory (excluding files ending
+        with '_inputs.yaml') and adds their parsed metadata to the registry.
+
+        Parameters
+        ----------
+        root : Path
+            The directory path to scan for YAML specification files.
+        pkg_root : Path
+            The root directory of the package.
+        Raises
+        ------
+        SpecValidationError
+            If a duplicate function name is found or if YAML parsing fails.
+        """
+        for yaml_file in root.glob("*.yaml"):
+            if yaml_file.name.endswith("_inputs.yaml"):
+                continue
+            info = parse_info(yaml_file, pkg_root)
+            if info.name in self._entries:
+                raise SpecValidationError(f"Duplicate entry for {info.name}")
+            self._entries[info.name] = info
+
+    @property
+    def entries(self) -> Dict[str, UQTestFunInfo]:
+        """Return a dictionary of all registered test functions.
+
+        Returns
+        -------
+        Dict[str, UQTestFunInfo]
+            The dictionary of registered test functions metadata.
+        """
+        return self._entries
+
+    def items(self):
+        """Return an iterator over (name, info) pairs.
+
+        Returns
+        -------
+        dict_items
+            An iterator over tuples of (function_name, UQTestFunInfo).
+        """
+        return self._entries.items()
+
+    def keys(self):
+        """Return an iterator over registered function names.
+
+        Returns
+        -------
+        dict_keys
+            An iterator over the names of registered test functions.
+        """
+        return self._entries.keys()
+
+    def __len__(self):
+        """Return the number of registered test functions.
+
+        Returns
+        -------
+        int
+            The count of test functions in the registry.
+        """
+        return len(self._entries)
+
+    def __getitem__(self, key):
+        """Retrieve metadata for a test function by name.
+
+        Parameters
+        ----------
+        key : str
+            The name of the test function.
+
+        Returns
+        -------
+        UQTestFunInfo
+            The metadata object for the requested test function.
+
+        Raises
+        ------
+        KeyError
+            If the function name is not found in the registry.
+        """
+        return self._entries[key]

--- a/src/uqtestfuns/core/registry/registry_entry.py
+++ b/src/uqtestfuns/core/registry/registry_entry.py
@@ -1,0 +1,97 @@
+"""Registry entry data structures for UQ test function metadata.
+
+This module defines the data structures used to store metadata about
+uncertainty quantification (UQ) test functions in the registry.
+The metadata is parsed from YAML specification files and used for
+function discovery and instantiation.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional, Dict, Any
+
+from pathlib import Path
+from typing_extensions import TypedDict
+
+
+class KeywordInfo(TypedDict):
+    """Type definition for parameter keyword metadata.
+
+    Attributes
+    ----------
+    type : Any
+        The Python type of the parameter keyword value.
+    description : Optional[str]
+        Human-readable description of the parameter keyword.
+    """
+
+    type: Any
+    description: Optional[str]
+
+
+@dataclass(frozen=True)
+class UQTestFunInfo:
+    """Registry entry containing metadata about a UQ test function.
+
+    This class stores enough information about a test function parsed
+    from its YAML specification file required for its discovery. This includes
+    its name, description, dimensionality properties,
+    and available input/parameter configurations.
+
+    Parameters
+    ----------
+    name : str
+        Unique identifier for the test function.
+    description : str
+        Human-readable description of the test function.
+    tags : List[str]
+        List of categorical tags for classification and search.
+    variable_dimension : bool
+        Whether the function supports variable input dimensions.
+    input_dimension : Optional[int]
+        Number of input dimensions (None if variable_dimension is True).
+    output_dimension : int
+        Number of output dimensions (default is 1).
+    spec_path : Path
+        Absolute path to the YAML specification file
+        for the next targeted read.
+    module_path : str
+        Dotted import path to the Python module containing the evaluate
+        function
+    evaluate_name : str
+        The name of the evaluate function in the module.
+    available_input_ids : Dict[str, str]
+        Mapping of input IDs to their descriptions.
+    default_input_id : str
+        Identifier for the default input configuration.
+    available_parameter_ids : Optional[Dict[str, str]], optional
+        Mapping of parameter IDs to their descriptions (default is None).
+    default_parameter_id : Optional[str], optional
+        Identifier for the default parameter configuration (default is None).
+    parameter_keywords : Optional[Dict[str, KeywordInfo]], optional
+        Mapping of parameter keywords to their type and description
+        (default is None).
+    """
+
+    # Identity
+    name: str
+    description: str
+    tags: List[str]
+
+    # Dimension info
+    variable_dimension: bool
+    input_dimension: Optional[int]
+    output_dimension: int
+
+    # File references
+    spec_path: Path
+    module_path: str
+    evaluate_name: str
+
+    # Input variant IDs
+    available_input_ids: Dict[str, str]
+    default_input_id: str
+
+    # Parameter variant IDs
+    available_parameter_ids: Optional[Dict[str, str]] = None
+    default_parameter_id: Optional[str] = None
+    parameter_keywords: Optional[Dict[str, KeywordInfo]] = None

--- a/src/uqtestfuns/core/registry/spec_parser.py
+++ b/src/uqtestfuns/core/registry/spec_parser.py
@@ -1,0 +1,205 @@
+"""YAML specification parser for test function metadata.
+
+This module provides functionality to parse YAML specification files
+that define metadata for uncertainty quantification (UQ) test functions.
+It validates the structure and content of these specifications
+and converts them into structured UQTestFunInfo objects.
+"""
+
+import yaml
+
+from pathlib import Path
+from typing import Callable
+
+from .registry_entry import UQTestFunInfo, KeywordInfo
+
+
+class SpecValidationError(Exception):
+    """Exception raised when YAML specification validation fails.
+
+    This exception is raised when a YAML specification file contains
+    structural or semantic errors, such as:
+
+    - Invalid field types or values
+    - Conflicting configuration (e.g., input_dimension specified for
+      variable-dimension functions)
+    - Empty required blocks (e.g., inputs or parameter sets)
+
+    It is used throughout the spec_parser module to provide clear error
+    messages about specification validation failures.
+    """
+
+    pass
+
+
+def parse_info(yaml_file: Path, pkg_root: Path) -> UQTestFunInfo:
+    """Parse a YAML specification file and return UQTestFunInfo object.
+
+    This function reads a YAML file containing test function metadata and
+    parses it into a structured UQTestFunInfo object. It validates required
+    fields and handles optional fields with default values.
+
+    Parameters
+    ----------
+    yaml_file : Path
+        Path to the YAML specification file containing test function metadata.
+    pkg_root : Path, optional
+        Root path of the package, used to resolve module paths relative to
+        the package structure (default is the uqtestfuns package root).
+
+    Returns
+    -------
+    UQTestFunInfo
+        A structured object containing all parsed test function information,
+        including name, description, tags, dimensions, inputs, and parameters.
+
+    Raises
+    ------
+    KeyError
+        If any mandatory field is missing from the YAML file.
+    SpecValidationError
+        If the spec is structurally invalid (e.g., input_dimension specified
+        for a variable-dimension function, invalid field values, or empty
+        inputs block).
+
+    Notes
+    -----
+    Mandatory fields in the YAML file:
+
+    - name: str
+    - description: str
+    - tags: list
+    - variable_dimension: bool
+    - inputs: dict
+    - input_dimension: int (only if variable_dimension is False)
+    - default_input_id: str (only if multiple inputs are defined)
+
+    Optional fields with defaults:
+
+    - output_dimension: int (default=1)
+    - parameters: dict (default=None)
+    """
+    # Open the YAML file
+    with open(yaml_file, "r") as f:
+        data = yaml.safe_load(f)
+
+    # --- Mandatory fields (if not specified, raise KeyError)
+    name = data["name"]
+    description = data["description"]
+    tags = data["tags"]
+    variable_dimension = data["variable_dimension"]
+    inputs = data["inputs"]
+
+    # --- tags must be a list
+    if not isinstance(tags, list):
+        raise SpecValidationError(
+            f"'tags' must be a list, "
+            f"got {type(tags).__name__!r} in {yaml_file}"
+        )
+
+    # --- Input dimension (conditionally optional)
+    if not variable_dimension:
+        input_dimension = data["input_dimension"]
+        if not isinstance(input_dimension, int) or input_dimension < 1:
+            raise SpecValidationError(
+                f"'input_dimension' must be a positive integer, "
+                f"got {input_dimension!r} in {yaml_file}"
+            )
+    else:
+        if "input_dimension" in data:
+            raise SpecValidationError(
+                f"'input_dimension' is specified for a variable-dimension "
+                f"test function in {yaml_file}"
+            )
+        input_dimension = None
+
+    # --- Output dimension (optional with default value)
+    output_dimension = data.get("output_dimension", 1)
+
+    # --- File references
+    spec_path = yaml_file.resolve()
+    evaluate = data.get("evaluate")
+    if evaluate is None:
+        module_file = spec_path.with_suffix(".py")
+        if not module_file.exists():
+            raise SpecValidationError(
+                f"Module file {module_file} does not exist!"
+            )
+        evaluate_name = "evaluate"
+    else:
+        module_stem, evaluate_name = evaluate.rsplit(".", 1)
+        module_file = spec_path.parent / (module_stem + ".py")
+        if not module_file.exists():
+            raise SpecValidationError(
+                f"Module file {module_file} does not exist!"
+            )
+    module_path = ".".join(
+        module_file.relative_to(pkg_root.parent.resolve())
+        .with_suffix("")
+        .parts
+    )
+
+    # --- Inputs specification
+    if not inputs:
+        raise SpecValidationError(
+            f"'inputs' must contain at least one entry in {yaml_file}"
+        )
+    available_input_ids = {k: v.get("description") for k, v in inputs.items()}
+    if len(inputs) == 1:
+        default_input_id = next(iter(inputs))
+    else:
+        default_input_id = data["default_input_id"]
+
+    # --- Parameters specification (optional; None if not defined)
+    parameters = data.get("parameters")
+    if parameters is None:
+        available_parameter_ids = None
+        default_parameter_id = None
+        parameter_keywords = None
+    else:
+        # -- Validate that 'sets' sub-block is present and non-empty
+        available_sets = parameters.get("sets")
+        if not available_sets:
+            raise SpecValidationError(
+                f"'parameters' block is present but missing 'sets' "
+                f"in {yaml_file}"
+            )
+
+        # -- Collect available parameter set IDs and their descriptions
+        keyword_descriptions = parameters.get("keywords", {})
+        available_parameter_ids = {
+            k: v.get("description") for k, v in available_sets.items()
+        }
+
+        # -- Resolve default parameter set ID
+        if len(available_sets) == 1:
+            default_parameter_id = next(iter(available_sets))
+        else:
+            default_parameter_id = parameters["default_parameter_id"]
+
+        # -- Infer keyword types from the default parameter set
+        default_set = available_sets[default_parameter_id]
+        parameter_keywords = {}
+        for k, v in default_set["values"].items():
+            is_callable = isinstance(v, str) and v.endswith("()")
+            parameter_keywords[k] = KeywordInfo(
+                type=Callable if is_callable else type(v),
+                description=keyword_descriptions.get(k),
+            )
+
+    return UQTestFunInfo(
+        name,
+        description,
+        tags,
+        variable_dimension,
+        input_dimension,
+        output_dimension,
+        spec_path,
+        module_path,
+        evaluate_name,
+        available_input_ids,
+        default_input_id,
+        available_parameter_ids,
+        default_parameter_id,
+        parameter_keywords,
+    )

--- a/tests/fixtures/valid_yaml/fixed_multi_inputs_no_params.yaml
+++ b/tests/fixtures/valid_yaml/fixed_multi_inputs_no_params.yaml
@@ -1,0 +1,25 @@
+name: FixedMultiInputsNoParams
+description: "Fixed-dimension function, multiple inputs, no parameter"
+tags:
+  - metamodeling
+  - sensitivity
+variable_dimension: false
+input_dimension: 1
+output_dimension: 1
+
+evaluate: fixed_single_input_no_params.evaluate
+
+inputs:
+  DefaultInput:
+    description: "Default input, uniform distribution"
+    marginals:
+      - name: X
+        distribution: uniform
+        parameters: [-1, 1.0]
+  AlternativeInput:
+    description: "Alternative input, normal distribution"
+    marginals:
+      - name: X
+        distribution: normal
+        parameters: [0, 1.0]
+default_input_id: DefaultInput

--- a/tests/fixtures/valid_yaml/fixed_single_input_fixed_params.py
+++ b/tests/fixtures/valid_yaml/fixed_single_input_fixed_params.py
@@ -1,0 +1,2 @@
+def evaluate(xx, *, a, b):
+    return xx + a + b

--- a/tests/fixtures/valid_yaml/fixed_single_input_fixed_params.yaml
+++ b/tests/fixtures/valid_yaml/fixed_single_input_fixed_params.yaml
@@ -1,0 +1,34 @@
+name: FixedSingleInputFixedParams
+description: "Fixed-dimension function, single input, multiple fixed parameters"
+tags:
+  - metamodeling
+variable_dimension: false
+input_dimension: 1
+output_dimension: 1
+
+inputs:
+  DefaultInput:
+    marginals:
+      - name: X
+        distribution: uniform
+        parameters: [-1, 1.0]
+
+parameters:
+
+  keywords:
+    a: "Main effect strength of X2"
+    b: "Interaction strength of X1 and X3"
+
+  sets:
+    Ishigami1991:
+      description: "Parameter set from Ishigami and Homma (1991)"
+      values:
+        a: 7.0
+        b: 0.1
+    Sobol1999:
+      description: "Parameter set from Sobol' and Levitan (1999)"
+      values:
+        a: 7.0
+        b: 0.05
+
+  default_parameter_id: Ishigami1991

--- a/tests/fixtures/valid_yaml/fixed_single_input_no_params.py
+++ b/tests/fixtures/valid_yaml/fixed_single_input_no_params.py
@@ -1,0 +1,2 @@
+def evaluate(xx):
+    return xx

--- a/tests/fixtures/valid_yaml/fixed_single_input_no_params.yaml
+++ b/tests/fixtures/valid_yaml/fixed_single_input_no_params.yaml
@@ -1,0 +1,13 @@
+name: FixedSingleInputNoParams
+description: "Fixed-dimension function, single input, no parameter"
+tags: [metamodeling]
+variable_dimension: false
+input_dimension: 1
+output_dimension: 1
+
+inputs:
+  DefaultInput:
+    marginals:
+      - name: X
+        distribution: uniform
+        parameters: [-1, 1.0]

--- a/tests/fixtures/valid_yaml/var_multi_inputs_no_params.py
+++ b/tests/fixtures/valid_yaml/var_multi_inputs_no_params.py
@@ -1,0 +1,2 @@
+def evaluate(xx):
+    return xx

--- a/tests/fixtures/valid_yaml/var_multi_inputs_no_params.yaml
+++ b/tests/fixtures/valid_yaml/var_multi_inputs_no_params.yaml
@@ -1,0 +1,20 @@
+name: VarMultiInputsNoParams
+description: "Variable-dimension function, multiple inputs, no parameter"
+tags: [metamodeling]
+variable_dimension: true
+output_dimension: 1
+
+inputs:
+  DefaultInput:
+    description: "Default input, uniform distribution"
+    marginals:
+      - name: X
+        distribution: uniform
+        parameters: [-1, 1.0]
+  AlternativeInput:
+    description: "Default input, normal distribution"
+    marginals:
+      - name: X
+        distribution: normal
+        parameters: [0, 1.0]
+default_input_id: DefaultInput

--- a/tests/fixtures/valid_yaml/var_single_input_mixed_params.py
+++ b/tests/fixtures/valid_yaml/var_single_input_mixed_params.py
@@ -1,0 +1,2 @@
+def evaluate(xx, *, aa, bb):
+    return xx + aa + bb

--- a/tests/fixtures/valid_yaml/var_single_input_mixed_params.yaml
+++ b/tests/fixtures/valid_yaml/var_single_input_mixed_params.yaml
@@ -1,0 +1,35 @@
+name: VarSingleInputMixedParams
+description: "Variable-dimension function, single input, multiple Mixed parameters"
+tags:
+  - metamodeling
+  - reliability
+variable_dimension: true
+output_dimension: 1
+
+inputs:
+  DefaultInput:
+    marginals:
+      - name: X
+        distribution: uniform
+        parameters: [-1, 1.0]
+
+parameters:
+
+  keywords:
+      aa: "Coefficients of the Sobol-G function"
+      bb: "Shift parameter"
+
+  sets:
+    Kucherenko2011:
+      description: "Parameter set from Kucherenko et al. (2011)"
+      values:
+        aa: _get_aa_kucherenko2011()
+        bb: 1.5
+
+    Ishigami1991:
+      description: "Parameter set from Ishigami and Homma (1991)"
+      values:
+        aa: _get_aa_ishigami1991()
+        bb: 0.1
+
+  default_parameter_id: Kucherenko2011

--- a/tests/fixtures/valid_yaml/var_single_input_no_params.py
+++ b/tests/fixtures/valid_yaml/var_single_input_no_params.py
@@ -1,0 +1,2 @@
+def evaluate(xx):
+    return xx

--- a/tests/fixtures/valid_yaml/var_single_input_no_params.yaml
+++ b/tests/fixtures/valid_yaml/var_single_input_no_params.yaml
@@ -1,0 +1,12 @@
+name: VarSingleInputNoParams
+description: "Variable-dimension function, single input, no parameter"
+tags: [metamodeling]
+variable_dimension: true
+output_dimension: 1
+
+inputs:
+  DefaultInput:
+    marginals:
+      - name: X
+        distribution: uniform
+        parameters: [-1, 1.0]

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,63 @@
+import pytest
+
+from uqtestfuns.core.registry.registry import Registry
+from uqtestfuns.core.registry.spec_parser import SpecValidationError
+
+from pathlib import Path
+
+VALID_YAML_DIR = Path(__file__).parent / "fixtures" / "valid_yaml"
+
+PKG_ROOT = VALID_YAML_DIR
+
+
+class TestScan:
+    """All tests related to scanning for valid YAML files in the registry."""
+
+    def test_scan(self):
+        """Test scanning for valid YAML files into the registry."""
+        registry = Registry()
+        registry.scan(VALID_YAML_DIR, PKG_ROOT)
+
+        expected = sum(
+            1
+            for f in VALID_YAML_DIR.iterdir()
+            if f.is_file()
+            and f.suffix == ".yaml"
+            and not f.name.endswith("_inputs.yaml")
+        )
+
+        # Assertion
+        assert len(registry) == expected
+
+    def test_getitem(self):
+        """Test getting an entry from the registry."""
+        registry = Registry()
+        registry.scan(VALID_YAML_DIR, PKG_ROOT)
+
+        # Assertion
+        for key in registry.keys():
+            assert registry[key].name == key
+
+    def test_item(self):
+        """Test getting an item from the registry."""
+        registry = Registry()
+        registry.scan(VALID_YAML_DIR, PKG_ROOT)
+
+        # Assertion
+        for key, value in registry.items():
+            assert value.name == key
+
+    def test_getitem_invalid(self):
+        """Test getting an invalid entry from the registry."""
+        registry = Registry()
+
+        with pytest.raises(KeyError):
+            _ = registry["invalid_key"]
+
+    def test_duplicate_keys(self):
+        """Test that duplicate keys are not allowed."""
+        registry = Registry()
+        registry.scan(VALID_YAML_DIR, PKG_ROOT)
+
+        with pytest.raises(SpecValidationError):
+            registry.scan(VALID_YAML_DIR, PKG_ROOT)

--- a/tests/test_spec_parser.py
+++ b/tests/test_spec_parser.py
@@ -1,0 +1,81 @@
+from uqtestfuns.core.registry.spec_parser import parse_info
+
+from pathlib import Path
+
+FIXTURES_ROOT = Path(__file__).parent / "fixtures" / "valid_yaml"
+
+
+class TestParseInfo:
+    """All tests related to parsing spec files for UQTestFuns."""
+
+    def test_fixed_single_input_no_params(self):
+        """Parse spec: fixed-dim, single input, no parameters."""
+        yaml_file = FIXTURES_ROOT / "fixed_single_input_no_params.yaml"
+        info = parse_info(yaml_file, FIXTURES_ROOT)
+
+        # Assertions
+        assert not info.variable_dimension
+        assert info.input_dimension == 1
+        assert info.output_dimension == 1
+        assert info.spec_path == yaml_file.resolve()
+
+    def test_fixed_multi_inputs_no_params(self):
+        """Parse spec: fixed-dim, multiple inputs, no parameters."""
+        yaml_file = FIXTURES_ROOT / "fixed_multi_inputs_no_params.yaml"
+        info = parse_info(yaml_file, FIXTURES_ROOT)
+
+        # Assertions
+        assert not info.variable_dimension
+        assert info.input_dimension == 1
+        assert info.output_dimension == 1
+        assert info.spec_path == yaml_file.resolve()
+        assert len(info.available_input_ids) == 2
+
+    def test_fixed_single_input_fixed_params(self):
+        """Parse spec: fixed-dim, single input, fixed parameters."""
+        yaml_file = FIXTURES_ROOT / "fixed_single_input_fixed_params.yaml"
+        info = parse_info(yaml_file, FIXTURES_ROOT)
+
+        # Assertions
+        assert not info.variable_dimension
+        assert info.input_dimension == 1
+        assert info.output_dimension == 1
+        assert info.spec_path == yaml_file.resolve()
+        assert info.available_parameter_ids is not None
+        assert len(info.available_parameter_ids) == 2
+
+    def test_var_single_input_no_params(self):
+        """Parse spec: variable-dim, single input, no parameters."""
+        yaml_file = FIXTURES_ROOT / "var_single_input_no_params.yaml"
+        info = parse_info(yaml_file, FIXTURES_ROOT)
+
+        # Assertions
+        assert info.variable_dimension
+        assert info.input_dimension is None
+        assert info.output_dimension == 1
+        assert info.spec_path == yaml_file.resolve()
+
+    def test_var_multi_inputs_no_params(self):
+        """Parse spec: variable-dim, multiple inputs, no parameters."""
+        yaml_file = FIXTURES_ROOT / "var_multi_inputs_no_params.yaml"
+        info = parse_info(yaml_file, FIXTURES_ROOT)
+
+        # Assertions
+        assert info.variable_dimension
+        assert info.input_dimension is None
+        assert info.output_dimension == 1
+        assert info.spec_path == yaml_file.resolve()
+        assert len(info.available_input_ids) == 2
+
+    def test_var_single_input_mixed_params(self):
+        """Parse spec: variable-dim, single input, mixed parameters."""
+        yaml_file = FIXTURES_ROOT / "var_single_input_mixed_params.yaml"
+        info = parse_info(yaml_file, FIXTURES_ROOT)
+
+        # Assertions
+        assert info.variable_dimension
+        assert info.input_dimension is None
+        assert info.output_dimension == 1
+        assert info.spec_path == yaml_file.resolve()
+        assert info.available_parameter_ids is not None
+        assert len(info.available_parameter_ids) == 2


### PR DESCRIPTION
Introduce `Registry`, `UQTestFunInfo`, and `spec_parser` as the foundation for auto-discovering test function specs at import time.

- Registry scans `test_functions/` recursively for *.yaml files and populates `UQTestFunInfo` objects (discovery metadata only).
- Module-level `_registry` singleton scans default root directory on import.

Closes: #456
Ref: #452