### PR TITLE
refactor(prob_input): remove unused factory classmethods

### DIFF
--- a/src/uqtestfuns/core/prob_input/probabilistic_input_new.py
+++ b/src/uqtestfuns/core/prob_input/probabilistic_input_new.py
@@ -12,9 +12,8 @@ from __future__ import annotations
 
 import numpy as np
 
-from numpy.typing import ArrayLike
 from tabulate import tabulate
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, List, Optional, Sequence, Tuple, Union
 
 from uqtestfuns.core.prob_input.marginal import FIELD_NAMES, Marginal
 
@@ -51,124 +50,6 @@ class ProbInput:
         self._marginals = tuple(marginals)
         self._copulas = copulas
         self._name = name
-
-    # --- Factory methods
-    @classmethod
-    def replicate(
-        cls,
-        dimension: int,
-        distribution: str,
-        parameters: ArrayLike,
-        base_name: str = "X",
-        *,
-        copulas: Any = None,
-        name: Optional[str] = None,
-    ):
-        """Create a probabilistic input model with replicated marginals.
-
-        Parameters
-        ----------
-        dimension : int
-            The dimension of the probabilistic input.
-        distribution : str
-            The type of the probability distribution.
-        parameters :  array_like
-            The parameters of the chose probability distribution.
-        base_name : str, optional
-            The base name for the random variables. Default is "X" and will
-            be replicated as "X1", "X2", etc.
-        copulas : Any, optional
-            Copulas to model the dependence structure between the variables.
-            Currently, it is not used.
-        name : str, optional
-            The name of the probabilistic input model.
-
-        Returns
-        -------
-        ProbInput
-            An instance of `ProbInput` class with replicated marginals.
-        """
-        marginals = []
-        for i in range(1, dimension + 1):
-            marginal_name = f"{base_name}{i}"
-            marginal = Marginal(distribution, parameters, marginal_name)
-            marginals.append(marginal)
-
-        return cls(marginals, copulas, name)
-
-    @classmethod
-    def from_dicts(
-        cls,
-        marginals: Sequence[Dict[str, Any]],
-        copulas: Any = None,
-        name: Optional[str] = None,
-    ):
-        """Create a probabilistic input model from dictionaries.
-
-        Parameters
-        ----------
-        marginals : Sequence[Dict[str, Any]]
-            A sequence of dictionaries with the marginal specifications. Each
-            element consists of the distribution type, parameters,
-            name (optional), and description (optional) of the marginal.
-        copulas : Any, optional
-            Copulas to model the dependence structure between the variables.
-            Currently, it is not used.
-        name : str, optional
-            The name of the probabilistic input model.
-
-        Returns
-        -------
-        ProbInput
-            An instance of `ProbInput` class with the specified marginals
-            given as a sequence of dictionaries.
-        """
-        marginals_objects = tuple(
-            [Marginal(**marginal) for marginal in marginals]
-        )
-
-        return cls(marginals_objects, copulas, name)
-
-    @classmethod
-    def from_factory(
-        cls,
-        factory_function: Callable,
-        dimension: int,
-        factory_kwargs: Optional[Dict[str, Any]] = None,
-        *,
-        copulas: Any = None,
-        name: Optional[str] = None,
-    ):
-        """Create a probabilistic input model from a factory function.
-
-        Parameters
-        ----------
-        factory_function : Callable
-            The factory function that generates the marginal specifications.
-            The function should take the dimension of input as the first
-            positional argument and return a sequence of dictionaries.
-        dimension : int
-            The dimension of the probabilistic input model.
-        factory_kwargs : Optional[Dict[str, Any]], optional
-            Keyword arguments to pass to the factory function, by default None.
-        copulas : Any, optional
-            The copula specification for the probabilistic input model,
-            by default None.
-        name : Optional[str], optional
-            The name of the probabilistic input model, by default None.
-
-        Returns
-        -------
-        ProbInput
-            An instance of `ProbInput` class with the marginals created by
-            the factory function.
-        """
-        if factory_kwargs is None:
-            marginals = factory_function(dimension)
-        else:
-            marginals = factory_function(dimension, **factory_kwargs)
-
-        return cls.from_dicts(marginals, copulas, name)
 
     # --- Properties
     @property
