### PR TITLE
feat(parser): add parse_callable and parse_evaluate helpers

### DIFF
--- a/src/uqtestfuns/core/registry/parser.py
+++ b/src/uqtestfuns/core/registry/parser.py
@@ -1,0 +1,209 @@
+"""YAML specification parser for test function metadata.
+
+This module provides functionality to parse YAML specification files
+that define metadata for uncertainty quantification (UQ) test functions.
+It validates the structure and content of these specifications
+and converts them into structured UQTestFunInfo objects.
+"""
+
+import yaml
+
+from pathlib import Path
+from typing import Optional, Tuple
+
+from .specs import CallableSpec
+from .validation import SpecValidationError, validate_callable_string
+
+
+# --- Helper functions
+def safe_load(yaml_file: Path) -> dict:
+    """Load and parse a YAML file using safe loading.
+
+    This helper function reads a YAML specification file and parses it
+    into a Python dictionary using PyYAML's safe_load method, which
+    prevents arbitrary code execution and only constructs simple Python
+    objects (strings, lists, dicts, numbers, dates, etc.).
+
+    Parameters
+    ----------
+    yaml_file : Path
+        Path to the YAML file to be loaded.
+
+    Returns
+    -------
+    dict
+        Parsed YAML content as a Python dictionary containing the
+        specification data.
+
+    Notes
+    -----
+    - This function uses `yaml.safe_load()` rather than `yaml.load()` to
+      ensure security by preventing the execution of arbitrary Python code
+      that might be embedded in malicious YAML files.
+    """
+    with open(yaml_file, "r") as f:
+        data = yaml.safe_load(f)
+
+    return data
+
+
+def parse_evaluate(
+    evaluate: Optional[str],
+    yaml_file: Path,
+    pkg_root: Path,
+) -> CallableSpec:
+    """Parse the evaluate section of a YAML specification.
+
+    This function parses the 'evaluate' field from a YAML specification file
+    and constructs a CallableSpec object that identifies the evaluation
+    function for a UQ test function. It resolves the module path and function
+    name based on the specification format, supporting both explicit and
+    implicit naming conventions.
+
+    Parameters
+    ----------
+    evaluate : Optional[str]
+        The evaluate specification string from the YAML file. Can be:
+
+        - None: Assumes a module file with the same name as the YAML file
+          and a function named "evaluate"
+        - A function name only (e.g., "my_evaluate"): Uses the specified
+          function name from a module with the same name as the YAML file
+        - A fully qualified path (e.g., "my_module.my_evaluate"): Uses the
+          specified module file and function name
+    yaml_file : Path
+        Path to the YAML specification file being parsed. Used to resolve
+        relative module paths when evaluate is None or partially specified.
+    pkg_root : Path
+        Root path of the package, used to construct the absolute module path
+        relative to the package structure.
+
+    Returns
+    -------
+    CallableSpec
+        A specification object containing:
+
+        - module_path: Fully qualified Python module path (dot-separated)
+        - function_name: Name of the evaluation function within the module
+        - kwargs: None
+
+    Raises
+    ------
+    SpecValidationError
+        If the specified module file does not exist or if the evaluate
+        specification string is malformed (contains more than one dot).
+
+    Notes
+    -----
+    - The ``module_path`` is constructed relative to the parent of ``pkg_root``
+      to ensure proper Python import paths within the package structure.
+    """
+    if evaluate is None:
+        callable_ = "evaluate"
+    else:
+        callable_ = evaluate
+
+    module_path, evaluate_name = parse_callable(callable_, yaml_file, pkg_root)
+
+    return CallableSpec(
+        module_path=module_path,
+        function_name=evaluate_name,
+        kwargs=None,
+    )
+
+
+def parse_callable(
+    callable_: str,
+    yaml_file: Path,
+    pkg_root: Path,
+) -> Tuple[str, str]:
+    """Parse a callable spec string into the module path and the function name.
+
+    This helper function parses a callable specification string (typically from
+    a YAML file) and resolves it into a fully qualified Python module path and
+    a function name. It supports both explicit ``module.function`` notation and
+    implicit module resolution based on the YAML file name.
+
+    Parameters
+    ----------
+    callable_ : str
+        The callable specification string. The possible values are:
+
+        - A function name only (e.g., ``my_function``): Uses the specified
+          function name from a module with the same name as the YAML file
+        - A fully qualified path (e.g., ``my_module.my_function``): Uses the
+          specified module file and function name
+    yaml_file : Path
+        Path to the YAML specification file. Used to resolve relative module
+        paths when the value contains only a function name.
+    pkg_root : Path
+        Root path of the package, used to construct the absolute module path
+        relative to the package structure.
+
+    Returns
+    -------
+    Tuple[str, str]
+        A tuple of strings containing:
+
+        - ``module_path``: Fully qualified Python module path (dot-separated)
+        - ``callable_name``: Name of the callable within the module
+
+    Raises
+    ------
+    SpecValidationError
+        If the callable specification string is malformed (contains more than
+        one dot) or if the specified module file does not exist. Because import
+        is not carried out, the existence of the callable inside the module
+        cannot be verified.
+
+    Notes
+    -----
+    The function supports two specification formats:
+
+    1. **Function name only**: When a value contains no dots:
+
+       - Module: Same basename as the YAML file with .py extension
+       - Function: The specified name
+       - Example: ``value="my_func"`` with ``sobol_g.yaml`` means
+         module ``sobol_g.py``, function ``my_func``
+
+    2. **Fully qualified**: When a value contains exactly one dot:
+
+       - Module: Specified stem with .py extension in the same directory
+       - Function: Part after the dot
+       - Example: ``value="custom_module.my_func`` means
+         module ``custom_module.py``, function ``my_func``
+
+    The ``module_path`` is constructed relative to the parent of ``pkg_root``
+    to ensure proper Python import paths within the package structure.
+    """
+
+    # --- Validate the string is a valid callable specification
+    validate_callable_string(callable_)
+
+    # --- Split the callable string into module and function parts
+    # Validation ensures either 'name' or 'module.name' is present
+    parts = callable_.split(".")
+
+    if len(parts) == 2:
+        # Fully qualified module path
+        module_stem, callable_name = parts
+        module_file = yaml_file.parent / (module_stem + ".py")
+    else:
+        # The callable name
+        callable_name = parts[0]
+        # Assume that the Python module is named the same as the YAML file
+        module_file = yaml_file.with_suffix(".py")
+
+    # --- Check that the module file exists
+    if not module_file.exists():
+        raise SpecValidationError(f"Module file {module_file} does not exist!")
+
+    # --- Construct the module path relative to the package root
+    module_path = ".".join(
+        module_file.relative_to(pkg_root.parent.resolve())
+        .with_suffix("")
+        .parts
+    )
+
+    return module_path, callable_name

