### PR TITLE
refactor(marginal): Rewrite `Marginal` as a regular class

### DIFF
--- a/src/uqtestfuns/core/prob_input/marginal.py
+++ b/src/uqtestfuns/core/prob_input/marginal.py
@@ -1,18 +1,29 @@
 """
-Module with an implementation of the ``Marginal`` class.
 
-The ``Marginal`` class represents a one-dimensional marginal random variable
-(i.e., univariate random variable).
-Each random variable has a (parametric) probability distribution.
+This module provides the :class:`Marginal` class, which models a single random
+variable through a parametric probability distribution. It is intended as
+the building block for probabilistic input models, where each input dimension
+is described by one marginal distribution.
+
+The class offers a consistent interface for:
+
+- Validating the chosen distribution and its parameters
+- Evaluating the probability density function (PDF)
+- Evaluating the cumulative distribution function (CDF)
+- Computing the inverse CDF (ICDF)
+- Generating random samples
+- Transforming samples between marginal distributions
+
+For numerical purposes, each distribution is associated with finite lower and
+upper bounds. These bounds are used when evaluating PDFs, CDFs,
+and inverse CDFs through the helper functions imported from :mod:`.utils`.
 """
 
 from __future__ import annotations
 
 import numpy as np
 
-from numpy.random._generator import Generator
 from numpy.typing import ArrayLike
