### PR TITLE
feat(registry): add `resolve_prob_input` and `resolve_parameters`

### DIFF
--- a/src/uqtestfuns/core/registry/parser/inputs.py
+++ b/src/uqtestfuns/core/registry/parser/inputs.py
@@ -7,7 +7,6 @@ and supports input redirection to external YAML files.
 """
 
 from pathlib import Path
-from string import Template
 from typing import Any, Dict, List, Optional, Union
 
 from uqtestfuns.core.registry.specs import (
@@ -17,7 +16,7 @@ from uqtestfuns.core.registry.specs import (
     UQInputSpec,
 )
 
-from .utils import parse_factory, resolve_numeric, safe_load
+from .utils import parse_factory, resolve_numeric, safe_load, substitute_idx
 from .validation import (
     SpecValidationError,
     validate_marginal,
@@ -311,8 +310,8 @@ def _build_marginal_spec(
     description = marginal.get("description")
 
     if idx is not None:
-        name = _substitute_idx(name, idx)
-        description = _substitute_idx(description, idx)
+        name = substitute_idx(name, idx)
+        description = substitute_idx(description, idx)
 
     return MarginalSpec(
         distribution=distribution,
@@ -320,30 +319,6 @@ def _build_marginal_spec(
         name=name,
         description=description,
     )
-
-
-def _substitute_idx(template: Optional[str], idx: int) -> Optional[str]:
-    """Substitute the $idx placeholder in a template string.
-
-    Parameters
-    ----------
-    template : Optional[str]
-        Template string that may contain a ``$idx`` placeholder.
-        If None, the function returns None immediately.
-        Any other placeholders not provided are left unchanged.
-    idx : int
-        Integer value to substitute for the ``$idx`` placeholder.
-
-    Returns
-    -------
-    Optional[str]
-        The template string with ``$idx`` replaced by the given index value,
-        or None if the input template was None.
-    """
-    if template is None:
-        return None
-
-    return Template(template).safe_substitute(idx=idx)
 
 
 def _validate_repeat(repeat: int) -> None:

--- a/src/uqtestfuns/core/registry/parser/utils.py
+++ b/src/uqtestfuns/core/registry/parser/utils.py
@@ -17,6 +17,7 @@ import math
 import yaml
 
 from pathlib import Path
+from string import Template
 from typing import Any, Dict, Optional, Tuple, Union
 
 from uqtestfuns.core.registry.specs import CallableSpec
@@ -367,3 +368,24 @@ def parse_callable(
     )
 
     return module_path, callable_name
+
+
+def substitute_idx(template_str, idx):
+    """Substitute the $idx placeholder in a template string.
+
+    Parameters
+    ----------
+    template_str : str or None
+        A string potentially containing ``$idx``.
+    idx : int
+        The index value to substitute.
+
+    Returns
+    -------
+    str or None
+        The substituted string, or None if the input is None.
+    """
+    if template_str is None:
+        return None
+
+    return Template(template_str).safe_substitute(idx=idx)

--- a/src/uqtestfuns/core/registry/resolver.py
+++ b/src/uqtestfuns/core/registry/resolver.py
@@ -1,10 +1,29 @@
+"""Resolution utilities for UQ test function specifications.
+
+This module provides functions to resolve parsed specifications into
+concrete runtime objects. It handles dynamic imports of callables,
+construction of probabilistic input objects from various marginal
+representations, and parameter object creation with support for
+factory functions.
+"""
+
 import importlib
+import inspect
 
 from functools import partial
-from typing import Callable
+from typing import Any, Callable, Dict, List
 
-from .specs import CallableSpec
+from .specs import (
+    CallableSpec,
+    MarginalTemplate,
+    UQInputSpec,
+    UQParametersSpec,
+)
+from uqtestfuns.core.prob_input.marginal import Marginal
+from uqtestfuns.core.parameters import Parameters
 from uqtestfuns.core.registry.parser import SpecValidationError
+from uqtestfuns.core.prob_input.probabilistic_input_new import ProbInput
+from uqtestfuns.core.registry.parser.utils import substitute_idx
 
 
 def resolve_callable(callable_spec: CallableSpec) -> Callable:
@@ -64,3 +83,150 @@ def resolve_callable(callable_spec: CallableSpec) -> Callable:
         func = partial(func, **kwargs)
 
     return func
+
+
+def resolve_prob_input(
+    prob_input_spec: UQInputSpec,
+    input_dimension: int,
+) -> ProbInput:
+    """Resolve a UQInputSpec to a ProbInput object.
+
+    Constructs a list of Marginal objects from the marginals field
+    of the spec, handling three shapes: an explicit list, a template,
+    or a factory callable. The resulting marginals and copulas are
+    assembled into a ProbInput.
+
+    Parameters
+    ----------
+    prob_input_spec : UQInputSpec
+        A parsed input specification containing ``name``, ``marginals``,
+        and ``copulas``.
+    input_dimension : int
+        The number of input dimensions for the function.
+
+    Returns
+    -------
+    ProbInput
+        The constructed probabilistic input object.
+
+    Raises
+    ------
+    SpecValidationError
+        If the length of the marginals list does not match ``input_dimension``,
+        or if the factory callable returns invalid marginal definitions.
+    TypeError
+        If the marginals field has an unexpected type. This indicates
+        a programming error, not a spec issue.
+    """
+    # Fetch the relevant fields
+    name = prob_input_spec.name
+    marginals_spec = prob_input_spec.marginals
+    copulas_spec = prob_input_spec.copulas
+
+    # Resolve marginals
+    marginals: List[Marginal] = []
+
+    if isinstance(marginals_spec, list):
+        if len(marginals_spec) != input_dimension:
+            raise SpecValidationError(
+                f"Input dimension {input_dimension} does not match "
+                f"the number of marginals ({len(marginals_spec)})"
+            )
+        for marginal in marginals_spec:
+            marginals.append(
+                Marginal(
+                    name=marginal.name,
+                    description=marginal.description,
+                    distribution=marginal.distribution,
+                    parameters=marginal.parameters,
+                )
+            )
+
+    elif isinstance(marginals_spec, MarginalTemplate):
+        for i in range(input_dimension):
+            marginals.append(
+                Marginal(
+                    name=substitute_idx(marginals_spec.name, i + 1),
+                    description=substitute_idx(
+                        marginals_spec.description,
+                        i + 1,
+                    ),
+                    distribution=marginals_spec.distribution,
+                    parameters=marginals_spec.parameters,
+                )
+            )
+
+    elif isinstance(marginals_spec, CallableSpec):
+        func = resolve_callable(marginals_spec)
+        if _needs_input_dimension(func):
+            raw_marginals = func(input_dimension)
+        else:
+            raw_marginals = func()
+        for marginal in raw_marginals:
+            marginals.append(
+                Marginal(
+                    name=marginal["name"],
+                    description=marginal["description"],
+                    distribution=marginal["distribution"],
+                    parameters=marginal["parameters"],
+                )
+            )
+
+    else:
+        raise TypeError(f"Unexpected marginals type: {type(marginals_spec)}")
+
+    return ProbInput(marginals, copulas_spec, name=name)
+
+
+def resolve_parameters(
+    parameters_spec: UQParametersSpec,
+    input_dimension: int,
+) -> Parameters:
+    """Resolve a UQParametersSpec to a Parameters object.
+
+    Iterates over the parameter values in the spec, resolving any
+    factory callables to their computed values while passing literal
+    values through unchanged.
+
+    Parameters
+    ----------
+    parameters_spec : UQParametersSpec
+        A parsed parameter specification containing ``name``,
+        ``keyword_descriptions``, and ``values``.
+    input_dimension : int
+        The number of input dimensions for the function.
+
+    Returns
+    -------
+    Parameters
+        The constructed parameters object.
+    """
+    # Fetch the relevant metadata
+    name = parameters_spec.name
+    kw_descriptions = parameters_spec.keyword_descriptions
+
+    # Fetch values, resolve any callables
+    values: Dict[str, Any] = {}
+    for keyword, value in parameters_spec.values.items():
+        if isinstance(value, CallableSpec):
+            func = resolve_callable(value)
+            if _needs_input_dimension(func):
+                values[keyword] = func(input_dimension)
+            else:
+                values[keyword] = func()
+        else:
+            values[keyword] = value
+
+    return Parameters(
+        name=name,
+        descriptions=kw_descriptions,
+        values=values,
+    )
+
+
+def _needs_input_dimension(func: Callable) -> bool:
+    """Check if the first parameter of func is 'input_dimension'."""
+    sig = inspect.signature(func)
+    params = list(sig.parameters)
+
+    return len(params) > 0 and params[0] == "input_dimension"

--- a/tests/fixtures/valid_yaml/clipped_scaling_3d.py
+++ b/tests/fixtures/valid_yaml/clipped_scaling_3d.py
@@ -5,11 +5,31 @@ def evaluate(
     xx: np.ndarray,
     scale: float,
     coefficients: np.ndarray,
+    factors: np.ndarray,
     bounds: dict,
 ) -> np.ndarray:
-    raw = scale * np.sum(coefficients * xx, axis=1)
+    raw = scale * np.sum(factors * coefficients * xx, axis=1)
     return np.clip(raw, bounds["lower"], bounds["upper"])
 
 
 def get_coefficients(input_dimension: int) -> np.ndarray:
     return np.arange(1, input_dimension + 1, dtype=float)
+
+
+def get_factors() -> np.ndarray:
+    return np.array([1.0, 2.0, 3.0])
+
+
+def create_fixed_marginals():
+    marginals = []
+    for i in range(3):
+        marginals.append(
+            {
+                "name": f"X{i + 1}",
+                "distribution": "uniform",
+                "parameters": [0.0, 1.0],
+                "description": None,
+            }
+        )
+
+    return marginals

--- a/tests/fixtures/valid_yaml/clipped_scaling_3d.yaml
+++ b/tests/fixtures/valid_yaml/clipped_scaling_3d.yaml
@@ -14,6 +14,12 @@ inputs:
       distribution: uniform
       parameters: [0.0, 1.0]
       name: X$idx
+  Fixed:
+    description: Fixed inputs
+    marginals:
+      factory: create_fixed_marginals
+
+default_input: Default
 
 parameters:
   sets:
@@ -21,6 +27,8 @@ parameters:
       scale: 2.0
       coefficients:
         factory: get_coefficients
+      factors:
+        factory: get_factors
       bounds:
         lower: -5.0
         upper: 10.0

--- a/tests/test_registry_parser.py
+++ b/tests/test_registry_parser.py
@@ -1,4 +1,6 @@
+import numpy as np
 import pytest
+import yaml
 
 from pathlib import Path
 
@@ -10,7 +12,13 @@ from uqtestfuns.core.registry.specs import (
 )
 from uqtestfuns.core.registry.parser import parse_spec, SpecValidationError
 from uqtestfuns.core.registry.registry_entry import UQTestFunSpec
-from uqtestfuns.core.registry.resolver import resolve_callable
+from uqtestfuns.core.registry.resolver import (
+    resolve_callable,
+    resolve_parameters,
+    resolve_prob_input,
+)
+from uqtestfuns.core.parameters import Parameters
+from uqtestfuns.core.prob_input.probabilistic_input_new import ProbInput
 
 # Fixture roots
 FIXTURE_ROOT = Path(__file__).parent / "fixtures"
@@ -169,3 +177,78 @@ class TestResolverCallableSpec:
         spec = parse_spec(invalid_python_module, INVALID_ROOT_MOD)
         with pytest.raises(SpecValidationError):
             _ = resolve_callable(spec.evaluate)
+
+
+class TestResolveProbInput:
+    """All tests related to the resolution of ProbInput objects."""
+
+    def test_valid_spec(self, valid_spec_file, tmp_module_path):
+        """Test the resolution of ProbInput objects."""
+        # Parse the specification
+        spec = parse_spec(valid_spec_file, VALID_ROOT)
+
+        # Get the dimension of the function
+        yaml_file = VALID_ROOT / valid_spec_file
+        with open(yaml_file, "r") as f:
+            data = yaml.safe_load(f)
+        input_dimension = data["dimensions"]["input"]
+        if input_dimension == "variable":
+            input_dimension = 5  # Arbitrary input dimension for testing
+
+        for input_spec in spec.inputs.values():
+            prob_input = resolve_prob_input(input_spec, input_dimension)
+            assert isinstance(prob_input, ProbInput)
+            assert prob_input.dimension == input_dimension
+
+    def test_invalid_dimension(self, tmp_module_path):
+        """Test the resolution of ProbInput objects with invalid dimension."""
+        # Parse a fixed specification file
+        spec_file = VALID_ROOT / "circular_bar_2d.yaml"
+        spec = parse_spec(spec_file, VALID_ROOT)
+
+        for input_spec in spec.inputs.values():
+            with pytest.raises(SpecValidationError):
+                # Dimension is 2, but input is 3
+                _ = resolve_prob_input(input_spec, input_dimension=3)
+
+    def test_invalid_spec(self):
+        """Test the resolution of invalid ProbInput objects."""
+        input_spec = UQInputSpec(
+            name="test",
+            marginals=None,  # type: ignore
+            copulas=None,
+        )
+
+        with pytest.raises(TypeError):
+            _ = resolve_prob_input(input_spec, 1)
+
+
+class TestResolveParameters:
+    """All tests related to the resolution of Parameters objects."""
+
+    def test_valid_spec(self, valid_spec_file, tmp_module_path):
+        """Test the resolution of Parameters objects."""
+        # Parse the specification
+        spec = parse_spec(valid_spec_file, VALID_ROOT)
+
+        # Get the dimension of the function
+        yaml_file = VALID_ROOT / valid_spec_file
+        with open(yaml_file, "r") as f:
+            data = yaml.safe_load(f)
+        input_dimension = data["dimensions"]["input"]
+        if input_dimension == "variable":
+            input_dimension = 5  # Arbitrary input dimension for testing
+
+        # Parsed parameters (optional, may be None)
+        if spec.parameters is not None:
+            assert isinstance(spec.parameters, dict)
+            for parameters_spec in spec.parameters.values():
+                parameters = resolve_parameters(
+                    parameters_spec,
+                    input_dimension,
+                )
+
+                assert isinstance(parameters, Parameters)
+                for value in parameters_spec.values.values():
+                    if isinstance(value, np.ndarray):
+                        assert len(value) == input_dimension


### PR DESCRIPTION
Introduce functions to construct `ProbInput` and `Parameters` objects from parsed specifications, with support for resolving dynamic elements (templates, callables, and literals).

Consolidate `parser._substitute_idx` into `parser.utils` as `substitute_idx` for broader reuse.

Update the test suite to cover explicit list, template, and factory marginal shapes, as well as literal and factory parameter values.

Closes #484, #485
Refs: #452, #482