--- a/src/uqtestfuns/core/registry/specs.py
+++ b/src/uqtestfuns/core/registry/specs.py
@@ -1,0 +1,173 @@
+"""Specifications for callable objects in the registry.
+
+This module contains dataclass specifications used for registering and
+managing callable objects in the UQTestFuns registry system.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Union
+
+
+@dataclass(frozen=True)
+class CallableSpec:
+    """Specification for a callable object with its module path and parameters.
+
+    This immutable dataclass represents a callable object by storing its
+    module path, function name, and optional keyword arguments. It is used
+    in the registry system to define and instantiate callable objects
+    dynamically.
+
+    Parameters
+    ----------
+    module_path : str
+        The full module path where the callable is located (e.g.,
+        'uqtestfuns.test_functions.ackley').
+    function_name : str
+        The name of the callable/function to be retrieved from the module.
+    kwargs : Dict[str, Any], optional
+        Optional keyword arguments to be passed to the callable when
+        instantiated. Default is None.
+    """
+
+    module_path: str
+    function_name: str
+    kwargs: Optional[Dict[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class MarginalSpec:
+    """Specification for a marginal distribution.
+
+    This immutable dataclass represents a marginal distribution by storing
+    its distribution type, parameters, and optional metadata. It is used in
+    the registry system to define probabilistic input specifications for
+    UQ test functions.
+
+    Parameters
+    ----------
+    distribution : str
+        The name/type of the probability distribution (e.g., 'normal',
+        'uniform', 'beta').
+    parameters : List[Union[float, int]]
+        List of distribution parameters. The number and meaning of parameters
+        depend on the distribution type (e.g., [mean, std] for normal,
+        [lower, upper] for uniform).
+    name : str, optional
+        An optional name for the marginal distribution. Default is None.
+    description : str, optional
+        An optional description of the marginal distribution. Default is None.
+    """
+
+    distribution: str
+    parameters: List[Union[float, int]]
+    name: Optional[str] = None
+    description: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class MarginalList:
+    """Specification for a list of marginal distributions.
+
+    This immutable dataclass represents a collection of marginal distributions
+    that together define the probabilistic input space for a UQ test function.
+    It is used in the registry system to specify a (multidimensional)
+    probabilistic input model where each dimension has its own marginal
+    distribution.
+
+    Parameters
+    ----------
+    sequence : Sequence[MarginalSpec]
+        An ordered list of marginal distribution specifications. Each element
+        represents the marginal distribution for one input dimension. The
+        length of the sequence determines the dimensionality of the input
+        space.
+    """
+
+    sequence: List[MarginalSpec]
+
+
+@dataclass(frozen=True)
+class MarginalTemplate:
+    """Specification for a marginal distribution template.
+
+    This immutable dataclass represents a template for creating multiple
+    marginal distributions with the same distribution type and parameters
+    but with parameterized names and descriptions. It is used in the registry
+    system to define reusable marginal distribution patterns that can be
+    instantiated with different naming conventions.
+
+    Parameters
+    ----------
+    distribution : str
+        The name/type of the probability distribution (e.g., 'normal',
+        'uniform', 'beta').
+    parameters : List[Union[float, int]]
+        List of distribution parameters. The number and meaning of parameters
+        depend on the distribution type (e.g., [mean, std] for normal,
+        [lower, upper] for uniform).
+    name_template : str, optional
+        An optional template string for the marginal distribution name that
+        can contain placeholders for parameterization. Default is None.
+    description_template : str, optional
+        An optional template string for the marginal distribution description
+        that can contain placeholders for parameterization. Default is None.
+    """
+
+    distribution: str
+    parameters: List[Union[float, int]]
+    name_template: Optional[str] = None
+    description_template: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class UQInputSpec:
+    """Specification for UQ test function input.
+
+    This immutable dataclass represents the complete probabilistic input
+    specification for a UQ test function. It combines marginal distributions
+    (which define the behavior of individual input dimensions) with optional
+    copulas (which define dependencies between input dimensions). It is used
+    in the registry system to specify the full probabilistic input model
+    for uncertainty quantification test functions.
+
+    Parameters
+    ----------
+    marginals : Union[MarginalSpec, MarginalList, MarginalTemplate]
+        The marginal distribution specification(s) for the input dimensions.
+        Can be a single MarginalSpec (for one-dimensional inputs), a
+        MarginalList (for multi-dimensional inputs with different marginals
+        for each dimension), or a MarginalTemplate (for creating multiple
+        similar marginals from a template).
+    copulas : Any, optional
+        Optional copula specification that defines the dependence structure
+        between input dimensions. If None, independence between dimensions
+        is assumed. Default is None. This feature is not yet supported.
+    """
+
+    marginals: Union[MarginalList, MarginalTemplate, CallableSpec]
+    copulas: Optional[Any] = None
+
+
+@dataclass(frozen=True)
+class UQParametersSpec:
+    """Specification for UQ test function parameters.
+
+    This immutable dataclass represents the parameters of a UQ test function,
+    including their values and optional descriptions. It is used in the
+    registry system to specify configurable parameters that affect the
+    behavior of uncertainty quantification test functions.
+
+    Parameters
+    ----------
+    descriptions : Dict[str, str], optional
+        Optional dictionary mapping parameter names to their human-readable
+        descriptions. This provides documentation for what each parameter
+        represents and how it affects the test function. Default is None.
+    values : Dict[str, Any]
+        Dictionary mapping parameter names to their values. The keys are
+        parameter names (strings) and the values can be of any type
+        appropriate for the parameter (e.g., float, int, str, list).
+    """
+
+    descriptions: Optional[Dict[str, str]]
+    values: Dict[str, Any]

--- a/src/uqtestfuns/core/registry/validation.py
+++ b/src/uqtestfuns/core/registry/validation.py
@@ -1,3 +1,6 @@
+import re
+
+
 class SpecValidationError(Exception):
     """Exception raised when YAML specification validation fails.
 