@@ -545,11 +426,12 @@ class ProbInput:
             The prepared ProbInput instance for transformation.
         """
         if not isinstance(other, ProbInput):
-            other_ = ProbInput.replicate(
-                self.dimension,
-                distribution="uniform",
-                parameters=other,
-            )
+            marginals = []
+            for _ in range(self.dimension):
+                marginals.append(
+                    Marginal(distribution="uniform", parameters=other)
+                )
+            other_ = ProbInput(marginals)
         else:
             other_ = other
 

--- a/tests/test_prob_input_new.py
+++ b/tests/test_prob_input_new.py
@@ -4,7 +4,6 @@ import numpy as np
 from uqtestfuns import Marginal
 from uqtestfuns.core.prob_input.probabilistic_input_new import ProbInput
 from conftest import create_random_marginals, create_random_marginal_dicts
-from functools import partial
 
 # Dimension (`m`)
 DIMENSIONS = [1, 2, 10, 100]
@@ -37,74 +36,6 @@ class TestConstructor:
         assert prob_input.copulas is None
         for i in range(dimension):
             assert marginals[i] == prob_input.marginals[i]
-
-    def test_replicate(self, dimension):
-        """Test creating a probabilistic input with replicated marginals."""
-        # Create a single marginal
-        marginal = create_random_marginals(1)[0]
-        distribution = marginal.distribution
-        parameters = marginal.parameters
-
-        marginal_dicts = []
-        for i in range(1, dimension + 1):
-            marginal_dicts.append(
-                {
-                    "distribution": distribution,
-                    "parameters": parameters,
-                    "name": f"X{i}",
-                }
-            )
-
-        # Create new probabilistic input with replicated marginals
-        prob_input_1 = ProbInput.replicate(dimension, distribution, parameters)
-        prob_input_2 = ProbInput.from_dicts(marginal_dicts)
-
-        # Assertions
-        assert prob_input_1 == prob_input_2
-
-    def test_from_dicts(self, dimension):
-        """Test the creation of a ProbInput from a list of dictionaries."""
-        marginal_dicts = create_random_marginal_dicts(dimension)
-        marginals = [
-            Marginal(**marginal_dict) for marginal_dict in marginal_dicts
-        ]
-
-        # Create instances
-        prob_input_1 = ProbInput(marginals)
-        prob_input_2 = ProbInput.from_dicts(marginal_dicts)
-
-        # Assertion
-        assert prob_input_1 == prob_input_2
-
-    def test_from_factory(self, dimension):
-        """Test the creation of a ProbInput from a factory function."""
-        rng_seed = 42
-        marginal_dicts = create_random_marginal_dicts(dimension, rng_seed)
-
-        factory = partial(create_random_marginal_dicts, rng=rng_seed)
-
-        # Create instances
-        prob_input_1 = ProbInput.from_factory(factory, dimension)
-        prob_input_2 = ProbInput.from_dicts(marginal_dicts)
-
-        # Assertion
-        assert prob_input_1 == prob_input_2
-
-    def test_from_factory_with_kwargs(self, dimension):
-        """Test the creation from a factory function with args."""
-        rng_seed = 42
-        marginal_dicts = create_random_marginal_dicts(dimension, rng_seed)
-
-        # Create instances
-        prob_input_1 = ProbInput.from_factory(
-            create_random_marginal_dicts,
-            dimension,
-            factory_kwargs={"rng": rng_seed},
-        )
-        prob_input_2 = ProbInput.from_dicts(marginal_dicts)
-
-        # Assertion
-        assert prob_input_1 == prob_input_2
 
 
 class TestGetSample:
@@ -275,10 +206,10 @@ class TestPDF:
     def test_known_value(self):
         """Test PDF against known analytical value."""
         # Create an instance
-        prob_input = ProbInput.from_dicts(
+        prob_input = ProbInput(
             [
-                {"distribution": "uniform", "parameters": [0.0, 2.0]},
-                {"distribution": "uniform", "parameters": [0.0, 5.0]},
+                Marginal(distribution="uniform", parameters=[0.0, 2.0]),
+                Marginal(distribution="uniform", parameters=[0.0, 5.0]),
             ]
         )
 
@@ -359,10 +290,10 @@ class TestCDF:
     def test_known_value(self):
         """Test PDF against known analytical value."""
         # Create an instance
-        prob_input = ProbInput.from_dicts(
+        prob_input = ProbInput(
             [
-                {"distribution": "uniform", "parameters": [0.0, 2.0]},
-                {"distribution": "uniform", "parameters": [0.0, 5.0]},
+                Marginal(distribution="uniform", parameters=[0.0, 2.0]),
+                Marginal(distribution="uniform", parameters=[0.0, 5.0]),
             ]
         )
 
@@ -546,7 +477,7 @@ class TestEquality:
 
         # Create instances
         prob_input_1 = ProbInput(marginals)
-        prob_input_2 = ProbInput.from_dicts(marginal_dicts)
+        prob_input_2 = ProbInput(marginals)
 
         # Assertions
         assert prob_input_1 is not prob_input_2
@@ -686,7 +617,16 @@ class TestPrint:
     def test_str_no_marginal_description(self, dimension):
         """Test __str__ method when the marginals have no description."""
         # Create a test instance
-        prob_input = ProbInput.replicate(dimension, "uniform", [0.0, 1.0])
+        marginals = []
+        for i in range(dimension):
+            marginals.append(
+                Marginal(
+                    name=f"X{i+1}",
+                    distribution="uniform",
+                    parameters=[0.0, 1.0],
+                )
+            )
+        prob_input = ProbInput(marginals)
 
         # Assertion
         assert str(prob_input).count("   -") == dimension


### PR DESCRIPTION
Remove `replicate`, `from_dicts`, and `from_factory` from `ProbInput`. These methods were added in anticipation of resolver needs that did not materialise — the resolver constructs `Marginal` objects directly and passes them to the default constructor. Remove associated tests.

- Remove `from_dicts`, `from_factory`, `replicate` classmethods
- Remove associated unit tests

Ref: #452
Closes: #496