### PR TITLE
Refactor ProbInput and Marginal for registry-based architecture

### DIFF
--- a/src/uqtestfuns/core/prob_input/marginal.py
+++ b/src/uqtestfuns/core/prob_input/marginal.py
@@ -1,4 +1,5 @@
 """
+Module with an implementation of ``Marginal`` class.
 
 This module provides the :class:`Marginal` class, which models a single random
 variable through a parametric probability distribution. It is intended as
@@ -277,10 +278,10 @@ class Marginal:
         # Return the transformed sample in the current distribution
         return self.icdf(xx)
 
-    def transform_sample(
+    def transform_to(
         self,
         xx: Union[float, np.ndarray],
-        other: Marginal,
+        target: Marginal,
     ) -> np.ndarray:
         """Transform a sample from this distribution to another.
 
@@ -288,7 +289,7 @@ class Marginal:
         ----------
         xx : Union[float, np.ndarray]
             The sample points to be transformed.
-        other : Marginal
+        target : Marginal
             The target distribution to which the sample should be transformed.
 
         Returns
@@ -297,14 +298,14 @@ class Marginal:
             The transformed sample points in the target distribution.
             The output is an array of at least one dimension.
         """
-        if not isinstance(other, Marginal):
+        if not isinstance(target, Marginal):
             raise TypeError("Other instance must be of Marginal type!")
 
-        # Transform the sample to [0, 1] domain
+        # Transform the sample to [0, 1]
         xx_trans = self.cdf(xx)
 
-        # Transform the sample in [0, 1] to the domain of the other
-        return other.icdf(xx_trans)
+        # Transform the sample in [0, 1] to the other distribution
+        return target.icdf(xx_trans)
 
     # --- Dunder methods
     def __eq__(self, other: object) -> bool:

--- a/src/uqtestfuns/core/prob_input/probabilistic_input.py
+++ b/src/uqtestfuns/core/prob_input/probabilistic_input.py
@@ -162,7 +162,7 @@ class ProbInput:
             for idx_dim, (marginal_self, marginal_other) in enumerate(
                 zip(self.marginals, other.marginals)
             ):
-                xx_trans[:, idx_dim] = marginal_self.transform_sample(
+                xx_trans[:, idx_dim] = marginal_self.transform_to(
                     xx[:, idx_dim], marginal_other
                 )
         else:

--- a/src/uqtestfuns/core/prob_input/probabilistic_input_new.py
+++ b/src/uqtestfuns/core/prob_input/probabilistic_input_new.py
@@ -1,0 +1,526 @@
+"""
+Module with an implementation of `ProbInput` class.
+
+This module provides a `ProbInput` class for building, sampling, evaluating,
+and transforming the probabilistic input model of an uncertainty quantification
+test function.
+
+Copula-based dependence is reserved for future support.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from numpy.typing import ArrayLike
+from tabulate import tabulate
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+from uqtestfuns.core.prob_input.marginal import FIELD_NAMES, Marginal
+
+__all__ = ["ProbInput"]
+
+
+class ProbInput:
+    """A class representing a probabilistic input model to a UQ test function.
+
+    A probabilistic input model to an uncertainty quantification test function
+    is a random vector with a joint probability density function. It is
+    defined by a sequence of one-dimensional marginal distributions and,
+    optionally, a copula to model the dependence structure between the
+    variables.
+
+    Parameters
+    ----------
+    marginals : Sequence[Marginal]
+        A sequence of one-dimensional marginal distributions.
+    copulas : Any, optional
+        Copulas to model the dependence structure between the variables.
+        Currently, it is not used.
+    name : str, optional
+        The name of the probabilistic input model.
+    """
+
+    def __init__(
+        self,
+        marginals: Sequence[Marginal],
+        copulas: Any = None,
+        name: Optional[str] = None,
+    ):
+        # Read-only properties
+        self._marginals = tuple(marginals)
+        self._copulas = copulas
+        self._name = name
+
+    # --- Factory methods
+    @classmethod
+    def replicate(
+        cls,
+        dimension: int,
+        distribution: str,
+        parameters: ArrayLike,
+        base_name: str = "X",
+        *,
+        copulas: Any = None,
+        name: Optional[str] = None,
+    ):
+        """Create a probabilistic input model with replicated marginals.
+
+        Parameters
+        ----------
+        dimension : int
+            The dimension of the probabilistic input.
+        distribution : str
+            The type of the probability distribution.
+        parameters :  array_like
+            The parameters of the chose probability distribution.
+        base_name : str, optional
+            The base name for the random variables. Default is "X" and will
+            be replicated as "X1", "X2", etc.
+        copulas : Any, optional
+            Copulas to model the dependence structure between the variables.
+            Currently, it is not used.
+        name : str, optional
+            The name of the probabilistic input model.
+
+        Returns
+        -------
+        ProbInput
+            An instance of `ProbInput` class with replicated marginals.
+        """
+        marginals = []
+        for i in range(1, dimension + 1):
+            marginal_name = f"{base_name}{i}"
+            marginal = Marginal(distribution, parameters, marginal_name)
+            marginals.append(marginal)
+
+        return cls(marginals, copulas, name)
+
+    @classmethod
+    def from_dicts(
+        cls,
+        marginals: Sequence[Dict[str, Any]],
+        copulas: Any = None,
+        name: Optional[str] = None,
+    ):
+        """Create a probabilistic input model from dictionaries.
+
+        Parameters
+        ----------
+        marginals : Sequence[Dict[str, Any]]
+            A sequence of dictionaries with the marginal specifications. Each
+            element consists of the distribution type, parameters,
+            name (optional), and description (optional) of the marginal.
+        copulas : Any, optional
+            Copulas to model the dependence structure between the variables.
+            Currently, it is not used.
+        name : str, optional
+            The name of the probabilistic input model.
+
+        Returns
+        -------
+        ProbInput
+            An instance of `ProbInput` class with the specified marginals
+            given as a sequence of dictionaries.
+        """
+        marginals_objects = tuple(
+            [Marginal(**marginal) for marginal in marginals]
+        )
+
+        return cls(marginals_objects, copulas, name)
+
+    @classmethod
+    def from_factory(
+        cls,
+        factory_function: Callable,
+        dimension: int,
+        factory_kwargs: Optional[Dict[str, Any]] = None,
+        *,
+        copulas: Any = None,
+        name: Optional[str] = None,
+    ):
+        """Create a probabilistic input model from a factory function.
+
+        Parameters
+        ----------
+        factory_function : Callable
+            The factory function that generates the marginal specifications.
+            The function should take the dimension of input as the first
+            positional argument and return a sequence of dictionaries.
+        dimension : int
+            The dimension of the probabilistic input model.
+        factory_kwargs : Optional[Dict[str, Any]], optional
+            Keyword arguments to pass to the factory function, by default None.
+        copulas : Any, optional
+            The copula specification for the probabilistic input model,
+            by default None.
+        name : Optional[str], optional
+            The name of the probabilistic input model, by default None.
+
+        Returns
+        -------
+        ProbInput
+            An instance of `ProbInput` class with the marginals created by
+            the factory function.
+        """
+        if factory_kwargs is None:
+            marginals = factory_function(dimension)
+        else:
+            marginals = factory_function(dimension, **factory_kwargs)
+
+        return cls.from_dicts(marginals, copulas, name)
+
+    # --- Properties
+    @property
+    def marginals(self) -> Tuple[Marginal, ...]:
+        """Return the sequence of Marginals defining the probabilistic input.
+
+        Returns
+        -------
+        Tuple[Marginal, ...]
+            The sequence of Marginals that defines the probabilistic input.
+        """
+        return self._marginals
+
+    @property
+    def copulas(self) -> Any:
+        """Return the underlying Copulas of the probabilistic input.
+
+        Returns
+        -------
+        Any
+            The underlying Copulas of the probabilistic input.
+        """
+        return self._copulas
+
+    @property
+    def name(self) -> Optional[str]:
+        """Return the name of the probabilistic input model.
+
+        Returns
+        -------
+        str, optional
+            The name of the probabilistic input model.
+        """
+        return self._name
+
+    @property
+    def dimension(self) -> int:
+        """Return the number of random input variables.
+
+        Returns
+        -------
+        int
+            The number of random input variables.
+        """
+        return len(self.marginals)
+
+    # --- Public methods
+    def get_sample(
+        self,
+        sample_size: int = 1,
+        rng: Union[np.random.Generator, int, None] = None,
+    ) -> np.ndarray:
+        r"""Generate a random sample from the probabilistic input model.
+
+        Parameters
+        ----------
+        sample_size : int, optional
+            The number of sample points to generate. The default is 1.
+        rng :  Union[np.random.Generator, int, None]
+            The random number generator or the seed for the default NumPy
+            random number generator. If not specified, the default random
+            number generator with the operating system entropy is used.
+
+        Returns
+        -------
+        :class:`numpy:numpy.ndarray`
+            The generated random sample from the probabilistic input model,
+            a multi-dimensional array of shape :math:`(N, m)` where :math:`N`
+            and :math:`m` are the number of samples and the dimension of the
+            probabilistic input model, respectively.
+        """
+        if rng is None or isinstance(rng, int):
+            rng = np.random.default_rng(rng)
+
+        # Generate random sample of dimension 'm' in [0, 1]
+        xx = rng.random((sample_size, self.dimension))
+
+        if not self.copulas:
+            # Iso-probabilistically transform the sample to the marginal
+            for idx, marginal in enumerate(self.marginals):
+                xx[:, idx] = marginal.icdf(xx[:, idx])
+        else:
+            raise ValueError("Copulas are not currently supported!")
+
+        return xx
+
+    def transform_to(
+        self,
+        xx: np.ndarray,
+        target: Union[ProbInput, Tuple[float, float]] = (-1.0, 1.0),
+    ) -> np.ndarray:
+        """Transform a sample from this input model to another.
+
+        Parameters
+        ----------
+        xx : :class:`numpy:numpy.ndarray`
+            The sample points from the source (this) probabilistic input model.
+        target : Union[ProbInput, Tuple[float, float]], optional
+            The target probabilistic input model, or a tuple ``(lower, upper)``
+            specifying the bounds of a hypercube with independent uniform
+            marginals. The default is ``(-1.0, 1.0)``.
+
+        Returns
+        -------
+        :class:`numpy:numpy.ndarray`
+            The transformed sample from the current probabilistic input model
+            to the target probabilistic input model.
+        """
+        target_ = self._prepare_transform(xx, target)
+
+        if self.copulas:
+            raise ValueError("Copulas are not currently supported!")
+
+        xx_trans = np.empty(xx.shape)
+        # Independence copula, transform marginal by marginal
+        zipped_marginals = zip(self.marginals, target_.marginals)
+        for i, (m_self, m_target) in enumerate(zipped_marginals):
+            xx_trans[:, i] = m_self.transform_to(xx[:, i], m_target)
+
+        return xx_trans
+
+    def transform_from(
+        self,
+        xx: np.ndarray,
+        source: Union[ProbInput, Tuple[float, float]] = (-1.0, 1.0),
+    ) -> np.ndarray:
+        """Transform a sample from another input model to this one.
+
+        Parameters
+        ----------
+        xx : :class:`numpy:numpy.ndarray`
+            The sample points from the source probabilistic input model.
+        source : Union[ProbInput, Tuple[float, float]], optional
+            The source probabilistic input model, or a tuple ``(lower, upper)``
+            specifying the bounds of a hypercube with independent uniform
+            marginals. The default is ``(-1.0, 1.0)``.
+
+        Returns
+        -------
+        :class:`numpy:numpy.ndarray`
+            The transformed sample in the domain of this probabilistic input
+            model.
+        """
+        source_ = self._prepare_transform(xx, source)
+
+        return source_.transform_to(xx, self)
+
+    def pdf(self, xx: np.ndarray) -> np.ndarray:
+        """Compute the probability density function of the probabilistic input.
+
+        Parameters
+        ----------
+        xx : :class:`numpy:numpy.ndarray`
+            The input values in the support of the distribution,
+            a two-dimensional array of shape :math:`(N, m)` where :math:`N`
+            and :math:`m` are the number of sample points and the dimension,
+            respectively. A one-dimensional array of length :math:`m` is also
+            accepted and interpreted as a single sample point.
+
+        Returns
+        -------
+        :class:`numpy:numpy.ndarray`
+            The probability density function (PDF) values at the input values.
+            The output is a one-dimensional array of length :math:`N`.
+        """
+        if self.copulas:
+            raise ValueError("Copulas are not currently supported!")
+
+        xx = np.atleast_2d(xx)
+
+        if xx.shape[1] != self.dimension:
+            raise ValueError(
+                f"Input dimension {xx.shape[1]} does not match "
+                f"ProbInput dimension {self.dimension}"
+            )
+
+        log_pdf = np.zeros(xx.shape[0])
+        with np.errstate(divide="ignore"):
+            # Use log-transform because of the smallness of numbers
+            for i, marginal in enumerate(self.marginals):
+                log_pdf += np.log(marginal.pdf(xx[:, i]))
+
+        return np.exp(log_pdf)
+
+    def cdf(self, xx: np.ndarray) -> np.ndarray:
+        """Compute the cumulative distribution function of the input.
+
+        Parameters
+        ----------
+        xx : :class:`numpy:numpy.ndarray`
+            The input values in the support of the distribution,
+            a two-dimensional array of shape :math:`(N, m)` where :math:`N`
+            and :math:`m` are the number of sample points and the dimension,
+            respectively. A one-dimensional array of length :math:`m` is also
+            accepted and interpreted as a single sample point.
+
+        Returns
+        -------
+        :class:`numpy:numpy.ndarray`
+            The cumulative distribution function (CDF) values
+            at the input values. The output is a one-dimensional array
+            of length :math:`N`.
+        """
+        if self.copulas:
+            raise ValueError("Copulas are not currently supported!")
+
+        xx = np.atleast_2d(xx)
+
+        if xx.shape[1] != self.dimension:
+            raise ValueError(
+                f"Input dimension {xx.shape[1]} does not match "
+                f"ProbInput dimension {self.dimension}"
+            )
+
+        log_cdf = np.zeros(xx.shape[0])
+        with np.errstate(divide="ignore"):
+            # Use log-transform because of the smallness of numbers
+            for i, marginal in enumerate(self.marginals):
+                log_cdf += np.log(marginal.cdf(xx[:, i]))
+
+        return np.exp(log_cdf)
+
+    # --- Dunder methods
+    def __eq__(self, other: Any) -> bool:
+        """Check if two ProbInput instances are equal in value.
+
+        An equality in value between two instances of `ProbInput` means that:
+
+        - All the marginals are equal
+        - The copulas are equal
+        - The names are equal
+
+        Parameters
+        ----------
+        other : Any
+            The other instance to compare with.
+
+        Returns
+        -------
+        bool
+            ``True`` if the instances are equal in value, ``False`` otherwise.
+        """
+        if not isinstance(other, ProbInput):
+            return False
+
+        if self.name != other.name:
+            return False
+
+        if self.copulas != other.copulas:
+            return False
+
+        if self.dimension != other.dimension:
+            return False
+
+        for m_self, m_other in zip(self.marginals, other.marginals):
+            if m_self != m_other:
+                return False
+
+        return True
+
+    def __repr__(self):
+        """Return the unambiguous string representation of the instance."""
+        class_name = self.__class__.__name__
+        # Get the value of the constructor arguments
+        attrs = {
+            "marginals": self.marginals,
+            "copulas": self.copulas,
+            "name": self.name,
+        }
+        attrs_str = ", ".join(f"{k}={v!r}" for k, v in attrs.items())
+
+        return f"{class_name}({attrs_str})"
+
+    def __str__(self):
+        """Return human-readable string representation of the instance."""
+        if self.name is None or self.name == "":
+            table = f"Dimension : {self.dimension}\n"
+        else:
+            table = f"Name      : {self.name}\n"
+            table += f"Dimension : {self.dimension}\n"
+        table += "Marginals :\n\n"
+
+        # Get the header names
+        header_names = [name.capitalize() for name in FIELD_NAMES]
+        header_names.insert(0, "No.")
+
+        # Get the values for each field as a list
+        rows = []
+        for i, m in enumerate(self.marginals):
+            row: List[Any] = [i + 1]
+            for field_name in FIELD_NAMES:
+                attr_value = getattr(m, field_name)
+                if attr_value is None:
+                    attr_value = "-"
+                row.append(attr_value)
+            rows.append(row)
+
+        # Create a table of marginals details
+        table += tabulate(
+            rows,
+            headers=header_names,
+            stralign="center",
+            disable_numparse=True,
+        )
+
+        if self.dimension == 1:
+            return table
+
+        # Temporary solution for independence copula
+        copulas = "Independence" if self.copulas is None else self.copulas
+
+        table += f"\n\nCopulas         : {copulas}"
+
+        return table
+
+    # --- Private utilities
+    def _prepare_transform(
+        self,
+        xx: np.ndarray,
+        other: Union[ProbInput, Tuple[float, float]],
+    ) -> "ProbInput":
+        """Prepare the transformation counterpart as a ProbInput instance.
+
+        Parameters
+        ----------
+        xx : :class:`numpy:numpy.ndarray`
+            The sample points to transform.
+        other : Union[ProbInput, Tuple[float, float]]
+            The other instance for transformation, either as the source or
+            target. If the input is a tuple, it is assumed to be the parameters
+            of a uniform distribution (i.e., its lower and upper bounds).
+
+        Returns
+        -------
+        ProbInput
+            The prepared ProbInput instance for transformation.
+        """
+        if not isinstance(other, ProbInput):
+            other_ = ProbInput.replicate(
+                self.dimension,
+                distribution="uniform",
+                parameters=other,
+            )
+        else:
+            other_ = other
+
+        # Make sure the dimensions of the inputs are consistent
+        if xx.shape[1] != self.dimension or xx.shape[1] != other_.dimension:
+            raise ValueError(
+                f"The dimensions of the input samples ({xx.shape[1]}) and "
+                f"the probabilistic input models "
+                f"({self.dimension}, {other_.dimension}) do not match."
+            )
+
+        return other_

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,8 @@ All global fixtures are defined here.
 """
 
 import numpy as np
-import random
 import string
-from typing import List, Callable, Any
+from typing import List, Callable, Any, Dict
 
 from uqtestfuns.core.prob_input.utils import SUPPORTED_MARGINALS
 from uqtestfuns.core.prob_input.marginal import Marginal
@@ -15,26 +14,87 @@ from uqtestfuns.core.prob_input.marginal import Marginal
 MARGINALS = list(SUPPORTED_MARGINALS.keys())
 
 
-def create_random_alphanumeric(length: int) -> str:
+def create_random_alphanumeric(length: int, rng=None) -> str:
     """Create a random alphanumeric string of a given length.
 
     Parameters
     ----------
     length : int
         Length of the string
