### PR TITLE
feat(registry): add `validate_marginal`

### DIFF
--- a/src/uqtestfuns/core/registry/validation.py
+++ b/src/uqtestfuns/core/registry/validation.py
@@ -14,3 +14,25 @@ class SpecValidationError(Exception):
     """
 
     pass
+
+
+def validate_marginal(marginal: dict) -> None:
+    """Validate a marginal specification."""
+    errors = []
+
+    # --- Mandatory keys
+    required_keys = {"distribution", "parameters"}
+    missing_keys = required_keys - marginal.keys()
+    if missing_keys:
+        errors.append(f"Missing mandatory keys: {missing_keys}")
+
+    # --- Extraneous keys
+    supported_keys = {"distribution", "parameters", "name", "description"}
+    extra_keys = marginal.keys() - supported_keys
+    if extra_keys:
+        errors.append(f"Unexpected keys: {extra_keys}")
+
+    if errors:
+        raise SpecValidationError(
+            f"Invalid marginal {marginal}: " + "; ".join(errors)
+        )

--- a/tests/test_registry_resolver.py
+++ b/tests/test_registry_resolver.py
@@ -61,3 +61,13 @@ class TestResolveValue:
         # Assertion
         with pytest.raises(SpecValidationError):
             _ = resolve_value(expr)
+
+    def test_empty_expression(self):
+        """Test resolving an empty expression."""
+
+        # Create an expression
+        expr = "$()"
+
+        # Assertion
+        with pytest.raises(SpecValidationError):
+            _ = resolve_value(expr)

--- a/tests/test_registry_validation.py
+++ b/tests/test_registry_validation.py
@@ -1,0 +1,68 @@
+"""
+Test module for registry validation functionality.
+"""
+
+import pytest
+
+from uqtestfuns.core.registry.validation import (
+    SpecValidationError,
+    validate_marginal,
+)
+
+
+class TestMarginalValidation:
+    """All tests related to registry validation."""
+
+    def test_minimal_specification(self):
+        """Test that mandatory keys are present in the registry."""
+        marginal = {
+            "distribution": "normal",
+            "parameters": [0.0, 1.0],
+        }
+
+        # Raise no exception
+        validate_marginal(marginal)
+
+    def test_full_specification(self):
+        """Test that all keys are present in the registry."""
+        marginal = {
+            "name": "X",
+            "distribution": "normal",
+            "parameters": [0.0, 1.0],
+            "description": "A normal distribution",
+        }
+
+        # Raise no exception
+        validate_marginal(marginal)
+
+    @pytest.mark.parametrize("missing_key", ["distribution", "parameters"])
+    def test_missing_key(self, missing_key):
+        """Test that mandatory keys are missing."""
+        marginal = {
+            "name": "X",
+            "distribution": "normal",
+            "parameters": [0.0, 1.0],
+            "description": "A normal distribution",
+        }
+        _ = marginal.pop(missing_key)
+
+        with pytest.raises(SpecValidationError, match=missing_key):
+            validate_marginal(marginal)
+
+    def test_extra_key(self):
+        """Test that an extra key is present."""
+        marginal = {
+            "name": "X",
+            "distribution": "normal",
+            "parameters": [0.0, 1.0],
+            "description": "A normal distribution",
+            "repeat": 4,
+        }
+
+        with pytest.raises(SpecValidationError, match="repeat"):
+            validate_marginal(marginal)
+
+    def test_empty_margina(self):
+        """Test that an empty dictionary is not valid."""
+        with pytest.raises(SpecValidationError):
+            validate_marginal({})


### PR DESCRIPTION
Marginal specifications are loaded from YAML configs and must conform to a fixed schema: `distribution` and `parameters` are required; `name` and `description` are optional. Enforce this at load time so malformed configs fail fast with a clear error, rather than surfacing as a cryptic KeyError deep in the sampling code.

Refs: #452, #462
Closes: #469