@@ -17,7 +20,22 @@ class SpecValidationError(Exception):
 
 
 def validate_marginal(marginal: dict) -> None:
-    """Validate a marginal specification."""
+    """Validate a marginal specification.
+
+    Checks that the marginal dictionary contains required keys
+    (``'distribution'`` and ``'parameters'``) and only supported optional keys
+    (``'name'`` and ``'description'``).
+
+    Parameters
+    ----------
+    marginal : dict
+        The marginal specification dictionary to validate.
+
+    Raises
+    ------
+    SpecValidationError
+        If required keys are missing or unsupported keys are present.
+    """
     errors = []
 
     # --- Mandatory keys
@@ -35,4 +53,37 @@ def validate_marginal(marginal: dict) -> None:
     if errors:
         raise SpecValidationError(
             f"Invalid marginal {marginal}: " + "; ".join(errors)
+        )
+
+
+def validate_callable_string(callable_: str) -> None:
+    """Validate a callable string specification.
+
+    This function validates that a callable string follows the expected format
+    for referencing Python callables in YAML specifications.
+    Valid formats are:
+
+    - ``name``: a simple callable name (e.g., function or class)
+    - ``module.name``: a module-qualified callable name
+
+    Parameters
+    ----------
+    callable_ : str
+        The callable string to validate. Must be in the format ``name`` or
+        ``module.name``, where ``name`` and ``module`` contain only
+        alphanumeric characters and underscores.
+
+    Raises
+    ------
+    SpecValidationError
+        If the callable string does not match the expected format, or if it
+        contains more than one dot (nested modules are not supported).
+    """
+    pattern = re.compile(r"^([A-Za-z0-9_]+\.)?[A-Za-z0-9_]+$")
+
+    if not pattern.fullmatch(callable_):
+        raise SpecValidationError(
+            f"Invalid callable specification {callable_!r}: "
+            "expected 'name' or 'module.name', got "
+            f"{len(callable_.split('.')) - 1} dots"
         )