+    rng : Union[np.random.Generator, int], optional
+        The random number generator or the seed for the default NumPy
 
     Returns
     -------
     str
         A random alphanumeric string of the given length.
     """
+    if rng is None or isinstance(rng, int):
+        rng = np.random.default_rng(rng)
 
     out = "".join(
-        random.choice(string.ascii_letters + string.digits)
-        for _ in range(length)
+        rng.choice(list(string.ascii_letters + string.digits), size=length)
     )
 
     return out
+
+
+def create_random_marginal_dicts(
+    length: int,
+    rng=None,
+) -> List[Dict]:
+    """Create a random list of univariate random variables.
+
+    Parameters
+    ----------
+    length : int
+        Length of the list of dictionaries.
+    rng : Union[np.random.Generator, int], optional
+        The random number generator or the seed for the default NumPy
+    Returns
+    -------
+    List[Marginal]
+        List of dictionaries to specify a ProbInput instance.
+    """
+    if rng is None or isinstance(rng, int):
+        rng = np.random.default_rng(rng)
+
+    marginals = []
+
+    for i in range(length):
+        distribution = rng.choice(MARGINALS)
+        if distribution == "beta":
+            parameters = np.sort(1 + 2 * rng.random(4))
+        elif distribution == "exponential":
+            # Single parameter, must be strictly positive
+            parameters = 1 + rng.random(1)
+        elif distribution == "triangular":
+            parameters = np.sort(1 + 2 * rng.random(2))
+            parameters = np.insert(
+                parameters, 2, rng.uniform(parameters[0], parameters[1])
+            )
+        elif distribution in ["trunc-normal", "trunc-gumbel"]:
+            # mu must be inside the bounds
+            parameters = np.sort(1 + 2 * rng.random(3))
+            parameters[[0, 1]] = parameters[[1, 0]]
+            # Insert sigma/beta as the second parameter
+            parameters = np.insert(parameters, 1, 0.5 + rng.random(1))
+        elif distribution == "lognormal":
+            # Limit the size of the parameters
+            parameters = 1 + rng.random(2)
+        else:
+            parameters = np.sort(1 + 2 * rng.random(2))
+
+        marginals.append(
+            {
+                "name": f"X{i+1}",
+                "distribution": distribution,
+                "parameters": parameters,
+                "description": create_random_alphanumeric(10, rng),
+            }
+        )
+
+    return marginals
 
 
 def create_random_marginals(length: int) -> List[Marginal]:
@@ -50,42 +110,9 @@ def create_random_marginals(length: int) -> List[Marginal]:
     List[Marginal]
         List of dictionaries to specify a ProbInput instance.
     """
