### PR TITLE
chore(ci): drop Python 3.7-3.9, add 3.12-3.14 to test matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.14"
       - name: Install tox
         run: python -m pip install tox
       - name: Run black
@@ -23,7 +23,7 @@ jobs:
        - uses: actions/checkout@v4
        - uses: actions/setup-python@v5
          with:
-            python-version: "3.10"
+            python-version: "3.14"
        - name: Install tox
          run: python -m pip install tox
        - name: Run flake8
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.14"
       - name: Install tox
         run: python -m pip install tox
       - name: Run mypy
@@ -46,12 +46,8 @@ jobs:
     strategy:
       matrix:
         python:
-          - version: "3.7"
-            toxenv: "py37"
-          - version: "3.8"
-            toxenv: "py38"
-          - version: "3.9"
-            toxenv: "py39"
+          - version: "3.10"
+            toxenv: "py310"
           - version: "3.11"
             toxenv: "py311"
           - version: "3.12"
@@ -68,17 +64,17 @@ jobs:
       - name: Run pytest
         run: tox -e ${{ matrix.python.toxenv }}
   coverage:
-    name: Test (on Python 3.10) w/ coverage to CodeCov
+    name: Test (on Python 3.14) w/ coverage to CodeCov
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.14"
       - name: Install tox
         run: python -m pip install tox
       - name: Run pytest
-        run: tox -e "py310" -- --cov-report=xml --cov-report=term
+        run: tox -e "py314" -- --cov-report=xml --cov-report=term
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
   build_wheels:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![JOSS](https://img.shields.io/badge/JOSS-10.21105/joss.05671-brightgreen?style=flat-square)](https://doi.org/10.21105/joss.05671)
 [![DOI](http://img.shields.io/badge/DOI-10.5281/zenodo.14710452-blue.svg?style=flat-square)](https://doi.org/10.5281/zenodo.14710452)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg?style=flat-square)](https://github.com/psf/black)
-[![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg?style=flat-square)](https://www.python.org/downloads/release/python-370/)
+[![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg?style=flat-square)](https://www.python.org/downloads/release/python-3100/)
 [![License](https://img.shields.io/github/license/damar-wicaksono/uqtestfuns?style=flat-square)](https://choosealicense.com/licenses/mit/)
 [![PyPI](https://img.shields.io/pypi/v/uqtestfuns?style=flat-square)](https://pypi.org/project/uqtestfuns/)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,11 +14,11 @@ classifiers =
    License :: OSI Approved :: MIT License
    Programming Language :: Python :: 3
    Programming Language :: Python :: 3 :: Only
-   Programming Language :: Python :: 3.7
-   Programming Language :: Python :: 3.8
-   Programming Language :: Python :: 3.9
    Programming Language :: Python :: 3.10
    Programming Language :: Python :: 3.11
+   Programming Language :: Python :: 3.12
+   Programming Language :: Python :: 3.13
+   Programming Language :: Python :: 3.14
    Topic :: Scientific/Engineering
    Topic :: Scientific/Engineering :: Mathematics
    Topic :: Software Development :: Libraries :: Python Modules
@@ -29,7 +29,7 @@ package_dir =
    =src
 packages = find:
 include_package_data = True
-python_requires = >=3.7
+python_requires = >=3.10
 install_requires =
    numpy>=1.13.3
    scipy>=1.7.3
@@ -85,11 +85,11 @@ source =
 [tox:tox]
 isolated_build = True
 envlist =
-   py37
-   py38
-   py39
    py310
    py311
+   py312
+   py313
+   py314
 
 [testenv]
 deps =
@@ -111,7 +111,7 @@ deps =
 commands = mypy --ignore-missing-imports {posargs:src tests}
 
 [mypy]
-python_version = 3.10
+python_version = 3.12
 warn_unused_configs = True
 show_error_context = True
 pretty = True


### PR DESCRIPTION
Bump python_requires floor to >=3.10 (no upper bound). 3.7-3.9 are end-of-life; 3.14 was released in October 2025. Updates classifiers, tox envs, and the GitHub Actions matrix accordingly.

---

Closes: #516
Ref: #502