### PR TITLE
feat(registry): add resolver for YAML named constants

### DIFF
--- a/src/uqtestfuns/core/registry/resolver.py
+++ b/src/uqtestfuns/core/registry/resolver.py
@@ -1,0 +1,130 @@
+"""
+Module for resolving YAML specification values with named constants.
+
+This module provides functionality to resolve values from YAML specifications,
+particularly handling named mathematical constants (e.g., 'pi', 'e') and
+converting them to their numeric equivalents.
+"""
+
+import math
+
+from typing import Union
+
+from .validation import SpecValidationError
+
+NAMED_CONSTANTS = {
+    "pi": math.pi,
+    "e": math.e,
+}
+
+
+def resolve_value(value: Union[str, float, int]) -> Union[str, float, int]:
+    """Resolve a string value, substituting named constants.
+
+    This function resolves values from YAML specifications by:
+    - Returning numeric values (float, int) unchanged
+    - Extracting and resolving expressions wrapped in '$()' syntax
+    - Substituting named mathematical constants with their numeric values
+    - Handling negative constants (e.g., '$(-pi)')
+
+    Parameters
+    ----------
+    value : Union[str, float, int]
+        The value to resolve.
+
+    Returns
+    -------
+    Union[str, float, int]
+        The resolved value. Expressions wrapped in '$()' are substituted
+        with their numeric equivalents. Numeric values are returned unchanged.
+        Non-expression strings are returned as-is.
+
+    Raises
+    ------
+    SpecValidationError
+        If the value is a string expression and cannot be evaluated.
+
+    Notes
+    -----
+    - Expression syntax requires both '$(' prefix and ')' suffixes.
+    - Currently, only named constants are supported for the expression.
+    - Supported named constants are defined in the NAMED_CONSTANTS dictionary
+    - Negative constants are handled by prefixing with '-'
+      inside the expression.
+    - Non-expression strings are returned unchanged (not validated).
+
+    Examples
+    --------
+    >>> resolve_value(3.14)
+    3.14
+    >>> resolve_value("value")
+    'value'
+    >>> resolve_value('$(pi)')
+    3.141592653589793
+    >>> resolve_value('$(-pi)')
+    -3.141592653589793
+    >>> resolve_value('$(e)')
+    2.718281828459045
+    """
+    if isinstance(value, str) and _is_expression(value):
+        # Evaluate the expression
+        value = _resolve_expression(value)
+
+    return value
+
+
+def _is_expression(value) -> bool:
+    """Check if a value is an expression wrapped in '$()' syntax.
+
+    Parameters
+    ----------
+    value : any
+        The value to check.
+
+    Returns
+    -------
+    bool
+        True if the value is a string starting with '$(' and ending with ')',
+        False otherwise.
+    """
+    if isinstance(value, str):
+        return value.startswith("$(") and value.endswith(")")
+
+    return False
+
+
+def _resolve_expression(value: str) -> Union[float, int]:
+    """Resolve an expression wrapped in '$()' syntax.
+
+    This function extracts and evaluates an expression from a string value
+    that is wrapped in the '$()' syntax. It supports named mathematical
+    constants and their negations.
+
+    Parameters
+    ----------
+    value : str
+        A string expression wrapped in '$()' syntax (e.g., '$(pi)', '$(-e)').
+
+    Returns
+    -------
+    Union[float, int]
+        The numeric value of the resolved expression. Returns the value
+        of the named constant, potentially negated if prefixed with '-'.
+
+    Raises
+    ------
+    SpecValidationError
+        If the expression does not match any supported named constant.
+
+    Notes
+    -----
+    - The function assumes the input is already validated to have '$()' syntax.
+    """
+    expression = value[2:-1].strip()
+    if expression.startswith("-") and expression[1:] in NAMED_CONSTANTS:
+        return -1 * NAMED_CONSTANTS[expression[1:]]
+
+    if expression in NAMED_CONSTANTS:
+        return NAMED_CONSTANTS[expression]
+
+    raise SpecValidationError(f"Unrecognized string value: {expression!r}")

--- a/src/uqtestfuns/core/registry/validation.py
+++ b/src/uqtestfuns/core/registry/validation.py
@@ -1,0 +1,16 @@
+class SpecValidationError(Exception):
+    """Exception raised when YAML specification validation fails.
+
+    This exception is raised when a YAML specification file contains
+    structural or semantic errors, such as:
+
+    - Invalid field types or values
+    - Conflicting configuration (e.g., input_dimension specified for
+      variable-dimension functions)
+    - Empty required blocks (e.g., inputs or parameter sets)
+
+    It is used throughout the spec_parser module to provide clear error
+    messages about specification validation failures.
+    """
+
+    pass

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,63 @@
+"""
+Test module for value resolution functionality in the registry resolver.
+"""
+
+import math
+import pytest
+
+from uqtestfuns.core.registry.validation import SpecValidationError
+from uqtestfuns.core.registry.resolver import resolve_value
+
+SUPPORTED_CONSTANTS = ["pi", "e"]
+
+
+class TestResolveValue:
+    """All tests related to resolving values."""
+
+    @pytest.mark.parametrize("value", [1.0, 2, "1", "abc"])
+    def test_numerical_values(self, value):
+        """Test resolving non-expression values; return as-is."""
+
+        # Resolve value
+        value_ = resolve_value(value)
+
+        # Assertions
+        assert value_ == value
+        assert value_ is value
+
+    @pytest.mark.parametrize("value", SUPPORTED_CONSTANTS)
+    def test_supported_constants(self, value):
+        """Test resolving supported constants."""
+
+        # Create an expression
+        expr = f"$( {value} )"
+
+        # Resolve value
+        value_ = resolve_value(expr)
+
+        # Assertion
+        assert value_ == getattr(math, value)
+
+    @pytest.mark.parametrize("value", SUPPORTED_CONSTANTS)
+    def test_negation(self, value):
+        """Test resolving the negation of supported constants."""
+
+        # Create an expression
+        expr = f"$( -{value} )"
+
+        # Resolve value
+        value_ = resolve_value(expr)
+
+        # Assertion
+        assert value_ == -getattr(math, value)
+
+    @pytest.mark.parametrize("value", ["a", "b", "c"])
+    def test_unsupported_constants(self, value):
+        """Test resolving unsupported constants."""
+
+        # Create an expression
+        expr = f"$( {value} )"
+
+        # Assertion
+        with pytest.raises(SpecValidationError):
+            _ = resolve_value(expr)


### PR DESCRIPTION
Introduce a module to resolve special values in YAML specifications. Values wrapped in $() are treated as expressions; currently supports named mathematical constants (pi, e) and their negated forms. Non-expression values pass through unchanged.

Refs: #452, #462
Closes: #468