--- a/tests/fixtures/invalid_yaml/invalid_eval.yaml
+++ b/tests/fixtures/invalid_yaml/invalid_eval.yaml
@@ -1,0 +1,16 @@
+name: CommonEvalVarInputNoParams
+description: "Variable-dimension function, multiple inputs, no parameter"
+tags: [metamodeling]
+
+dimensions:
+  input: variable
+  output: 1
+
+evaluate: test.common.compute
+
+inputs:
+  DefaultInput:
+    description: "Default input"
+    marginals:
+      distribution: uniform
+      parameters: [0.0, 1.0]

--- a/tests/fixtures/invalid_yaml/invalid_eval_no_file.yaml
+++ b/tests/fixtures/invalid_yaml/invalid_eval_no_file.yaml
@@ -1,0 +1,14 @@
+name: CommonEvalVarInputNoParams
+description: "Variable-dimension function, multiple inputs, no parameter"
+tags: [metamodeling]
+
+dimensions:
+  input: variable
+  output: 1
+
+inputs:
+  DefaultInput:
+    description: "Default input"
+    marginals:
+      distribution: uniform
+      parameters: [0.0, 1.0]

--- a/tests/fixtures/valid_yaml/dette.py
+++ b/tests/fixtures/valid_yaml/dette.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+
+def evaluate_curved(xx: np.ndarray) -> np.ndarray:
+    """Evaluate the highly-curved function from Dette and Pepelyshev (2010).
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        M-Dimensional input values given by an N-by-3 array where
+        N is the number of input values.
+
+    Returns
+    -------
+    np.ndarray
+        The output of the test function evaluated on the input values.
+        The output is a 1-dimensional array of length N.
+    """
+    term_1 = 4 * (xx[:, 0] - 2 + 8 * xx[:, 1] - 8 * xx[:, 1] ** 2)
+    term_2 = (3 - 4 * xx[:, 1]) ** 2
+    term_3 = (16 * (xx[:, 2] + 1) ** 0.5) * (2 * xx[:, 2] - 1) ** 2
+
+    return term_1 + term_2 + term_3
+
+
+def evaluate_8d(xx: np.ndarray) -> np.ndarray:
+    """Evaluate the 8D function from Dette and Pepelyshev (2010).
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        M-Dimensional input values given by an N-by-8 array where
+        N is the number of input values.
+
+    Returns
+    -------
+    np.ndarray
+        The output of the test function evaluated on the input values.
+        The output is a 1-dimensional array of length N.
+    """
+    term_1 = evaluate_curved(xx)
+    term_2 = np.zeros(len(xx))
+    for j in range(3, xx.shape[1]):
+        term_2 += (j + 1) * np.log(1 + np.sum(xx[:, 2:j], axis=1))
+
+    return term_1 + term_2

