### PR TITLE
refactor(registry): extend `parameter_keywords` to per-set inference

### DIFF
--- a/src/uqtestfuns/core/registry/entries.py
+++ b/src/uqtestfuns/core/registry/entries.py
@@ -47,8 +47,6 @@ class UQTestFunInfo:
         Human-readable description of the test function.
     tags : List[str]
         List of categorical tags for classification and search.
-    variable_dimension : bool
-        Whether the function supports variable input dimensions.
     input_dimension : Optional[int]
         Number of input dimensions (None if variable_dimension is True).
     output_dimension : int
@@ -64,7 +62,7 @@ class UQTestFunInfo:
         Mapping of parameter IDs to their descriptions (default is None).
     default_parameters_id : Optional[str], optional
         Identifier for the default parameter configuration (default is None).
-    parameter_keywords : Optional[Dict[str, KeywordInfo]], optional
+    parameters_keywords : Optional[Dict[str, KeywordInfo]], optional
         Mapping of parameter keywords to their type and description
         (default is None).
     """
@@ -88,7 +86,7 @@ class UQTestFunInfo:
     # Parameter variant IDs
     available_parameters_ids: Dict[str, str]
     default_parameters_id: Optional[str]
-    parameter_keywords: Dict[str, KeywordInfo]
+    parameters_keywords: Dict[str, Dict[str, KeywordInfo]]
 
     @property
     def variable_dimension(self) -> bool:

--- a/src/uqtestfuns/core/registry/parser/spec_file.py
+++ b/src/uqtestfuns/core/registry/parser/spec_file.py
@@ -116,10 +116,10 @@ def parse_info(yaml_file: Path) -> UQTestFunInfo:
 
     # --- Parameter specification (optional; None if not defined)
     parameters = data.get("parameters")
+    parameters_keywords: Dict[str, Dict[str, KeywordInfo]] = {}
     if parameters is None:
         available_parameter_ids = {}
         default_parameter_id = None
-        parameter_keywords: Dict[str, KeywordInfo] = {}
     else:
         # -- Validate that 'sets' sub-block is present and non-empty
         available_sets = parameters.get("sets")
@@ -141,18 +141,19 @@ def parse_info(yaml_file: Path) -> UQTestFunInfo:
         else:
             default_parameter_id = parameters["default_parameters"]
 
-        # -- Infer keyword types from the default parameter set
-        default_set = available_sets[default_parameter_id]
-        default_set = {
-            k: v for k, v in default_set.items() if k != "description"
-        }
-        parameter_keywords = {}
-        for k, v in default_set.items():
-            is_callable = isinstance(v, str) and v.endswith("()")
-            parameter_keywords[k] = KeywordInfo(
-                type=Callable if is_callable else type(v),
-                description=keyword_descriptions.get(k),
-            )
+        # -- Infer keyword types from each of the available sets
+        for set_name, available_set in available_sets.items():
+            # Filter it
+            available_set = {
+                k: v for k, v in available_set.items() if k != "description"
+            }
+            parameters_keywords[set_name] = {}
+            for k, v in available_set.items():
+                is_callable = isinstance(v, dict) and "factory" in v
+                parameters_keywords[set_name][k] = KeywordInfo(
+                    type=Callable if is_callable else type(v),
+                    description=keyword_descriptions.get(k),
+                )
 
     return UQTestFunInfo(
         name,
@@ -165,7 +166,7 @@ def parse_info(yaml_file: Path) -> UQTestFunInfo:
         default_input_id,
         available_parameter_ids,
         default_parameter_id,
-        parameter_keywords,
+        parameters_keywords,
     )
 
 

--- a/tests/fixtures/invalid_yaml/common.py
+++ b/tests/fixtures/invalid_yaml/common.py
@@ -3,3 +3,14 @@ import numpy as np
 
 def evaluate(xx: np.ndarray) -> np.ndarray:
     return np.sum(xx, axis=1)
+
+
+def evaluate_with_parameters(
+    xx: np.ndarray,
+    coefficients: np.ndarray,
+) -> np.ndarray:
+    return np.sum(xx * coefficients, axis=1)
+
+
+def get_coefficients(a, c) -> np.ndarray:
+    return a * np.ones(3) + c

--- a/tests/fixtures/invalid_yaml/invalid_parameters_factory.yaml
+++ b/tests/fixtures/invalid_yaml/invalid_parameters_factory.yaml
@@ -1,0 +1,31 @@
+name: InvalidParameters
+description: Invalid parameters specification
+tags:
+  - reliability
+
+dimensions:
+  input: 2
+  output: 1
+
+evaluate: common.evaluate_with_parameters
+
+inputs:
+  Default:
+    description: Two standard normal inputs
+    marginals:
+      - name: X1
+        distribution: normal
+        parameters: [0.0, 1.0]
+        description: Load variable
+      - name: X2
+        distribution: normal
+        parameters: [0.0, 1.0]
+        description: Resistance variable
+
+parameters:
+  sets:
+    Default:
+      coefficients:
+        factory: common.get_coefficients
+        a: 1.0
+        b: 0.5

--- a/tests/test_registry_parser.py
+++ b/tests/test_registry_parser.py
@@ -252,3 +252,20 @@ class TestResolveParameters:
                 for value in parameters_spec.values.values():
                     if isinstance(value, np.ndarray):
                         assert len(value) == input_dimension
+
+    def test_invalid_factory(self, tmp_module_path):
+        """Test the resolution of Parameters with invalid factory function."""
+        spec_file = INVALID_ROOT / "invalid_parameters_factory.yaml"
+
+        # Parse the specification
+        spec = parse_spec(spec_file, INVALID_ROOT)
+
+        # Get the dimension of the function
+        with open(spec_file, "r") as f:
+            data = yaml.safe_load(f)
+        input_dimension = data["dimensions"]["input"]
+
+        assert spec.parameters is not None
+        with pytest.raises(SpecValidationError):
+            for parameters_spec in spec.parameters.values():
+                _ = resolve_parameters(parameters_spec, input_dimension)


### PR DESCRIPTION
Change `parameter_keywords` in `UQTestFunInfo` from a flat `Dict[str, KeywordInfo]` to `Dict[str, Dict[str, KeywordInfo]]`, keyed by parameter set ID. This avoids misreporting the type of keywords whose value differs across sets. Keyword type inference now runs for all parameter sets rather than the default set only.

- Rename `parameter_keywords` → `parameters_keywords` for naming consistency
- Extend keyword inference in `parse_info` to cover all parameter sets
- Update signature validation tests

Ref: #452
Closes: #497