-from dataclasses import dataclass, field
 from typing import Optional, Union
 
 from .utils import (
@@ -23,7 +34,6 @@ from .utils import (
     get_cdf_values,
     get_icdf_values,
 )
-from ...global_settings import ARRAY_FLOAT
 
 __all__ = ["Marginal"]
 
@@ -31,144 +41,324 @@ __all__ = ["Marginal"]
 FIELD_NAMES = ["name", "distribution", "parameters", "description"]
 
 
-@dataclass(frozen=True)
 class Marginal:
-    """A class for one-dimensional marginal random variables.
+    """A random variable represented by a univariate probability distribution.
+
+    The class represents a single random variable defined by its distribution
+    type and parameters. Within a probabilistic input model, each univariate
+    distribution serves as a marginal of the joint distribution.
 
     Parameters
     ----------
     distribution : str
-        The type of the probability distribution.
-    parameters : ArrayLike
-        The parameters of the chosen probability distribution
+        The type of probability distribution.
+    parameters : array_like
+        The parameters of the chosen probability distribution.
     name : str, optional
-        The name of the random variable
+        The name of the random variable.
     description : str, optional
-        The short text description of the random variable
-    rng_seed : int, optional.
-        The seed used to initialize the pseudo-random number generator.
-        If not specified, the value is taken from the system entropy.
-
-    Attributes
-    ----------
-    lower : float
-        The lower bound of the distribution
-    upper : float
-        The upper bound of the distribution
-    _rng : Generator
-        The default pseudo-random number generator of NumPy.
-        The generator is only created if or when needed (e.g., generating
-        a random sample from the distribution).
+        A short text description of the random variable.
     """
 
-    distribution: str
-    parameters: ArrayLike
-    name: Optional[str] = None
-    description: Optional[str] = None
-    lower: float = field(init=False, repr=False)
-    upper: float = field(init=False, repr=False)
-    rng_seed: Optional[int] = field(default=None, repr=False)
-    _rng: Optional[Generator] = field(init=False, default=None, repr=False)
-
-    def __post_init__(self) -> None:
-        # Because frozen=True, post init must access self via setattr
-        # Make sure the distribution is lower-case
-        object.__setattr__(self, "distribution", self.distribution.lower())
-
-        # Convert parameters to a numpy array
-        object.__setattr__(self, "parameters", np.array(self.parameters))
-
-        # Verify the selected univariate distribution type
+    def __init__(
+        self,
+        distribution: str,
+        parameters: ArrayLike,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+    ):
+        # Assign and verify the distribution type
+        self._distribution = distribution.lower()
         verify_distribution(self.distribution)
 
-        # Verify the value of the parameters
+        # Assign and verify the parameters
+        self._parameters = np.array(parameters)
         verify_parameters(self.distribution, self.parameters)
 
-        # Get and set the lower and upper bounds
-        _lower, _upper = get_distribution_bounds(
-            self.distribution, self.parameters
+        # Assign the name and description
+        self._name = name
+        self._description = description
+
+        # Compute the lower and upper bounds of the distribution
+        self._lower, self._upper = get_distribution_bounds(
+            self.distribution,
+            self.parameters,
         )
-        object.__setattr__(self, "lower", _lower)
-        object.__setattr__(self, "upper", _upper)
+
+    # --- Public properties
+    @property
+    def distribution(self) -> str:
+        """The type of the probability distribution.
+
+        Returns
+        -------
+        str
+            The type of the one-dimensional marginal distribution.
+        """
+        return self._distribution
+
+    @property
+    def parameters(self) -> np.ndarray:
+        """The parameters of the chosen probability distribution.
+
+        Returns
+        -------
+        np.ndarray
+            The parameters of the chosen probability distribution.
+        """
+        return self._parameters
+
+    @property
+    def name(self) -> Optional[str]:
+        """The name of the random variable.
+
+        Returns
+        -------
+        str, optional
+            The name of the random variable.
+        """
+        return self._name
+
+    @property
+    def description(self) -> Optional[str]:
+        """A short text description of the random variable.
+
+        Returns
+        -------
+        str, optional
+            A short text description of the random variable.
+        """
+        return self._description
+
+    @property
+    def lower(self) -> float:
+        """The lower bound of the distribution.
+
+        Returns
+        -------
+        float
+            The lower bound of the distribution.
+
+        Notes
+        -----
+        - While the support of many continuous probability density functions
+          is unbounded, numerically they are always bounded. Below the lower
+          bound, the density values are always zero.
+        """
+        return self._lower
+
+    @property
+    def upper(self) -> float:
+        """The upper bound of the distribution.
+
+        Returns
+        -------
+        float
+            The upper bound of the distribution.
+
+        Notes
+        -----
+        - While the support of many continuous probability density functions
+          is unbounded, numerically they are always bounded. Above the upper
+          bound, the density values are always zero.
+        """
+        return self._upper
+
+    # --- Public methods
+    def pdf(self, xx: Union[float, np.ndarray]) -> np.ndarray:
+        """Compute the probability density function of the distribution.
+
+        Parameters
+        ----------
+        xx : Union[float, np.ndarray]
+            The input values in the support of the distribution.
+
+        Returns
+        -------
+        np.ndarray
+            The probability density function (PDF) values at the input values.
+            The output is an array of at least one dimension.
+        """
+        # Convert input to a NumPy array of at least one dimension
+        xx = np.atleast_1d(xx)
+
+        return get_pdf_values(
+            xx,
+            self.distribution,
+            self.parameters,
+            self.lower,
+            self.upper,
+        )
+
+    def cdf(self, xx: Union[float, np.ndarray]) -> np.ndarray:
+        """Compute the cumulative distribution function on input values.
+
+        Parameters
+        ----------
+        xx : Union[float, np.ndarray]
+            The input values in the support of the distribution.
+
+        Returns
+        -------
+        np.ndarray
+            The cumulative distribution function (CDF) values at the input
+            values. The output is an array of at least one dimension.
+        """
+        # Convert input to a NumPy array of at least one dimension
+        xx = np.atleast_1d(xx)
+
+        return get_cdf_values(
+            xx,
+            self.distribution,
+            self.parameters,
+            self.lower,
+            self.upper,
+        )
+
+    def icdf(self, xx: Union[float, np.ndarray]) -> np.ndarray:
+        """Compute the inverse CDF on input values.
+
+        Parameters
+        ----------
+        xx : Union[float, np.ndarray]
+            The input values in the [0,1] domain.
+
+        Returns
+        -------
+        np.ndarray
+            The inverse cumulative distribution function (ICDF) values at the
+            input points. These are points in the distribution's support.
+            The output is an array of at least one dimension.
+
+        Notes
+        -----
+        - If the input values are outside the [0, 1] domain, NaN values
+          are returned.
+        """
+        # Convert input to a NumPy array of at least one dimension
+        xx = np.atleast_1d(xx)
+
+        return get_icdf_values(
+            xx,
+            self.distribution,
+            self.parameters,
+            self.lower,
+            self.upper,
+        )
+
+    def get_sample(
+        self,
+        sample_size: int = 1,
+        rng: Optional[Union[np.random.Generator, int]] = None,
+    ) -> np.ndarray:
+        """Get a random sample from the distribution.
+
+        Parameters
+        ----------
+        sample_size : int, optional
+            The number of sample points. Default is 1.
+        rng :  Union[np.random.Generator, int], optional
+            The random number generator or the seed for the default NumPy
+            random number generator. If not specified, the default random
+            number generator with the operating system entropy is used.
+
+        Returns
+        -------
+        np.ndarray
+            A one-dimensional array of length ``sample_size`` containing
+            the sample points.
+        """
+        if rng is None or isinstance(rng, int):
+            rng = np.random.default_rng(rng)
+
+        # Draw random sample in [0, 1]
+        xx = rng.random(sample_size)
+
+        # Return the transformed sample in the current distribution
+        return self.icdf(xx)
 
     def transform_sample(
         self,
         xx: Union[float, np.ndarray],
         other: Marginal,
     ) -> np.ndarray:
-        """Transform a sample from a given distribution to another."""
-        if not isinstance(other, Marginal):
-            raise TypeError("Other instance must be of Marginal type!")
-
-        xx_trans = self.cdf(xx)
-
-        return get_icdf_values(
-            xx_trans,
-            other.distribution,
-            other.parameters,
-            other.lower,
-            other.upper,
-        )
-
-    def get_sample(self, sample_size: int = 1) -> np.ndarray:
-        """Get a random sample from the distribution."""
-        if self._rng is None:  # pragma: no cover
-            # Create a pseudo-random number generator (lazy evaluation)
-            rng = np.random.default_rng(self.rng_seed)
-            object.__setattr__(self, "_rng", rng)
-
-        xx = self._rng.random(sample_size)  # type: ignore
-
-        return get_icdf_values(
-            xx, self.distribution, self.parameters, self.lower, self.upper
-        )
-
-    def reset_rng(self, rng_seed: Optional[int]) -> None:
-        """Reset the random number generator.
+        """Transform a sample from this distribution to another.
 
         Parameters
         ----------
-        rng_seed : int, optional.
-            The seed used to initialize the pseudo-random number generator.
-            If not specified, the value is taken from the system entropy.
+        xx : Union[float, np.ndarray]
+            The sample points to be transformed.
+        other : Marginal
+            The target distribution to which the sample should be transformed.
+
+        Returns
+        -------
+        np.ndarray
+            The transformed sample points in the target distribution.
+            The output is an array of at least one dimension.
         """
-        rng = np.random.default_rng(rng_seed)
-        object.__setattr__(self, "_rng", rng)
-        object.__setattr__(self, "rng_seed", rng_seed)
+        if not isinstance(other, Marginal):
+            raise TypeError("Other instance must be of Marginal type!")
 
-    def pdf(self, xx: Union[float, np.ndarray]) -> ARRAY_FLOAT:
-        """Compute the PDF of the distribution on a set of values."""
-        # TODO: check if you put a scalar inside
-        # Convert input to an np.array
-        xx = np.asarray(xx)
+        # Transform the sample to [0, 1] domain
+        xx_trans = self.cdf(xx)
 
-        return get_pdf_values(
-            xx, self.distribution, self.parameters, self.lower, self.upper
-        )
+        # Transform the sample in [0, 1] to the domain of the other
+        return other.icdf(xx_trans)
 
-    def cdf(self, xx: Union[float, np.ndarray]) -> ARRAY_FLOAT:
-        """Compute the CDF of the distribution on a set of values.
+    # --- Dunder methods
+    def __eq__(self, other: object) -> bool:
+        """Check the equality in value between two instances.
 
-        The function transforms the sample values in the domain
-        of the distribution to the [0, 1] domain.
+        An equality in value between two instances of Marginal means that:
+
+        - The distributions are the same
+        - The parameters are the same
+        - The name and description are the same
+
+        Parameters
+        ----------
+        other : object
+            The other instance to compare with.
+
+        Returns
+        -------
+        bool
+            True if the two instances are equal in value, False otherwise.
         """
-        # TODO: check if you put a scalar inside
-        # Convert input to an np.array
-        xx = np.asarray(xx)
+        if not isinstance(other, Marginal):
+            return False
 
-        return get_cdf_values(
-            xx, self.distribution, self.parameters, self.lower, self.upper
-        )
+        if self.distribution != other.distribution:
+            return False
 
-    def icdf(self, xx: Union[float, np.ndarray]) -> ARRAY_FLOAT:
-        """Compute the inverse CDF of the distribution on a set of values.
+        if not np.array_equal(self.parameters, other.parameters):
+            return False
 
-        The function transforms values in the [0,1] domain to the domain
-        of the distribution.
+        if self.name != other.name:
+            return False
+
+        if self.description != other.description:
+            return False
+
+        return True
+
+    def __repr__(self) -> str:
+        """Return the unambiguous string representation of the instance.
+
+        Returns
+        -------
+        str
+            The unambiguous string representation of the instance.
         """
-        # TODO: verify that the input is in [0, 1]
-        xx = np.asarray(xx)
+        class_name = self.__class__.__name__
+        # Get the value of the constructor arguments
+        attrs = {
+            "distribution": self.distribution,
+            "parameters": self.parameters,
+            "name": self.name,
+            "description": self.description,
+        }
+        attrs_str = ", ".join(f"{k}={v!r}" for k, v in attrs.items())
 
-        return get_icdf_values(
-            xx, self.distribution, self.parameters, self.lower, self.upper
-        )
+        return f"{class_name}({attrs_str})"

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/utils.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/utils.py
@@ -4,14 +4,12 @@ Utility module for univariate distribution calculations.
 
 import numpy as np
 
-from ....global_settings import ARRAY_FLOAT
-
 
 def postprocess_icdf(
-    xx: ARRAY_FLOAT,
+    xx: np.ndarray,
     lower_bound: float,
     upper_bound: float,
-) -> ARRAY_FLOAT:
+) -> np.ndarray:
     """Postprocess the computed ICDF values.
 
     The postprocessing ensures that the output is an array and always
@@ -19,7 +17,7 @@ def postprocess_icdf(
 
     Parameters
     ----------
-    xx : ARRAY_FLOAT
+    xx : np.ndarray
         The raw ICDF values of a distribution computed either from a built-in
         function or a re-parameterization of the SciPy implementation.
     lower_bound : float
@@ -31,21 +29,11 @@ def postprocess_icdf(
 
     Return
     ------
-    ARRAY_FLOAT
+    np.ndarray
         The post-processed ICDF values.
     """