--- a/tests/fixtures/valid_yaml/dette8d.yaml
+++ b/tests/fixtures/valid_yaml/dette8d.yaml
@@ -1,0 +1,20 @@
+name: Dette8D
+description: 8D function from Dette and Pepelyshev (2010)
+tags:
+  - metamodeling
+
+dimensions:
+  input: 8
+  output: 1
+
+evaluate: dette.evaluate_8d
+
+inputs:
+  Dette2010:
+    description: >-
+      Input specification for the 8D test function from
+      Dette and Pepelyshev (2010)
+    marginals:
+      distribution: uniform
+      parameters: [0.0, 1.0]
+      name: X$idx

--- a/tests/fixtures/valid_yaml/otlcircuit.py
+++ b/tests/fixtures/valid_yaml/otlcircuit.py
@@ -1,0 +1,67 @@
+"""
+Module with an implementation of the OTL circuit test function.
+
+The OTL circuit test function is a six-dimensional scalar-valued function
+that computes the mid-point voltage
+of an output transformerless (OTL) push-pull circuit.
+The function has been used as a test function in metamodeling exercises [1].
+A 20-dimensional variant was used for sensitivity analysis in [2]
+by introducing 14 additional inert input variables.
+
+References
+----------
+
+1. E. N. Ben-Ari and D. M. Steinberg, "Modeling data from computer
+   experiments: An empirical comparison of Kriging with MARS
+   and projection pursuit regression," Quality Engineering,
+   vol. 19, pp. 327-338, 2007.
+   DOI: 10.1080/08982110701580930
+2. H. Moon, "Design and Analysis of Computer Experiments for Screening Input
+   Variables," Ph.D. dissertation, Ohio State University, Ohio, 2010.
+   URL: http://rave.ohiolink.edu/etdc/view?acc_num=osu1275422248
+"""
+
+import numpy as np
+
+
+def evaluate(xx: np.ndarray) -> np.ndarray:
+    """Evaluate the OTL circuit test function on a set of input values.
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        (At least) 6-dimensional input values given by N-by-6 arrays
+        where N is the number of input values.
+
+    Returns
+    -------
+    np.ndarray
+        The output of the OTL circuit test function,
+        i.e., the mid-point voltage in Volt.
+        The output is a one-dimensional array of length N.
+
+    Notes
+    -----
+    - The variant of this test function has 14 additional inputs,
+      but they are all taken to be inert and therefore should not affect
+      the output.
+    """
+    rr_b1 = xx[:, 0]  # Resistance b1
+    rr_b2 = xx[:, 1]  # Resistance b2
+    rr_f = xx[:, 2]  # Resistance f
+    rr_c1 = xx[:, 3]  # Resistance c1
+    rr_c2 = xx[:, 4]  # Resistance c2
+    beta = xx[:, 5]  # Current gain
+
+    # Compute the voltage across b1
+    vb1 = 12 * rr_b2 / (rr_b1 + rr_b2)
+
+    # Compute the mid-point voltage
+    denom = beta * (rr_c2 + 9) + rr_f
+    term_1 = ((vb1 + 0.74) * beta * (rr_c2 + 9)) / denom
+    term_2 = 11.35 * rr_f / denom
+    term_3 = 0.74 * rr_f * beta * (rr_c2 + 9) / (rr_c1 * denom)
+
+    vm = term_1 + term_2 + term_3
+
+    return vm