-    marginals = []
+    marginal_dicts = create_random_marginal_dicts(length)
 
-    for i in range(length):
-        distribution = random.choice(MARGINALS)
-        if distribution == "beta":
-            parameters = np.sort(1 + 2 * np.random.rand(4))
-        elif distribution == "exponential":
-            # Single parameter, must be strictly positive
-            parameters = 1 + np.random.rand(1)
-        elif distribution == "triangular":
-            parameters = np.sort(1 + 2 * np.random.rand(2))
-            parameters = np.insert(
-                parameters, 2, np.random.uniform(parameters[0], parameters[1])
-            )
-        elif distribution in ["trunc-normal", "trunc-gumbel"]:
-            # mu must be inside the bounds
-            parameters = np.sort(1 + 2 * np.random.rand(3))
-            parameters[[0, 1]] = parameters[[1, 0]]
-            # Insert sigma/beta as the second parameter
-            parameters = np.insert(parameters, 1, 0.5 + np.random.rand(1))
-        elif distribution == "lognormal":
-            # Limit the size of the parameters
-            parameters = 1 + np.random.rand(2)
-        else:
-            parameters = np.sort(1 + 2 * np.random.rand(2))
-
-        marginals.append(
-            Marginal(
-                name=f"X{i+1}",
-                distribution=distribution,
-                parameters=parameters,
-                description=create_random_alphanumeric(10),
-            )
-        )
-
-    return marginals
+    return [Marginal(**marginal_dict) for marginal_dict in marginal_dicts]
 
 
 def assert_call(fct: Callable[..., Any], *args: Any, **kwargs: Any) -> None:

--- a/tests/core/prob_input/test_univariate_input.py
+++ b/tests/core/prob_input/test_univariate_input.py
@@ -186,7 +186,7 @@ def test_transform_sample() -> None:
         name=name_2, distribution=distribution_2, parameters=parameters_2
     )
 
-    xx_trans = my_univariate_input_1.transform_sample(
+    xx_trans = my_univariate_input_1.transform_to(
         xx, my_univariate_input_2
     )
 
@@ -209,7 +209,7 @@ def test_failed_transform_sample() -> None:
     xx = my_univariate_input.get_sample(sample_size)
 
     with pytest.raises(TypeError):
-        my_univariate_input.transform_sample(xx, [])  # type: ignore
+        my_univariate_input.transform_to(xx, [])  # type: ignore
 
 
 def test_cdf_monotonously_increasing(univariate_input: Any) -> None:

--- a/tests/core/prob_input/test_univariate_input.py
+++ b/tests/core/prob_input/test_univariate_input.py
@@ -186,9 +186,7 @@ def test_transform_sample() -> None:
         name=name_2, distribution=distribution_2, parameters=parameters_2
     )
 
-    xx_trans = my_univariate_input_1.transform_to(
-        xx, my_univariate_input_2
-    )
+    xx_trans = my_univariate_input_1.transform_to(xx, my_univariate_input_2)
 
     # Assertions
     assert np.min(xx_trans) >= my_univariate_input_2.lower

