### PR TITLE
refactor(registry): add factory layer and module-level lazy access

### DIFF
--- a/src/uqtestfuns/__init__.py
+++ b/src/uqtestfuns/__init__.py
@@ -15,6 +15,7 @@ from .core import (
 from .core import UQTestFun
 from .core import FunParams
 from .core import RealVariable
+from .core.registry import get_registry
 
 from . import test_functions
 from .test_functions import *  # noqa
@@ -49,3 +50,19 @@ __all__ = [
     "list_functions",
     "api",
 ]
+
+
+# Lazy attribute access: registered test function names are resolved
+# to factory callables via the registry on first access.
+def __getattr__(name: str):
+    registry = get_registry()
+    if name in registry:
+        return registry.get_factory(name)
+    raise AttributeError(f"module 'uqtestfuns' has no attribute {name!r}")
+
+
+# Include registered test function names in dir() so that
+# tab-completion and introspection tools can discover them.
+def __dir__():
+    registry = get_registry()
+    return sorted(list(globals()) + list(registry))

--- a/src/uqtestfuns/api.py
+++ b/src/uqtestfuns/api.py
@@ -4,8 +4,9 @@ from typing import Dict, List, Optional, Union
 
 from tabulate import tabulate as tbl
 
+from uqtestfuns.core.uqtestfun import UQTestFun
 from uqtestfuns.core.registry.entries import UQTestFunInfo
-from uqtestfuns.core.registry import _registry
+from uqtestfuns.core.registry import get_registry
 
 SUPPORTED_TAGS = (
     "sensitivity",
@@ -16,6 +17,58 @@ SUPPORTED_TAGS = (
 )
 
 
+def create(
+    name: str,
+    input_dimension: Optional[int] = None,
+    *,
+    input_id: Optional[str] = None,
+    parameters_id: Optional[str] = None,
+) -> UQTestFun:
+    """Create a UQ test function instance by name.
+
+    This function retrieves a factory from the registry and uses it to
+    instantiate a UQTestFun object with the specified configuration.
+    It supports both fixed-dimension and variable-dimension test functions.
+
+    Parameters
+    ----------
+    name : str
+        The name of the test function to create. Must match a built-in UQ test
+        function name.
+    input_dimension : int, optional
+        The number of input dimensions for the test function. Required for
+        variable-dimension functions. For fixed-dimension functions, this
+        parameter is optional and defaults to the function's specified
+        dimension. Default is None.
+    input_id : str, optional
+        Identifier for selecting the probabilistic input configuration.
+        If not specified, the default input ID from the function's
+        specification will be used. Default is None.
+    parameters_id : str, optional
+        Identifier for selecting parameter configuration. Required for
+        parameterized functions if no default is specified. Ignored for
+        non-parameterized functions. Default is None.
+
+    Returns
+    -------
+    UQTestFun
+        A fully configured UQ test function instance.
+    """
+
+    factory = get_registry().get_factory(name)
+
+    kwargs = {}
+    if input_id is not None:
+        kwargs["input_id"] = input_id
+    if parameters_id is not None:
+        kwargs["parameters_id"] = parameters_id
+
+    if input_dimension is not None:
+        return factory(input_dimension, **kwargs)
+    else:
+        return factory(**kwargs)
+
+
 def list_functions(
     input_dimension: Optional[Union[str, int]] = None,
     output_dimension: Optional[int] = None,
@@ -23,10 +76,10 @@ def list_functions(
     tag: Optional[str] = None,
     tabulate: bool = True,
     tablefmt: str = "grid",
-    *,
-    entries: Dict[str, UQTestFunInfo] = _registry.entries,
 ) -> Optional[Union[List[str], str]]:
     """List available test functions from a registry entries dictionary."""
+
+    entries = get_registry().entries
 
     if tag is not None and tag not in SUPPORTED_TAGS:
         raise ValueError(
@@ -47,7 +100,7 @@ def list_functions(
             if entry.output_dimension != output_dimension:
                 continue
         if parameterized is not None:
-            if bool(entry.available_parameter_ids) != parameterized:
+            if bool(entry.available_parameters_ids) != parameterized:
                 continue
         if tag is not None:
             if tag not in entry.tags:
@@ -80,7 +133,7 @@ def list_functions(
     rows = []
     for i, name in enumerate(sorted(filtered)):
         entry = filtered[name]
-        row = [i + 1, name + "()"]
+        row: List[str] = [str(i + 1), name + "()"]
         if show_input_dim:
             if entry.variable_dimension:
                 dim_str = "M"
@@ -88,9 +141,13 @@ def list_functions(
                 dim_str = str(entry.input_dimension)
             row.append(dim_str)
         if show_output_dim:
-            row.append(entry.output_dimension)
+            if entry.output_dimension is None:
+                output_dim = "1"
+            else:
+                output_dim = str(entry.output_dimension)
+            row.append(output_dim)
         if show_param:
-            row.append(bool(entry.available_parameter_ids))
+            row.append(str(bool(entry.available_parameters_ids)))
         if show_tags:
             row.append(", ".join(entry.tags))
         row.append(entry.description)

--- a/src/uqtestfuns/core/registry/__init__.py
+++ b/src/uqtestfuns/core/registry/__init__.py
@@ -7,3 +7,14 @@ from .registry import DEFAULT_ROOT, PKG_ROOT, Registry
 # Singleton registry
 _registry = Registry(PKG_ROOT)
 _registry.scan(DEFAULT_ROOT)
+
+
+def get_registry() -> Registry:
+    """Returns the singleton registry instance.
+
+    Returns
+    -------
+    Registry
+        Singleton registry instance.
+    """
+    return _registry

--- a/src/uqtestfuns/core/registry/entries.py
+++ b/src/uqtestfuns/core/registry/entries.py
@@ -60,9 +60,9 @@ class UQTestFunInfo:
         Mapping of input IDs to their descriptions.
     default_input_id : str
         Identifier for the default input configuration.
-    available_parameter_ids : Optional[Dict[str, str]], optional
+    available_parameters_ids : Optional[Dict[str, str]], optional
         Mapping of parameter IDs to their descriptions (default is None).
-    default_parameter_id : Optional[str], optional
+    default_parameters_id : Optional[str], optional
         Identifier for the default parameter configuration (default is None).
     parameter_keywords : Optional[Dict[str, KeywordInfo]], optional
         Mapping of parameter keywords to their type and description
@@ -75,7 +75,6 @@ class UQTestFunInfo:
     tags: List[str]
 
     # Dimension info
-    variable_dimension: bool
     input_dimension: Optional[int]
     output_dimension: int
 
@@ -87,9 +86,14 @@ class UQTestFunInfo:
     default_input_id: str
 
     # Parameter variant IDs
-    available_parameter_ids: Optional[Dict[str, str]] = None
-    default_parameter_id: Optional[str] = None
-    parameter_keywords: Optional[Dict[str, KeywordInfo]] = None
+    available_parameters_ids: Dict[str, str]
+    default_parameters_id: Optional[str]
+    parameter_keywords: Dict[str, KeywordInfo]
+
+    @property
+    def variable_dimension(self) -> bool:
+        """Indicates if the test function has a variable input dimension."""
+        return self.input_dimension is None
 
 
 @dataclass(frozen=True)

--- a/src/uqtestfuns/core/registry/factory.py
+++ b/src/uqtestfuns/core/registry/factory.py
@@ -1,0 +1,165 @@
+"""Factory functions for creating UQ test function instances.
+
+This module provides utilities for generating callable factories that
+instantiate UQTestFun objects from their specifications and metadata.
+The factory pattern allows dynamic creation of test functions
+with configurable dimensions, input configurations,
+and parameters while respecting constraints defined in the function metadata.
+"""
+
+from typing import Callable, Optional
+
+from uqtestfuns.core.uqtestfun import UQTestFun
+from uqtestfuns.core.registry.entries import UQTestFunInfo, UQTestFunSpec
+from uqtestfuns.core.registry.resolver import (
+    resolve_callable,
+    resolve_prob_input,
+    resolve_parameters,
+)
+
+
+def make_factory(spec: UQTestFunSpec, info: UQTestFunInfo) -> Callable:
+    """Create a factory function for instantiating UQ test functions.
+
+    This function generates a callable factory that can be used to create
+    UQTestFun instances with configurable input dimensions, input IDs, and
+    parameter IDs. The factory respects dimension constraints specified in
+    the function metadata and provides appropriate default values.
+
+    Parameters
+    ----------
+    spec : UQTestFunSpec
+        The specification containing callable definitions,
+        input configurations, and parameter settings for the test function.
+    info : UQTestFunInfo
+        Metadata about the test function including name, description, default
+        IDs, and dimension constraints.
+
+    Returns
+    -------
+    Callable
+        A factory function that creates UQTestFun instances. The factory
+        signature depends on whether the input dimension is fixed or variable.
+    """
+
+    # Get default input_id
+    default_input_id = info.default_input_id
+
+    # Get default parameters_id
+    default_parameters_id = info.default_parameters_id
+
+    def factory(
+        input_dimension: Optional[int] = None,
+        *,
+        input_id: str = default_input_id,
+        parameters_id: Optional[str] = default_parameters_id,
+    ) -> UQTestFun:
+
+        default_input_dim = info.input_dimension
+        if default_input_dim is None:
+            # Variable-dimension: dimension is required
+            if input_dimension is None:
+                raise ValueError(
+                    f"'{info.name}' is a variable-dimension function; "
+                    f"input_dimension must be provided."
+                )
+            input_dim = input_dimension
+        else:
+            # Fixed-dimension: ignore or validate user-supplied value
+            if input_dimension is not None:
+                input_dim = input_dimension
+            else:
+                input_dim = default_input_dim
+
+            if input_dim != default_input_dim:
+                raise ValueError(
+                    f"'{info.name}' has fixed input dimension "
+                    f"{default_input_dim}, got {input_dim}."
+                )
+
+        return _instantiate(spec, info, input_dim, input_id, parameters_id)
+
+    factory.__name__ = info.name
+    factory.__qualname__ = info.name
+    factory.__doc__ = info.description
+
+    return factory
+
+
+def _instantiate(
+    spec: UQTestFunSpec,
+    info: UQTestFunInfo,
+    input_dimension: int,
+    input_id: str,
+    parameters_id: Optional[str],
+) -> UQTestFun:
+    """Create a UQTestFun instance from specification and metadata.
+
+    This helper function resolves and validates all components needed to
+    instantiate a UQTestFun object, including the evaluation callable,
+    probabilistic input, and optional parameters.
+
+    Parameters
+    ----------
+    spec : UQTestFunSpec
+        The specification containing callable definitions and configurations.
+    info : UQTestFunInfo
+        Metadata about the test function including dimension constraints.
+    input_dimension : int
+        The number of input dimensions for the test function.
+    input_id : str
+        Identifier for selecting the probabilistic input configuration.
+    parameters_id : Optional[str]
+        Identifier for selecting parameter configuration, or None if no
+        parameters are needed.
+
+    Returns
+    -------
+    UQTestFun
+        A fully configured UQTestFun instance.
+
+    Raises
+    ------
+    ValueError
+        If input_dimension does not match the fixed dimension,
+        if input_id is not among the available inputs,
+        or if parameters_id is missing or invalid for a parameterized
+        function.
+    """
+
+    # Resolve evaluate
+    evaluate = resolve_callable(spec.evaluate)
+
+    # Resolve probabilistic input
+    if input_id not in info.available_input_ids:
+        raise ValueError(
+            f"Input ID '{input_id}' is not available "
+            f"for function '{info.name}'"
+        )
+    input_spec = spec.inputs[input_id]
+    prob_input = resolve_prob_input(input_spec, input_dimension)
+
+    # Resolve parameters
+    if spec.parameters is None:
+        parameters = None
+    else:
+        if parameters_id is None:
+            raise ValueError(
+                f"Parameter ID must be specified for function '{info.name}'"
+            )
+        if parameters_id not in info.available_parameters_ids:
+            raise ValueError(
+                f"Parameter ID '{parameters_id}' is not available "
+                f"for function '{info.name}'"
+            )
+        parameters_spec = spec.parameters[parameters_id]
+        parameters = resolve_parameters(parameters_spec, input_dimension)
+
+    # Create an instance of UQTestFun
+    return UQTestFun(
+        evaluate=evaluate,
+        prob_input=prob_input,
+        parameters=parameters,
+        name=info.name,
+        description=info.description,
+    )

--- a/src/uqtestfuns/core/registry/parser/spec_file.py
+++ b/src/uqtestfuns/core/registry/parser/spec_file.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Dict
 
 import yaml
 
@@ -83,7 +83,6 @@ def parse_info(yaml_file: Path) -> UQTestFunInfo:
     dimensions = data["dimensions"]
     input_dimension = dimensions["input"]
     if input_dimension == "variable":
-        variable_dimension = True
         input_dimension = None
     else:
         if not isinstance(input_dimension, int) or input_dimension < 1:
@@ -91,7 +90,6 @@ def parse_info(yaml_file: Path) -> UQTestFunInfo:
                 f"'input_dimension' must be a positive integer, "
                 f"got {input_dimension!r} in {yaml_file}"
             )
-        variable_dimension = False
 
     # --- Output dimension (optional with default value)
     output_dimension = dimensions.get("output_dimension", 1)
@@ -119,9 +117,9 @@ def parse_info(yaml_file: Path) -> UQTestFunInfo:
     # --- Parameter specification (optional; None if not defined)
     parameters = data.get("parameters")
     if parameters is None:
-        available_parameter_ids = None
+        available_parameter_ids = {}
         default_parameter_id = None
-        parameter_keywords = None
+        parameter_keywords: Dict[str, KeywordInfo] = {}
     else:
         # -- Validate that 'sets' sub-block is present and non-empty
         available_sets = parameters.get("sets")
@@ -160,7 +158,6 @@ def parse_info(yaml_file: Path) -> UQTestFunInfo:
         name,
         description,
         tags,
-        variable_dimension,
         input_dimension,
         output_dimension,
         spec_path,

--- a/src/uqtestfuns/core/registry/registry.py
+++ b/src/uqtestfuns/core/registry/registry.py
@@ -15,11 +15,12 @@ The Registry class acts as a container that:
 """
 
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Callable
 
 from uqtestfuns.core.registry.entries import UQTestFunInfo
+from uqtestfuns.core.registry.factory import make_factory
 from uqtestfuns.core.registry.parser import SpecValidationError
-from uqtestfuns.core.registry.parser.spec_file import parse_info
+from uqtestfuns.core.registry.parser.spec_file import parse_info, parse_spec
 
 DEFAULT_ROOT = Path(__file__).parent.parent.parent / "test_functions"
 
@@ -38,14 +39,15 @@ class Registry:
 
     Attributes
     ----------
-    _entries : Dict[str, UQTestFunInfo]
+    _infos : Dict[str, UQTestFunInfo]
         Internal dictionary mapping function names to their metadata.
     """
 
     def __init__(self, pkg_root: Path = PKG_ROOT):
         """Initialize an empty Registry."""
-        self._entries: Dict[str, UQTestFunInfo] = {}
+        self._infos: Dict[str, UQTestFunInfo] = {}
         self._pkg_root = pkg_root
+        self._factories: Dict[str, Callable] = {}
 
     def scan(self, root: Path):
         """Scan a directory for test function specification files.
@@ -68,9 +70,9 @@ class Registry:
             if is_inputs_yaml(yaml_file.name):
                 continue
             info = parse_info(yaml_file)
-            if info.name in self._entries:
+            if info.name in self._infos:
                 raise SpecValidationError(f"Duplicate entry for {info.name}")
-            self._entries[info.name] = info
+            self._infos[info.name] = info
 
     @property
     def entries(self) -> Dict[str, UQTestFunInfo]:
@@ -81,7 +83,7 @@ class Registry:
         Dict[str, UQTestFunInfo]
             The dictionary of registered test functions metadata.
         """
-        return self._entries
+        return self._infos
 
     def items(self):
         """Return an iterator over (name, info) pairs.
@@ -91,7 +93,7 @@ class Registry:
         dict_items
             An iterator over tuples of (function_name, UQTestFunInfo).
         """
-        return self._entries.items()
+        return self._infos.items()
 
     def keys(self):
         """Return an iterator over registered function names.
@@ -101,7 +103,7 @@ class Registry:
         dict_keys
             An iterator over the names of registered test functions.
         """
-        return self._entries.keys()
+        return self._infos.keys()
 
     def values(self):
         """Return an iterator over UQTestFunInfo objects.
@@ -111,7 +113,32 @@ class Registry:
         dict_values
             An iterator over the metadata objects of registered test functions.
         """
-        return self._entries.values()
+        return self._infos.values()
+
+    def __contains__(self, key: str) -> bool:
+        """Check if a function is registered.
+
+        Parameters
+        ----------
+        key : str
+            The name of the test function.
+
+        Returns
+        -------
+        bool
+            True if the function is registered, False otherwise.
+        """
+        return key in self._infos
+
+    def __iter__(self):
+        """Return an iterator over registered test function names.
+
+        Returns
+        -------
+        dict_keys
+            An iterator over the names of registered test functions.
+        """
+        return iter(self._infos)
 
     def __len__(self):
         """Return the number of registered test functions.
@@ -121,7 +148,7 @@ class Registry:
         int
             The count of test functions in the registry.
         """
-        return len(self._entries)
+        return len(self._infos)
 
     def __getitem__(self, key):
         """Retrieve metadata for a test function by name.
@@ -141,7 +168,40 @@ class Registry:
         KeyError
             If the function name is not found in the registry.
         """
-        return self._entries[key]
+        return self._infos[key]
+
+    def get_factory(self, name: str):
+        """Retrieve or create a factory function for a test function.
+
+        Returns a factory callable that can be used to instantiate
+        a UQTestFun object with the specified name. The factory is
+        created on first access and cached for later calls.
+
+        Parameters
+        ----------
+        name : str
+            The name of the test function.
+
+        Returns
+        -------
+        Callable
+            A factory function that creates UQTestFun instances.
+
+        Raises
+        ------
+        KeyError
+            If the test function name is not found in the registry.
+        """
+        if name not in self:
+            raise KeyError(f"Test function '{name}' not available")
+
+        if name not in self._factories:
+            info = self._infos[name]
+            spec = parse_spec(info.spec_path, self._pkg_root)
+            factory = make_factory(spec, info)
+            self._factories[name] = factory
+
+        return self._factories[name]
 
 
 def is_inputs_yaml(filename: str) -> bool:

--- a/src/uqtestfuns/core/registry/resolver.py
+++ b/src/uqtestfuns/core/registry/resolver.py
@@ -162,13 +162,13 @@ def resolve_prob_input(
             raw_marginals = func(input_dimension)
         else:
             raw_marginals = func()
-        for marginal in raw_marginals:
+        for raw_marginal in raw_marginals:
             marginals.append(
                 Marginal(
-                    name=marginal["name"],
-                    description=marginal["description"],
-                    distribution=marginal["distribution"],
-                    parameters=marginal["parameters"],
+                    name=raw_marginal["name"],
+                    description=raw_marginal["description"],
+                    distribution=raw_marginal["distribution"],
+                    parameters=raw_marginal["parameters"],
                 )
             )
 

--- a/src/uqtestfuns/core/uqtestfun.py
+++ b/src/uqtestfuns/core/uqtestfun.py
@@ -189,10 +189,16 @@ class UQTestFun:
 
     def __str__(self) -> str:
         """Return a human-readable summary of the UQ test function."""
-        table = f"Name        : {self.name}\n"
-        table += f"Description : {self.description}\n"
-        table += f"Input dim.  : {self.input_dimension}\n"
-        table += f"Output dim. : {self.output_dimension}"
+        table = f"Name          : {self.name or 'N/A'}\n"
+        table += f"Description   : {self.description or 'N/A'}\n"
+        table += f"Input dim.    : {self.input_dimension}\n"
+        table += f"Output dim.   : {self.output_dimension}\n"
+
+        if self._parameters is not None:
+            _params = True
+        else:
+            _params = False
+        table += f"Parameterized : {_params}"
 
         return table
 
@@ -203,9 +209,13 @@ class UQTestFun:
         equivalent instance, provided the function is a built-in registered
         function.
         """
-        parameters_id = (
-            self._parameters.name if self._parameters is not None else None
-        )
+
+        parameters = self.parameters
+        if parameters is not None:
+            parameters_id = parameters.name
+        else:
+            parameters_id = None
+
         return (
             f"<UQTestFun "
             f"name={self.name!r}, "

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,0 +1,323 @@
+"""Tests for UQTestFuns test function construction, evaluation, and API.
+
+This module contains comprehensive tests for creating and using
+UQ test functions, including construction via the API,
+parameter/input ID handling, dimension validation,
+function evaluation, sampling, input transformation, and string representation.
+"""
+
+import numpy as np
+import pytest
+import random
+import string
+
+import uqtestfuns as uqtf
+
+from uqtestfuns import UQTestFun
+from uqtestfuns.api import create
+from uqtestfuns.core.registry.entries import UQTestFunInfo
+from uqtestfuns.core.registry import get_registry
+
+
+def random_string(length):
+    letters = string.ascii_letters  # a-z and A-Z
+    return "".join(random.choice(letters) for _ in range(length))
+
+
+def assert_equal(f1: UQTestFun, f2: UQTestFun) -> None:
+    """Assert that two UQTestFun instances are equal in value."""
+    assert isinstance(f1, UQTestFun)
+    assert isinstance(f2, UQTestFun)
+    assert f1.name == f2.name
+    assert f1.description == f2.description
+    assert f1._evaluate == f2._evaluate
+    assert f1.prob_input == f2.prob_input
+    assert f1.parameters == f2.parameters
+
+
+@pytest.fixture(params=list(get_registry()))
+def builtin_name(request) -> str:
+
+    return request.param
+
+
+@pytest.fixture
+def info(builtin_name: str) -> UQTestFunInfo:
+    return get_registry()[builtin_name]
+
+
+@pytest.fixture(params=[1, 3, 5])
+def input_dimension(request) -> int:
+    return request.param
+
+
+def test_dir_includes_registered_names(builtin_name: str):
+    """Test that the module's dir includes all registered function names."""
+    assert builtin_name in dir(uqtf)
+
+
+def test_factory_metadata(builtin_name: str, info: UQTestFunInfo):
+    """Test that the factory function has the correct metadata."""
+    factory = getattr(uqtf, builtin_name)
+
+    # Assertions
+    assert factory.__name__ == builtin_name
+    assert factory.__doc__ == info.description
+
+
+class TestConstruction:
+
+    def test_props_fixed_dim(self, builtin_name: str, info: UQTestFunInfo):
+        """Test the properties of a fixed-dimension UQ test function."""
+        if info.variable_dimension:
+            pytest.skip(f"{builtin_name} is variable dimension")
+
+        f = create(builtin_name)
+
+        # Assertions
+        assert f.name == info.name
+        assert f.input_dimension == info.input_dimension
+        assert f.output_dimension == info.output_dimension
+        assert f.description == info.description
+
+    def test_props_var_dim(self, builtin_name: str, info: UQTestFunInfo):
+        """Test the properties of a variable-dimension UQ test function."""
+        if not info.variable_dimension:
+            pytest.skip(f"{builtin_name} is fixed dimension")
+
+        input_dim = 5
+        f = create(builtin_name, input_dimension=input_dim)
+
+        # Assertions
+        assert f.name == info.name
+        assert f.input_dimension == input_dim
+        assert f.output_dimension == info.output_dimension
+        assert f.description == info.description
+
+    def test_create_fixed_dim_default(
+        self,
+        builtin_name: str,
+        info: UQTestFunInfo,
+    ):
+        """Test creating a default fixed-dim UQ test function."""
+        if info.variable_dimension:
+            pytest.skip(f"{builtin_name} is not fixed dimension")
+
+        f1 = create(builtin_name)
+        f2 = getattr(uqtf, builtin_name)()
+
+        # Assertion
+        assert_equal(f1, f2)
+
+    def test_create_var_dim_default(
+        self,
+        builtin_name: str,
+        input_dimension: int,
+        info: UQTestFunInfo,
+    ):
+        """Test creating a default variable-dim UQ test function."""
+        if not info.variable_dimension:
+            pytest.skip(f"{builtin_name} is not variable dimension")
+
+        f_1 = create(builtin_name, input_dimension=input_dimension)
+        f_2 = getattr(uqtf, builtin_name)(input_dimension=input_dimension)
+
+        assert_equal(f_1, f_2)
+
+    def test_create_input_id(self, builtin_name: str, info: UQTestFunInfo):
+        """Test creating a UQ test function with input_id."""
+
+        if info.input_dimension is None:
+            input_dim = 5
+        else:
+            input_dim = info.input_dimension
+
+        for input_id in info.available_input_ids.keys():
+            f_1 = create(builtin_name, input_dim, input_id=input_id)
+            f_2 = getattr(uqtf, builtin_name)(input_dim, input_id=input_id)
+
+            assert_equal(f_1, f_2)
+
+    def test_create_params_id(self, builtin_name: str, info: UQTestFunInfo):
+        """Test creating a UQ test function with parameters_id."""
+
+        if info.input_dimension is None:
+            input_dim = 5
+        else:
+            input_dim = info.input_dimension
+
+        if info.available_parameters_ids is not None:
+            for parameters_id in info.available_parameters_ids.keys():
+                f_1 = create(
+                    builtin_name,
+                    input_dim,
+                    parameters_id=parameters_id,
+                )
+                f_2 = getattr(uqtf, builtin_name)(
+                    input_dim,
+                    parameters_id=parameters_id,
+                )
+
+                assert_equal(f_1, f_2)
+        else:
+            pytest.skip(f"No parameters IDs available for {builtin_name}")
+
+    def test_invalid_var_dim(self, builtin_name: str, info: UQTestFunInfo):
+        """Test creating a UQ test function with an invalid var dimension."""
+
+        if info.input_dimension is not None:
+            pytest.skip(f"{builtin_name} is not variable dimension")
+        else:
+            with pytest.raises(ValueError):
+                _ = create(builtin_name)
+
+            with pytest.raises(ValueError):
+                _ = getattr(uqtf, builtin_name)()
+
+    def test_invalid_fixed_dim(self, builtin_name: str, info: UQTestFunInfo):
+        """Test creating a UQ test function with invalid fixed dimension."""
+
+        if info.input_dimension is None:
+            pytest.skip(f"{builtin_name} is not fixed dimension")
+        else:
+            fixed_dim = info.input_dimension + 1
+            with pytest.raises(ValueError):
+                _ = create(builtin_name, input_dimension=fixed_dim)
+
+            with pytest.raises(ValueError):
+                _ = getattr(uqtf, builtin_name)(input_dimension=fixed_dim)
+
+    def test_invalid_input_id(self, builtin_name: str, info: UQTestFunInfo):
+        """Test creating a UQ test function with invalid input ID."""
+        if info.input_dimension is None:
+            input_dim = 5
+        else:
+            input_dim = info.input_dimension
+
+        # None is valid in create() but should be rejected by the factory
+        with pytest.raises(ValueError):
+            _ = getattr(uqtf, builtin_name)(input_dim, input_id=None)
+
+        random_id = random_string(5)
+        with pytest.raises(ValueError):
+            _ = create(builtin_name, input_dim, input_id=random_id)
+        with pytest.raises(ValueError):
+            _ = getattr(uqtf, builtin_name)(input_dim, input_id=random_id)
+
+    def test_invalid_params_id(self, builtin_name: str, info: UQTestFunInfo):
+        """Test creating a UQ test function with invalid parameters ID."""
+
+        if info.input_dimension is None:
+            input_dim = 5
+        else:
+            input_dim = info.input_dimension
+
+        if not info.available_parameters_ids:
+            pytest.skip(f"{builtin_name} is not parameterized")
+
+        # None is valid in create() but should be rejected by the factory
+        with pytest.raises(ValueError):
+            _ = getattr(uqtf, builtin_name)(input_dim, parameters_id=None)
+
+        random_id = random_string(5)
+        with pytest.raises(ValueError):
+            _ = create(builtin_name, input_dim, parameters_id=random_id)
+        with pytest.raises(ValueError):
+            _ = getattr(uqtf, builtin_name)(input_dim, parameters_id=random_id)
+
+
+class TestCall:
+
+    def test_call(self, builtin_name: str, info: UQTestFunInfo):
+        """Test calling an instance of built-in UQ test function."""
+
+        # Create instances of UQ test function
+        if info.variable_dimension:
+            input_dimension = 5
+            f_1 = create(builtin_name, input_dimension=input_dimension)
+            f_2 = getattr(uqtf, builtin_name)(input_dimension=input_dimension)
+        else:
+            f_1 = create(builtin_name)
+            f_2 = getattr(uqtf, builtin_name)()
+
+        # Generate and evaluate sample points
+        sample_size = 100
+        rng_seed = 42
+        xx_1 = f_1.prob_input.get_sample(sample_size, rng_seed)
+        xx_2 = f_2.prob_input.get_sample(sample_size, rng_seed)
+        yy_1 = f_1(xx_1)
+        yy_2 = f_2(xx_2)
+
+        # Assertions
+        assert xx_1.shape == (sample_size, f_1.input_dimension)
+        assert xx_2.shape == (sample_size, f_2.input_dimension)
+        assert len(yy_1) == sample_size
+        assert len(yy_2) == sample_size
+        assert np.array_equal(xx_1, xx_2)
+        assert np.array_equal(yy_1, yy_2)
+
+    def test_get_sample(self, builtin_name: str, info: UQTestFunInfo):
+        """Test getting sample from built-in UQ test function instances."""
+
+        # Create instances of UQ test function
+        if info.variable_dimension:
+            input_dimension = 5
+            f_1 = create(builtin_name, input_dimension=input_dimension)
+            f_2 = getattr(uqtf, builtin_name)(input_dimension=input_dimension)
+        else:
+            f_1 = create(builtin_name)
+            f_2 = getattr(uqtf, builtin_name)()
+
+        # Generate sample with the same random seed
+        sample_size = 100
+        rng_seed = 42
+        yy_1 = f_1.get_sample(sample_size, rng_seed)
+        yy_2 = f_2.get_sample(sample_size, rng_seed)
+
+        # Assertion
+        assert len(yy_1) == sample_size
+        assert len(yy_2) == sample_size
+        assert np.array_equal(yy_1, yy_2)
+
+
+class TestStr:
+
+    def test_str(self, builtin_name: str, info: UQTestFunInfo):
+        """Test the __str__() method of a test function instance."""
+        input_dim = info.input_dimension
+        if input_dim is None:
+            input_dim = 5
+        f = create(builtin_name, input_dimension=input_dim)
+
+        s = str(f)
+
+        # Assertions
+        name = f.name
+        if name is not None:
+            assert name in s
+        assert str(input_dim) in s
+        assert str(f.output_dimension) in s
+        if f._parameters is None:
+            assert "False" in s
+        else:
+            assert "True" in s
+
+    def test_repr(self, builtin_name: str, info: UQTestFunInfo):
+        """Test the __repr__() method of a test function instance."""
+        input_dim = info.input_dimension
+        if input_dim is None:
+            input_dim = 5
+        f = create(builtin_name, input_dimension=input_dim)
+
+        r = repr(f)
+
+        # Assertions
+        assert "UQTestFun" in r
+        name = f.name
+        if name is not None:
+            assert name in r
+        assert str(input_dim) in r
+        assert info.default_input_id in r
+        default_parameters_id = info.default_parameters_id
+        if default_parameters_id is not None:
+            assert default_parameters_id in r

--- a/tests/test_uqtestfun.py
+++ b/tests/test_uqtestfun.py
@@ -78,14 +78,21 @@ def test_str(uqtestfun):
     """Test the __str__ method of UQTestFun."""
     uqtestfun_instance, _ = uqtestfun
 
-    str_ref = (
-        f"Name        : {uqtestfun_instance.name}\n"
-        f"Description : {uqtestfun_instance.description}\n"
-        f"Input dim.  : {uqtestfun_instance.input_dimension}\n"
-        f"Output dim. : {uqtestfun_instance.output_dimension}"
-    )
+    s = str(uqtestfun_instance)
 
-    assert uqtestfun_instance.__str__() == str_ref
+    name = uqtestfun_instance.name
+    if name is None:
+        name = "N/A"
+    description = uqtestfun_instance.description
+    if description is None:
+        description = "N/A"
+
+    # Assertions
+    assert name in s
+    assert description in s
+    assert str(uqtestfun_instance.input_dimension) in s
+    assert str(uqtestfun_instance.output_dimension) in s
+    assert str(uqtestfun_instance.parameters is not None) in s
 
 
 def test_repr(uqtestfun):


### PR DESCRIPTION
Wire up Stages 2 and 3 of the lazy pipeline, connecting the existing registry scan and resolvers to a user-facing factory API.

- Add `make_factory` / `_instantiate` in `core/registry/factory.py`
- Add `Registry.get_factory` with first-access caching
- Add module-level `__getattr__` / `__dir__` for lazy attribute access
- Add `create()` convenience wrapper in `api.py`
- Rename `_entries` to `_infos` for consistency
- Update `list_functions` for registry-backed entries
- Refine `UQTestFun.__str__` and `__repr__`
- Add end-to-end test suite for construction, evaluation, and API

Ref: #452
Closes: #490