--- a/tests/fixtures/valid_yaml/otlcircuit.yaml
+++ b/tests/fixtures/valid_yaml/otlcircuit.yaml
@@ -1,0 +1,41 @@
+name: OTLCircuit
+description: >-
+  Output transformerless (OTL) circuit model from Ben-Ari and Steinberg (2007)
+tags:
+  - metamodeling
+  - sensitivity
+
+dimensions:
+  input: 6
+  output: 1
+
+inputs:
+  BenAri2007:
+    description: >-
+      Probabilistic input model for the OTL Circuit function
+      from Ben-Ari and Steinberg (2007)
+    marginals:
+      - name: Rb1
+        distribution: uniform
+        parameters: [50.0, 150.0]
+        description: Resistance b1 [kOhm]
+      - name: Rb2
+        distribution: uniform
+        parameters: [25.0, 70.0]
+        description: Resistance b2 [kOhm]
+      - name: Rf
+        distribution: uniform
+        parameters: [0.5, 3.0]
+        description: Resistance f [kOhm]
+      - name: Rc1
+        distribution: uniform
+        parameters: [1.2, 2.5]
+        description: Resistance c1 [kOhm]
+      - name: Rc2
+        distribution: uniform
+        parameters: [0.25, 1.20]
+        description: Resistance c2 [kOhm]
+      - name: beta
+        distribution: uniform
+        parameters: [50.0, 300.0]
+        description: Current gain [A]