--- a/tests/test_prob_input_new.py
+++ b/tests/test_prob_input_new.py
@@ -1,0 +1,692 @@
+import pytest
+import numpy as np
+
+from uqtestfuns import Marginal
+from uqtestfuns.core.prob_input.probabilistic_input_new import ProbInput
+from conftest import create_random_marginals, create_random_marginal_dicts
+from functools import partial
+
+# Dimension (`m`)
+DIMENSIONS = [1, 2, 10, 100]
+
+
+def _id_m(dimension):
+    return f"m={dimension}"
+
+
+@pytest.fixture(params=DIMENSIONS, ids=_id_m)
+def dimension(request):
+    """Return dimension (`m`) fixture."""
+    return request.param
+
+
+class TestConstructor:
+    """All tests related to the constructor of ProbInput."""
+
+    def test_default(self, dimension):
+        """Test the creation of a ProbInput via the default constructor."""
+        marginals = create_random_marginals(dimension)
+        test_name = "test_name"
+
+        # Create an instance
+        prob_input = ProbInput(marginals, name=test_name)
+
+        # Assertions
+        assert prob_input.dimension == dimension
+        assert prob_input.name == test_name
+        assert prob_input.copulas is None
+        for i in range(dimension):
+            assert marginals[i] == prob_input.marginals[i]
+
+    def test_replicate(self, dimension):
+        """Test creating a probabilistic input with replicated marginals."""
+        # Create a single marginal
+        marginal = create_random_marginals(1)[0]
+        distribution = marginal.distribution
+        parameters = marginal.parameters
+
+        marginal_dicts = []
+        for i in range(1, dimension + 1):
+            marginal_dicts.append(
+                {
+                    "distribution": distribution,
+                    "parameters": parameters,
+                    "name": f"X{i}",
+                }
+            )
+
+        # Create new probabilistic input with replicated marginals
+        prob_input_1 = ProbInput.replicate(dimension, distribution, parameters)
+        prob_input_2 = ProbInput.from_dicts(marginal_dicts)
+
+        # Assertions
+        assert prob_input_1 == prob_input_2
+
+    def test_from_dicts(self, dimension):
+        """Test the creation of a ProbInput from a list of dictionaries."""
+        marginal_dicts = create_random_marginal_dicts(dimension)
+        marginals = [
+            Marginal(**marginal_dict) for marginal_dict in marginal_dicts
+        ]
+
+        # Create instances
+        prob_input_1 = ProbInput(marginals)
+        prob_input_2 = ProbInput.from_dicts(marginal_dicts)
+
+        # Assertion
+        assert prob_input_1 == prob_input_2
+
+    def test_from_factory(self, dimension):
+        """Test the creation of a ProbInput from a factory function."""
+        rng_seed = 42
+        marginal_dicts = create_random_marginal_dicts(dimension, rng_seed)
+
+        factory = partial(create_random_marginal_dicts, rng=rng_seed)
+
+        # Create instances
+        prob_input_1 = ProbInput.from_factory(factory, dimension)
+        prob_input_2 = ProbInput.from_dicts(marginal_dicts)
+
+        # Assertion
+        assert prob_input_1 == prob_input_2
+
+    def test_from_factory_with_kwargs(self, dimension):
+        """Test the creation from a factory function with args."""
+        rng_seed = 42
+        marginal_dicts = create_random_marginal_dicts(dimension, rng_seed)
+
+        # Create instances
+        prob_input_1 = ProbInput.from_factory(
+            create_random_marginal_dicts,
+            dimension,
+            factory_kwargs={"rng": rng_seed},
+        )
+        prob_input_2 = ProbInput.from_dicts(marginal_dicts)
+
+        # Assertion
+        assert prob_input_1 == prob_input_2
+
+
+class TestGetSample:
+    """All tests related to the get_sample() method of ProbInput."""
+
+    def test_default(self, dimension):
+        """Test the generation of sample point."""
+        marginals = create_random_marginals(dimension)
+
+        # Create an instance
+        prob_input = ProbInput(marginals)
+
+        # Generate a sample point
+        xx = prob_input.get_sample()
+
+        # Assertion
+        assert len(xx) == 1
+        assert xx.shape[1] == dimension
+
+    def test_rng_reproducible(self, dimension):
+        """Test the generation of sample points with a NumPy rng."""
+        marginals = create_random_marginals(dimension)
+
+        # Create an instance
+        prob_input = ProbInput(marginals)
+
+        # Generate sample points
+        sample_size = 1000
+        rng = np.random.default_rng(42)
+        xx_1 = prob_input.get_sample(sample_size, rng)
+        # Reset the RNG and generate new sample points
+        rng = np.random.default_rng(42)
+        xx_2 = prob_input.get_sample(sample_size, rng)
+
+        # Assertion
+        assert np.allclose(xx_1, xx_2)
+
+    def test_rng_continuing_stream(self, dimension):
+        """Test that successive calls with same Generator differ."""
+        marginals = create_random_marginals(dimension)
+
+        # Create an instance
+        prob_input = ProbInput(marginals)
+
+        # Generate sample points
+        sample_size = 1000
+        rng = np.random.default_rng(42)
+        xx_1 = prob_input.get_sample(sample_size, rng)
+        xx_2 = prob_input.get_sample(sample_size, rng)
+
+        # Assertion
+        assert not np.allclose(xx_1, xx_2)
+
+    def test_rng_int(self, dimension):
+        """Test the generation of sample points with an integer seed."""
+        marginals = create_random_marginals(dimension)
+
+        # Create an instance
+        prob_input = ProbInput(marginals)
+
+        # Generate sample points
+        sample_size = 1000
+        rng = 42
+        xx_1 = prob_input.get_sample(sample_size, rng)
+        xx_2 = prob_input.get_sample(sample_size, rng)
+
+        # Assertion
+        assert np.allclose(xx_1, xx_2)
+
+    def test_get_sample(self, dimension):
+        """Test sample generation of a given size."""
+        marginals = create_random_marginals(dimension)
+
+        # Create an instance
+        prob_input = ProbInput(marginals)
+
+        # Generate sample points
+        sample_size = 5325
+        xx = prob_input.get_sample(sample_size)
+
+        # Assertions
+        # Test the number of sample points
+        assert xx.shape[0] == sample_size
+        # Test the dimensionality of the sample
+        assert xx.shape[1] == dimension
+        # Test the bounds
+        for i in range(dimension):
+            assert np.min(xx[:, i]) >= prob_input.marginals[i].lower
+            assert np.max(xx[:, i]) <= prob_input.marginals[i].upper
+
+    def test_generate_dependent_sample(self, dimension):
+        """Test dependent sample generation (unsupported; raise error)."""
+        marginals = create_random_marginals(dimension)
+
+        my_multivariate_input = ProbInput(marginals, "a")
+
+        with pytest.raises(ValueError):
+            my_multivariate_input.get_sample(1000)
+
+
+class TestPDF:
+    """All tests related to the pdf() method of ProbInput."""
+
+    def test_default(self, dimension):
+        """Test the PDF computation for a given input."""
+        marginals = create_random_marginals(dimension)
+
+        # Create an instance
+        prob_input = ProbInput(marginals)
+
+        # Generate sample points
+        sample_size = 100
+        xx = prob_input.get_sample(sample_size)
+
+        # Compute the PDF values
+        pdf_values = prob_input.pdf(xx)
+
+        # Assertions
+        assert len(pdf_values) == sample_size
+        assert pdf_values.ndim == 1
+        assert np.all(pdf_values >= 0)
+        assert np.all(pdf_values < np.inf)
+
+    def test_single_value(self, dimension):
+        """Test the PDF computation for a single input value."""
+        marginals = create_random_marginals(dimension)
+
+        # Create an instance
+        prob_input = ProbInput(marginals)
+
+        # Generate a sample point
+        sample_size = 1
+        xx = prob_input.get_sample(sample_size)[0, :]
+
+        # Compute the PDF values
+        pdf_values = prob_input.pdf(xx)
+
+        # Assertions
+        assert len(pdf_values) == sample_size
+        assert pdf_values.ndim == 1
+        assert np.all(pdf_values >= 0)
+        assert np.all(pdf_values < np.inf)
+
+    def test_get_dependent_pdf_values(self, dimension):
+        """Test dependent PDF value computation (not yet supported)."""
+        marginals = create_random_marginals(dimension)
+
+        # Create an instance
+        prob_input = ProbInput(marginals, copulas="b")
+
+        with pytest.raises(ValueError):
+            _ = prob_input.pdf(np.random.rand(2, dimension))
+
+    def test_invalid_input(self, dimension):
+        """Test invalid input for the pdf() method."""
+        marginals = create_random_marginals(dimension)
+
+        # Create an instance
+        prob_input = ProbInput(marginals)
+
+        # Generate a sample point
+        xx = np.random.rand(100, dimension + 1)
+
+        # Compute the PDF values
+        with pytest.raises(ValueError):
+            _ = prob_input.pdf(xx)
+
+    def test_known_value(self):
+        """Test PDF against known analytical value."""
+        # Create an instance
+        prob_input = ProbInput.from_dicts(
+            [
+                {"distribution": "uniform", "parameters": [0.0, 2.0]},
+                {"distribution": "uniform", "parameters": [0.0, 5.0]},
+            ]
+        )
+
+        # Generate sample points
+        xx = prob_input.get_sample(1000)
+
+        # Assertion: Joint PDF = 1/2 * 1/5 = 0.1
+        assert np.allclose(prob_input.pdf(xx), 0.1)
+
+
+class TestCDF:
+    """All tests related to the cdf() method of ProbInput."""
+
+    def test_default(self, dimension):
+        """Test the CDF computation for a given input."""
+        marginals = create_random_marginals(dimension)
+
+        # Create an instance
+        prob_input = ProbInput(marginals)
+
+        # Generate sample points
+        sample_size = 100
+        xx = prob_input.get_sample(sample_size)
+
+        # Compute the CDF values
+        cdf_values = prob_input.cdf(xx)
+
+        # Assertions
+        assert len(cdf_values) == sample_size
+        assert cdf_values.ndim == 1
+        assert np.all(cdf_values >= 0.0)
+        assert np.all(cdf_values <= 1.0)
+
+    def test_single_value(self, dimension):
+        """Test the CDF computation for a single input value."""
+        marginals = create_random_marginals(dimension)
+
+        # Create an instance
+        prob_input = ProbInput(marginals)
+
+        # Generate a sample point
+        sample_size = 1
+        xx = prob_input.get_sample(sample_size)[0, :]
+
+        # Compute the CDF values
+        cdf_values = prob_input.cdf(xx)
+
+        # Assertions
+        assert len(cdf_values) == sample_size
+        assert cdf_values.ndim == 1
+        assert np.all(cdf_values >= 0.0)
+        assert np.all(cdf_values <= 1.0)
+
+    def test_get_dependent_cdf_values(self, dimension):
+        """Test dependent CDF value computation (not yet supported)."""
+        marginals = create_random_marginals(dimension)
+
+        # Create an instance
+        prob_input = ProbInput(marginals, copulas="b")
+
+        with pytest.raises(ValueError):
+            _ = prob_input.cdf(np.random.rand(2, dimension))
+
+    def test_invalid_input(self, dimension):
+        """Test invalid input for the cdf() method."""
+        marginals = create_random_marginals(dimension)
+
+        # Create an instance
+        prob_input = ProbInput(marginals)
+
+        # Generate a sample point
+        xx = np.random.rand(100, dimension + 1)
+
+        # Compute the PDF values
+        with pytest.raises(ValueError):
+            _ = prob_input.cdf(xx)
+
+    def test_known_value(self):
+        """Test PDF against known analytical value."""
+        # Create an instance
+        prob_input = ProbInput.from_dicts(
+            [
+                {"distribution": "uniform", "parameters": [0.0, 2.0]},
+                {"distribution": "uniform", "parameters": [0.0, 5.0]},
+            ]
+        )
+
+        # Generate sample points
+        xx = np.array(
+            [
+                [0.0, 0.0],  # 0.0 * 0.0 = 0.0
+                [2.0, 0.0],  # 0.0 * 0.0 = 0.0
+                [0.0, 5.0],  # 0.0 * 0.0 = 0.0
+                [2.0, 5.0],  # 1.0 * 1.0 = 1.0
+                [1.0, 2.5],  # 0.5 * 0.5 = 0.25
+            ]
+        )
+
+        # Assertion
+        cdf_ref = np.array([0.0, 0.0, 0.0, 1.0, 0.25])
+        assert np.allclose(prob_input.cdf(xx), cdf_ref)
+
+
+class TestTransformation:
+    """All tests related to the transformation methods of ProbInput."""
+
+    def test_transform_to(self, dimension):
+        """Test the transformation of sample values to another distribution."""
+        marginals_1 = create_random_marginals(dimension)
+        prob_input_1 = ProbInput(marginals_1)
+
+        marginals_2 = create_random_marginals(dimension)
+        prob_input_2 = ProbInput(marginals_2)
+
+        # Generate sample
+        sample_size = 5000
+        xx_1 = prob_input_1.get_sample(sample_size)
+
+        # Transform the sample points
+        xx_2 = prob_input_1.transform_to(xx_1, prob_input_2)
+
+        # Assertions
+        assert np.allclose(xx_1, prob_input_2.transform_to(xx_2, prob_input_1))
+        for i, marginal in enumerate(prob_input_2.marginals):
+            assert np.min(xx_2[:, i]) >= marginal.lower
+            assert np.max(xx_2[:, i]) <= marginal.upper
+
+    def test_transform_from(self, dimension):
+        """Test the transformation of sample from another distribution."""
+        marginals_1 = create_random_marginals(dimension)
+        prob_input_1 = ProbInput(marginals_1)
+
+        marginals_2 = create_random_marginals(dimension)
+        prob_input_2 = ProbInput(marginals_2)
+
+        # Generate sample
+        sample_size = 5000
+        xx_2 = prob_input_2.get_sample(sample_size)
+
+        # Transform the sample points
+        xx_1 = prob_input_1.transform_from(xx_2, prob_input_2)
+        xx_2_ = prob_input_2.transform_from(xx_1, prob_input_1)
+
+        # Assertions
+        assert np.allclose(xx_2, xx_2_)
+        for i, marginal in enumerate(prob_input_1.marginals):
+            assert np.min(xx_1[:, i]) >= marginal.lower
+            assert np.max(xx_1[:, i]) <= marginal.upper
+
+    def test_failed_transform_sample(self, dimension):
+        """Test the failure of sample transformation."""
+        marginals_1 = create_random_marginals(dimension)
+        my_multivariate_input_1 = ProbInput(marginals_1)
+
+        marginals_2 = create_random_marginals(dimension + 1)
+        my_multivariate_input_2 = ProbInput(marginals_2)
+
+        sample_size = 5000
+        xx = my_multivariate_input_1.get_sample(sample_size)
+
+        # Transformation between two random variables of different dimensions
+        with pytest.raises(ValueError):
+            my_multivariate_input_1.transform_to(xx, my_multivariate_input_2)
+        with pytest.raises(ValueError):
+            my_multivariate_input_1.transform_from(xx, my_multivariate_input_2)
+
+    def test_transform_dependent_sample(self, dimension):
+        """Test dependent transformation (unsupported; raise an error)."""
+        marginals_1 = create_random_marginals(dimension)
+        prob_input_1 = ProbInput(marginals_1, copulas="a")
+
+        marginals_2 = create_random_marginals(dimension)
+        prob_input_2 = ProbInput(marginals_2, copulas="b")
+
+        xx = np.random.rand(2, dimension)
+
+        # Assertions
+        with pytest.raises(ValueError):
+            _ = prob_input_1.transform_to(xx, prob_input_2)
+
+        with pytest.raises(ValueError):
+            _ = prob_input_2.transform_to(xx, prob_input_1)
+
+    def test_transform_to_hypercube(self, dimension):
+        """Test the transformation of sample values to a hypercube."""
+        # Create a test instance
+        marginals = create_random_marginals(dimension)
+        prob_input = ProbInput(marginals)
+
+        # Generate sample
+        sample_size = 5000
+        xx = prob_input.get_sample(sample_size)
+
+        # Transform to hypercube
+        xx_trans = prob_input.transform_to(xx)
+
+        # Assertions
+        assert np.all(xx_trans >= -1.0)
+        assert np.all(xx_trans <= 1.0)
+
+    def test_transform_from_hypercube(self, dimension):
+        """Test the transformation of sample values from a hypercube."""
+        # Create a test instance
+        marginals = create_random_marginals(dimension)
+        prob_input = ProbInput(marginals)
+
+        # Generate sample
+        sample_size = 5000
+        rng = np.random.default_rng(42)
+        xx = rng.random((sample_size, dimension))
+
+        # Transform from hypercube
+        xx_trans = prob_input.transform_from(xx, (0.0, 1.0))
+
+        # Assertions
+        for i, marginal in enumerate(prob_input.marginals):
+            assert np.all(xx_trans[:, i] >= marginal.lower)
+            assert np.all(xx_trans[:, i] <= marginal.upper)
+
+    def test_round_trip(self, dimension):
+        """Test the round-trip transformation of sample values."""
+        marginals = create_random_marginals(dimension)
+        prob_input = ProbInput(marginals)
+
+        # Generate sample
+        sample_size = 5000
+        xx_1 = prob_input.get_sample(sample_size)
+
+        # Transform the sample points
+        xx_2 = prob_input.transform_to(xx_1)
+        xx_1_ = prob_input.transform_from(xx_2)
+
+        # Assertion
+        assert np.allclose(xx_1, xx_1_)
+
+    def test_transform_to_from(self, dimension):
+        """Test that transformation to and from are inverses."""
+        marginals_1 = create_random_marginals(dimension)
+        prob_input_1 = ProbInput(marginals_1)
+
+        marginals_2 = create_random_marginals(dimension)
+        prob_input_2 = ProbInput(marginals_2)
+
+        # Generate sample
+        sample_size = 5000
+        xx_1 = prob_input_1.get_sample(sample_size)
+
+        # Transform the sample points
+        xx_2_a = prob_input_1.transform_from(xx_1, prob_input_2)
+        xx_2_b = prob_input_2.transform_to(xx_1, prob_input_1)
+
+        # Assertion
+        assert np.allclose(xx_2_a, xx_2_b)
+
+
+class TestEquality:
+    """All tests related to the equality operator."""
+
+    def test_equal(self, dimension):
+        """Test equality operator for ProbInput instances."""
+        marginal_dicts = create_random_marginal_dicts(dimension)
+        marginals = [
+            Marginal(**marginal_dict) for marginal_dict in marginal_dicts
+        ]
+
+        # Create instances
+        prob_input_1 = ProbInput(marginals)
+        prob_input_2 = ProbInput.from_dicts(marginal_dicts)
+
+        # Assertions
+        assert prob_input_1 is not prob_input_2
+        assert prob_input_1 == prob_input_2
+
+    @pytest.mark.parametrize("other", [None, 42, "string", [1, 2, 3]])
+    def test_not_equal_other_types(self, dimension, other):
+        """Test inequality operator for instances with other types."""
+        marginals = create_random_marginals(dimension)
+
+        # Create an instance
+        prob_input = ProbInput(marginals)
+
+        # Assertion
+        assert prob_input != other
+
+    def test_not_equal_different_name(self, dimension):
+        """Test inequality operator for instances with different names."""
+        marginals = create_random_marginals(dimension)
+
+        # Create instances
+        prob_input_1 = ProbInput(marginals, name="a")
+        prob_input_2 = ProbInput(marginals, name="b")
+
+        # Assertion
+        assert prob_input_1 != prob_input_2
+
+    def test_not_equal_copulas(self, dimension):
+        """Test inequality operator for instances with different copulas."""
+        marginals = create_random_marginals(dimension)
+
+        # Create instances
+        prob_input_1 = ProbInput(marginals, copulas="a")
+        prob_input_2 = ProbInput(marginals, copulas="b")
+
+        # Assertion
+        assert prob_input_1 != prob_input_2
+
+    def test_not_equal_different_dimension(self, dimension):
+        """Test inequality operator for instances with different dimensions."""
+        # Create instances
+        marginals_1 = create_random_marginals(dimension)
+        prob_input_1 = ProbInput(marginals_1)
+        marginals_2 = create_random_marginals(dimension + 1)
+        prob_input_2 = ProbInput(marginals_2)
+
+        # Assertion
+        assert prob_input_1 != prob_input_2
+
+    def test_not_equal_different_marginals(self, dimension):
+        """Test inequality operator for instances with different marginals."""
+        # Create instances
+        marginals_1 = create_random_marginals(dimension)
+        prob_input_1 = ProbInput(marginals_1)
+        marginals_2 = create_random_marginals(dimension)
+        prob_input_2 = ProbInput(marginals_2)
+
+        # Assertion
+        assert prob_input_1 != prob_input_2
+
+
+class TestPrint:
+    """All tests related to the print(), repr(), and str() functions."""
+
+    def test_repr(self, dimension):
+        """Test __repr__ method of an instance of ProbInput."""
+        # Create a test instance
+        marginals = create_random_marginals(dimension)
+        prob_input = ProbInput(marginals)
+
+        # Create a repr string
+        my_str = repr(prob_input)
+
+        # Assertion
+        assert isinstance(my_str, str)
+
+    def test_str(self, dimension):
+        """Test __str__ method of an instance of ProbInput."""
+        # Create a test instance
+        marginals = create_random_marginals(dimension)
+        prob_input = ProbInput(marginals)
+
+        # Create a str string
+        my_str = str(prob_input)
+
+        # Assertion
+        assert isinstance(my_str, str)
+
+    def test_str_with_name(self, dimension):
+        """Test __str__ method of an instance of ProbInput."""
+        # Create a test instance
+        marginals = create_random_marginals(dimension)
+        prob_input = ProbInput(marginals, name="Test")
+
+        # Create a str string
+        my_str = str(prob_input)
+
+        # Assertion
+        assert isinstance(my_str, str)
+
+    def test_repr_contains_class_name(self, dimension):
+        """Test that __repr__ method includes class name."""
+        # Create a test instance
+        marginals = create_random_marginals(dimension)
+        prob_input = ProbInput(marginals)
+
+        # Assertion
+        assert "ProbInput(" in repr(prob_input)
+
+    def test_str_contains_dimension(self, dimension):
+        """Test that __str__ method includes dimension."""
+        # Create a test instance
+        marginals = create_random_marginals(dimension)
+        prob_input = ProbInput(marginals)
+
+        # Assertion
+        assert str(dimension) in str(prob_input)
+
+    def test_str_with_name_contains_name(self, dimension):
+        """Test that __str__ method includes name."""
+        # Create a test instance
+        marginals = create_random_marginals(dimension)
+        prob_input = ProbInput(marginals, name="Test")
+
+        # Assertion
+        assert "Test" in str(prob_input)
+
+    def test_str_without_name_omits_name_line(self, dimension):
+        """Test that __str__ method omits name line if no name is provided."""
+        # Create a test instance
+        marginals = create_random_marginals(dimension)
+        prob_input = ProbInput(marginals)
+
+        # Assertion
+        assert "Name      :" not in str(prob_input)
+
+    def test_str_no_marginal_description(self, dimension):
+        """Test __str__ method when the marginals have no description."""
+        # Create a test instance
+        prob_input = ProbInput.replicate(dimension, "uniform", [0.0, 1.0])
+
+        # Assertion
+        assert str(prob_input).count("   -") == dimension


### PR DESCRIPTION
Refactor `ProbInput` into a pure probabilistic input descriptor and align `Marginal`'s API ahead of the YAML-driven registry system.

## Changes

**`Marginal`**: Rename `transform_sample` → `transform_to` for clarity and consistency with the new `ProbInput` transform API.

**`ProbInput`**: Simplify the constructor by removing discovery metadata (`input_id`, `function_id`, `description`) and mutable RNG state (`rng_seed`, `reset_rng()`). Rename `input_id` → `name` and `input_dimension` → `dimension`.

Add the three construction paths needed by `_build_instance`:

- `from_dicts()` — from marginal spec dictionaries
- `from_factory()` — via dimension-dependent factory function
- `replicate()` — already existed, signature updated

Replace `transform_sample()` with a symmetric pair:

- `transform_to(target)` — self → target (ProbInput or hypercube)
- `transform_from(source)` — source → self

Add `cdf()`, improve `pdf()` with log-sum-exp, and add `__eq__`.

---

Closes: #459, #460
Ref: #452