-    # A scalar output
-    if xx.ndim == 0:
-        if xx < lower_bound:
-            xx = np.asarray(lower_bound)
-        if xx > upper_bound:
-            xx = np.asarray(upper_bound)
-
-        xx = np.asarray(xx)
-
-    else:
-        xx[xx < lower_bound] = lower_bound
-        xx[xx > upper_bound] = upper_bound
+    xx[xx < lower_bound] = lower_bound
+    xx[xx > upper_bound] = upper_bound
 
     return xx
 

--- a/tests/core/prob_input/test_univariate_input.py
+++ b/tests/core/prob_input/test_univariate_input.py
@@ -11,6 +11,7 @@ from numpy.typing import ArrayLike
 from uqtestfuns.core.prob_input.marginal import Marginal
 from uqtestfuns.core.prob_input.utils import SUPPORTED_MARGINALS
 from conftest import create_random_alphanumeric
+from copy import copy
 
 MARGINALS = list(SUPPORTED_MARGINALS.keys())
 
@@ -24,13 +25,14 @@ def univariate_input(
     # All random values (distribution parameters are limited to 5 digits
     # to avoid awkward yet unrealistic values)
     name = create_random_alphanumeric(8)
+    description = create_random_alphanumeric(10)
     distribution = request.param
     if distribution == "uniform":
         parameters = np.sort(np.round(np.random.rand(2), decimals=5))
     elif distribution == "beta":
         parameters = np.sort(np.round(np.random.rand(4), decimals=5))
     elif distribution == "exponential":
-        # Single parameter, must be strictly positive
+        # Single parameter must be strictly positive
         parameters = (1 + np.round(np.random.rand(1), decimals=5)).astype(
             np.float64
         )
@@ -63,6 +65,7 @@ def univariate_input(
         "name": name,
         "distribution": distribution,
         "parameters": parameters,
+        "description": description,
     }
 
     my_univariate_input = Marginal(**specs)
@@ -232,39 +235,125 @@ def test_cdf_monotonously_increasing(univariate_input: Any) -> None:
     assert np.all(yy_diff >= 0.0)
 
 
-def test_pass_random_seed():
-    """Test passing random seed to the constructor."""
+def test_pass_rng_seed(univariate_input):
+    """Test passing random seed to generate sample."""
 
-    # Create two instances with an identical seed number
-    rng_seed = 42
-    my_input_1 = Marginal("uniform", [0, 1], rng_seed=rng_seed)
-    my_input_2 = Marginal("uniform", [0, 1], rng_seed=rng_seed)
+    marginal, _ = univariate_input
 
     # Generate sample points
-    xx_1 = my_input_1.get_sample(1000)
-    xx_2 = my_input_2.get_sample(1000)
+    rng_seed = 42
+    xx_1 = marginal.get_sample(1000, rng_seed)
+    xx_2 = marginal.get_sample(1000, rng_seed)
 
     # Assertion: Both samples are equal because the seed is identical
-    assert np.allclose(xx_1, xx_2)
+    assert np.all(xx_1 == xx_2)
 
 
-def test_reset_rng():
-    """Test resetting the RNG once an instance has been created."""
+def test_pass_rng(univariate_input):
+    """Test passing random number generator to generate sample."""
+    marginal, _ = univariate_input
 
-    # Create two instances with an identical seed number
-    rng_seed = 42
-    my_input = Marginal("uniform", [0, 1], rng_seed=rng_seed)
+    # Generate sample points with the same random number generators
+    rng_1 = np.random.default_rng(42)
+    xx_1 = marginal.get_sample(1000, rng_1)
+    rng_2 = np.random.default_rng(42)
+    xx_2 = marginal.get_sample(1000, rng_2)
 
-    # Generate sample points
-    xx_1 = my_input.get_sample(1000)
-    xx_2 = my_input.get_sample(1000)
+    # Assertion: Both samples are equal because the seed is identical
+    assert np.all(xx_1 == xx_2)
 
-    # Assertion: Both samples should not be equal
-    assert not np.allclose(xx_1, xx_2)
 
-    # Reset the RNG and generate new sample
-    my_input.reset_rng(rng_seed)
-    xx_2 = my_input.get_sample(1000)
+class TestEquality:
+    """All tests related to checking the equality in value of two instances."""
 
-    # Assertion: Both samples should now be equal
-    assert np.allclose(xx_1, xx_2)
+    def test_equal_identical(self, univariate_input):
+        """Test the equality in value of two identical instances."""
+        marginal, _ = univariate_input
+
+        # Assertions
+        assert marginal == marginal
+        assert marginal is marginal
+
+    def test_equal_unidentical(self, univariate_input):
+        """Test the equality in value of two unidentical instances."""
+        marginal_1, _ = univariate_input
+
+        marginal_2 = copy(marginal_1)
+
+        # Assertions
+        assert marginal_1 == marginal_2
+        assert marginal_1 is not marginal_2
+
+    def test_inequal_name(self, univariate_input):
+        """Test the inequality in name of two instances."""
+        marginal_1, _ = univariate_input
+
+        marginal_2 = Marginal(
+            marginal_1.distribution,
+            marginal_1.parameters,
+            marginal_1.name + "_2",
+            marginal_1.description,
+        )
+
+        # Assertion
+        assert marginal_1 != marginal_2
+
+    def test_inequal_description(self, univariate_input):
+        """Test the inequality in description of two instances."""
+        marginal_1, _ = univariate_input
+
+        marginal_2 = Marginal(
+            marginal_1.distribution,
+            marginal_1.parameters,
+            marginal_1.name,
+            marginal_1.description + "_2",
+        )
+
+        # Assertion
+        assert marginal_1 != marginal_2
+
+    def test_inequal_parameters(self, univariate_input):
+        """Test the inequality in parameters of two instances."""
+        marginal_1, _ = univariate_input
+
+        marginal_2 = Marginal(
+            marginal_1.distribution,
+            marginal_1.parameters * (1 + 1e-4),
+            marginal_1.name,
+            marginal_1.description,
+        )
+
+        # Assertion
+        assert marginal_1 != marginal_2
+
+    @pytest.mark.parametrize("other_instance", [None, 1, "string"])
+    def test_inequal_instance(self, univariate_input, other_instance):
+        """Test the inequality in type of two instances."""
+        marginal_1, _ = univariate_input
+
+        # Assertion
+        assert marginal_1 != other_instance
+
+    def test_inequal_type(self, univariate_input):
+        """Test the inequality in type of two instances."""
+        marginal_1, _ = univariate_input
+
+        if marginal_1.distribution == "uniform":
+            parameters = np.sort(np.round(np.random.rand(4), decimals=5))
+            marginal_2 = Marginal(
+                "beta",
+                parameters,
+                marginal_1.name,
+                marginal_1.description,
+            )
+        else:
+            parameters = np.sort(np.round(np.random.rand(2), decimals=5))
+            marginal_2 = Marginal(
+                "uniform",
+                parameters,
+                marginal_1.name,
+                marginal_1.description,
+            )
+
+        # Assertion
+        assert marginal_1 != marginal_2


### PR DESCRIPTION
The `Marginal` class has been converted from a frozen dataclass to a regular class.

Additional changes:

- Remove `rng_seed` from the constructor; add `rng` as a parameter to the `get_sample()` method
- Remove `reset_rng()` method
- Add `__eq__() for value equality checks between `Marginal` instances
- Improve docstrings throughout
- Update the relevant test suite

Closes: #458
Ref: #452