--- a/tests/fixtures/valid_yaml/saltelli_linear.py
+++ b/tests/fixtures/valid_yaml/saltelli_linear.py
@@ -1,0 +1,111 @@
+"""
+Module with an implementation of the linear fun. from Saltelli et al. (2008).
+
+The linear function from Saltelli et al. (2008) is an M-dimensional
+scalar-valued function.
+It was introduced in [1] to illustrate sensitivity analysis methods and used
+in [2] for benchmarking purposes.
+
+Due to its simple structure, its moments and Sobol' sensitivity indices can
+be computed analytically.
+
+References
+----------
+1. A. Saltelli, K. Chan, and E. Scott, 2008. Sensitivity Analysis: Wiley Series
+   in Probability and Statistics. Wiley, New York.
+2. X. Sun, B. Croke, A. Jakeman, S. Roberts, "Benchmarking Active Subspace
+   methods of global sensitivity analysis against variance-based Sobol’
+   and Morris methods with established test functions," Environmental Modelling
+   & Software, vol. 149, p. 105310, 2022.
+   DOI: 10.1016/j.envsoft.2022.105310
+"""
+
+import numpy as np
+
+
+def create_marginals_1(input_dimension: int):
+    r"""Create a list of marginal specifications of the given dimension.
+
+    .. math::
+
+      X_i \sim \mathcal{U}[x_{o, i} - \sigma_{o, i}, x_{o, i} + \sigma_{o, i}]
+
+    where :math:`x_{o, i} = 3^{i - 1}` and :math:`\sigma_{o, i} = 0.5 x_{o, i}`
+    for :math:`i = 1, 2, \ldots`.
+
+    Parameters
+    ----------
+    input_dimension : int
+        The number of marginal specifications in the list.
+
+    Returns
+    -------
+    MarginalSpecs
+        The list of marginal specifications.
+    """
+    marginals = []
+    for i in range(input_dimension):
+        mid = 3**i
+        delta = 0.5 * mid
+        marginal = {
+            "name": f"X{i + 1}",
+            "distribution": "uniform",
+            "parameters": [mid - delta, mid + delta],
+            "description": None,
+        }
+        marginals.append(marginal)
+
+
+def create_marginals_2(input_dimension: int, factor: float):
+    r"""Create a list of marginal specifications of the given dimension.
+
+    .. math::
+
+      X_i \sim \mathcal{U}[x_{o, i} - \sigma_{o, i}, x_{o, i} + \sigma_{o, i}]
+
+    where :math:`x_{o, i} = 3^{i - 1}` and :math:`\sigma_{o, i} = 0.5 x_{o, i}`
+    for :math:`i = 1, 2, \ldots`.
+
+    Parameters
+    ----------
+    input_dimension : int
+        The number of marginal specifications in the list.
+
+    Returns
+    -------
+    MarginalSpecs
+        The list of marginal specifications.
+    """
+    marginals = []
+    for i in range(input_dimension):
+        mid = 3**i
+        delta = factor * mid
+        marginal = {
+            "name": f"X{i + 1}",
+            "distribution": "uniform",
+            "parameters": [mid - delta, mid + delta],
+            "description": None,
+        }
+        marginals.append(marginal)
+
+    return marginals
+
+
+def compute(xx: np.ndarray):
+    """Evaluate the linear function on a set of input values.
+
+    Parameters
+    ----------
+    xx : np.ndarray
+        M-Dimensional input values given by an N-by-M array where
+        N is the number of input values.
+
+    Returns
+    -------
+    np.ndarray
+        The output of the test function evaluated on the input values.
+        The output is a 1-dimensional array of length N.
+    """
+    yy = np.sum(xx, axis=1)
+
+    return yy

--- a/tests/fixtures/valid_yaml/saltelli_linear.yaml
+++ b/tests/fixtures/valid_yaml/saltelli_linear.yaml
@@ -1,0 +1,27 @@
+name: SaltelliLinear
+description: Linear function from Saltelli et al. (2000)
+tags:
+  - sensitivity
+
+dimensions:
+  input: variable
+  output: 1
+
+default_input: Saltelli2000_1
+
+evaluate: compute
+
+inputs:
+  Saltelli2000_1:
+    description: >-
+      Probabilistic input model for the linear function
+      from Saltelli et al. (2000)
+    marginals:
+      factory: create_marginals_1
+  Saltelli2000_2:
+    description: >-
+      Probabilistic input model for the linear function with factor
+      from Saltelli et al. (2000)
+    marginals:
+      factory: create_marginals_2
+      factor: 0.5

--- a/tests/test_registry_parser.py
+++ b/tests/test_registry_parser.py
@@ -1,0 +1,77 @@
+import pytest
+import yaml
+
+from pathlib import Path
+
+from uqtestfuns.core.registry.parser import parse_evaluate
+from uqtestfuns.core.registry.specs import CallableSpec
+from uqtestfuns.core.registry.validation import SpecValidationError
+
+FIXTURES_ROOT = Path(__file__).parent / "fixtures" / "valid_yaml"
+
+
+class TestParseEvaluate:
+    """All tests related to parsing the evaluate section of YAML files."""
+
+    def test_empty_evaluate(self):
+        """Test parsing an empty evaluate section."""
+        yaml_file = FIXTURES_ROOT / "otlcircuit.yaml"
+        with open(yaml_file, "r") as f:
+            data = yaml.safe_load(f)
+
+        # Parse the evaluate section
+        evaluate_ = data.get("evaluate", None)
+        evaluate = parse_evaluate(evaluate_, yaml_file, FIXTURES_ROOT)
+
+        # Assertions
+        assert evaluate_ is None
+        assert isinstance(evaluate, CallableSpec)
+        assert evaluate.function_name == "evaluate"
+        assert evaluate.module_path == "valid_yaml.otlcircuit"
+        assert evaluate.kwargs is None
+
+    def test_callable_name(self):
+        """Test parsing a callable name."""
+        yaml_file = FIXTURES_ROOT / "saltelli_linear.yaml"
+        with open(yaml_file, "r") as f:
+            data = yaml.safe_load(f)
+
+        # Parse the evaluate section
+        evaluate_ = data.get("evaluate", None)
+        evaluate = parse_evaluate(evaluate_, yaml_file, FIXTURES_ROOT)
+
+        # Assertions
+        assert isinstance(evaluate, CallableSpec)
+        assert evaluate.function_name == "compute"
+        assert evaluate.module_path == "valid_yaml.saltelli_linear"
+        assert evaluate.kwargs is None
+
+    def test_fully_qualified(self):
+        """Test parsing a fully qualified function name."""
+        yaml_file = FIXTURES_ROOT / "dette8d.yaml"
+        with open(yaml_file, "r") as f:
+            data = yaml.safe_load(f)
+
+        # Parse the evaluate section
+        evaluate_ = data.get("evaluate", None)
+        evaluate = parse_evaluate(evaluate_, yaml_file, FIXTURES_ROOT)
+
+        # Assertions
+        assert isinstance(evaluate, CallableSpec)
+        assert evaluate.function_name == "evaluate_8d"
+        assert evaluate.module_path == "valid_yaml.dette"
+        assert evaluate.kwargs is None
+
+    def test_no_module_file(self):
+        """Test parsing a YAML without the corresponding module file."""
+        root = Path(__file__).parent / "fixtures" / "invalid_yaml"
+        yaml_file = root / "invalid_eval_no_file.yaml"
+        with open(yaml_file, "r") as f:
+            data = yaml.safe_load(f)
+
+        # Parse the evaluate section
+        evaluate_ = data.get("evaluate", None)
+
+        # Assertion
+        with pytest.raises(SpecValidationError):
+            _ = parse_evaluate(evaluate_, yaml_file, FIXTURES_ROOT)

--- a/tests/test_registry_validation.py
+++ b/tests/test_registry_validation.py
@@ -7,6 +7,7 @@ import pytest
 from uqtestfuns.core.registry.validation import (
     SpecValidationError,
     validate_marginal,
+    validate_callable_string,
 )
 
 
@@ -66,3 +67,18 @@ class TestMarginalValidation:
         """Test that an empty dictionary is not valid."""
         with pytest.raises(SpecValidationError):
             validate_marginal({})
+
+
+class TestCallableStringValidation:
+    """All tests related to callable string validation."""
+
+    @pytest.mark.parametrize("valid_str", ["foo", "_foo.bar", "_hello"])
+    def test_valid_string(self, valid_str):
+        """Test that a valid callable string is valid."""
+        validate_callable_string(valid_str)
+
+    @pytest.mark.parametrize("invalid_str", ["", "foo.bar.ba", "foo.", ".bar"])
+    def test_invalid_string(self, invalid_str):
+        """Test that an invalid callable string is invalid."""
+        with pytest.raises(SpecValidationError):
+            validate_callable_string(invalid_str)


### PR DESCRIPTION
Add two pure helper functions to the YAML parser for resolving callable specifications from YAML into (module_path, callable_name) tuples without performing imports:

- `parse_callable`: parses a 'name' or 'module.name' string and resolves the module file relative to the YAML file's directory.
- `parse_evaluate`: thin wrapper built around `parse_callable` that applies the default 'evaluate' convention when the YAML omits an explicit evaluate directive.

Both functions raise `SpecValidationError` on malformed specs or missing module files. Callable existence within the module is deferred to instantiation (Stage 3) to keep scanning import-free.

Refs: #452, #462
Closes: #470