### PR TITLE
refactor(spec_parser): replace string slicing with AST-based resolver

### DIFF
--- a/src/uqtestfuns/core/registry/parser/expression.py
+++ b/src/uqtestfuns/core/registry/parser/expression.py
@@ -1,0 +1,202 @@
+import ast
+import math
+
+from typing import Any
+
+from .validation import SpecValidationError
+
+NAMED_CONSTANTS = {
+    "pi": math.pi,
+    "e": math.e,
+    "inf": math.inf,
+}
+
+
+def resolve_generic(value: Any) -> Any:
+    """Resolve generic value to either numeric or string value.
+
+    This function resolves values from YAML specifications by:
+    - Returning numeric values (float, int) unchanged
+    - Extracting and resolving expressions wrapped in '$()' syntax
+    - Substituting named mathematical constants with their numeric values
+    - Handling negative constants (e.g., '$(-pi)')
+    - Other string returned unchanged
+
+    Parameters
+    ----------
+    value : Any
+        The value to resolve.
+
+    Returns
+    -------
+    Any
+        The resolved value. Expressions wrapped in '$()' are substituted
+        with their numeric equivalents. Numeric values are returned unchanged.
+        Non-expression strings are returned as-is.
+
+    Raises
+    ------
+    SpecValidationError
+        If the value is a string expression and cannot be evaluated.
+
+    Notes
+    -----
+    - Expression syntax requires both '$(' prefix and ')' suffixes.
+    - Currently, only named constants are supported for the expression.
+    - Supported named constants are defined in the NAMED_CONSTANTS dictionary
+    - Negative constants are handled by prefixing with '-'
+      inside the expression.
+    - Non-expression strings are returned unchanged (not validated).
+
+    Examples
+    --------
+    >>> resolve_generic(3.14)
+    3.14
+    >>> resolve_generic("value")
+    'value'
+    >>> resolve_generic('$(pi)')
+    3.141592653589793
+    >>> resolve_generic('$(-pi)')
+    -3.141592653589793
+    >>> resolve_generic('$(e)')
+    2.718281828459045
+    """
+    if isinstance(value, str) and _is_expression(value):
+        # Evaluate the expression
+        value = value[2:-1].strip()
+        value = _resolve_expression(value)
+
+    return value
+
+
+def resolve_numeric(value: str | float | int) -> float | int:
+    """Resolve a value to a numeric type.
+
+    Parameters
+    ----------
+    value : float | int | str
+        The value to resolve. Can be a numeric value or a string expression.
+
+    Returns
+    -------
+    float | int
+        The resolved numeric value.
+
+    Raises
+    ------
+    SpecValidationError
+        If the value is a string that is not a valid expression.
+    """
+    if isinstance(value, (float, int)):
+        return value
+
+    if not _is_expression(value):
+        raise SpecValidationError(
+            f"Unrecognized string value: {value!r}, "
+            f"numeric value is expected."
+        )
+
+    value = value[2:-1].strip()
+
+    return _resolve_expression(value)
+
+
+def _is_expression(value: str) -> bool:
+    """Check if a value is an expression wrapped in '$()' syntax.
+
+    Parameters
+    ----------
+    value : str
+        The value to check.
+
+    Returns
+    -------
+    bool
+        True if the value is a string starting with '$(' and ending with ')',
+        False otherwise.
+    """
+    return value.startswith("$(") and value.endswith(")")
+
+
+def _resolve_expression(expression: str) -> float | int:
+    """Evaluate a `$()` expression body using a restricted AST walker.
+
+    Supports numeric literals, named constants from ``NAMED_CONSTANTS``,
+    and unary negation. All other syntax raises ``SpecValidationError``.
+
+    Parameters
+    ----------
+    expression : str
+        The expression string to evaluate (without the `$()` wrapper).
+
+    Returns
+    -------
+    float | int
+        The evaluated numeric result of the expression.
+
+    Raises
+    ------
+    SpecValidationError
+        If the expression has invalid syntax, contains unsupported operations,
+        or references unknown names.
+    """
+    try:
+        tree = ast.parse(expression, mode="eval")
+    except SyntaxError as exc:
+        raise SpecValidationError(
+            f"Invalid expression {expression!r}: {exc.msg}"
+        ) from exc
+
+    return _eval_node(tree.body, expression)
+
+
+def _eval_node(node: ast.AST, expression: str) -> float | int:
+    """Recursively evaluate an AST node from a `$()` expression.
+
+    Parameters
+    ----------
+    node : ast.AST
+        The AST node to evaluate. Supported node types include:
+        - ast.Constant: numeric literals (int, float)
+        - ast.Name: references to named constants in NAMED_CONSTANTS
+        - ast.UnaryOp with ast.USub: unary negation operator
+    expression : str
+        The original expression string (without `$()` wrapper) used for
+        error reporting.
+
+    Returns
+    -------
+    float | int
+        The evaluated numeric result of the AST node.
+
+    Raises
+    ------
+    SpecValidationError
+        If the node contains unsupported constant types (e.g., bool),
+        references an unknown name not in ``NAMED_CONSTANTS``, or uses
+        unsupported syntax or operations.
+    """
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, bool) or not isinstance(
+            node.value, (int, float)
+        ):
+            raise SpecValidationError(
+                f"Unsupported constant {node.value!r} "
+                f"in expression {expression!r}"
+            )
+        return node.value
+
+    if isinstance(node, ast.Name):
+        if node.id in NAMED_CONSTANTS:
+            return NAMED_CONSTANTS[node.id]
+        raise SpecValidationError(
+            f"Unknown name {node.id!r} in expression {expression!r}"
+        )
+
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        return -_eval_node(node.operand, expression)
+
+    raise SpecValidationError(
+        f"Unsupported syntax in expression {expression!r}: "
+        f"{type(node).__name__}"
+    )

--- a/src/uqtestfuns/core/registry/parser/inputs.py
+++ b/src/uqtestfuns/core/registry/parser/inputs.py
@@ -16,7 +16,8 @@ from uqtestfuns.core.registry.specs import (
     UQInputSpec,
 )
 
-from .utils import parse_factory, resolve_numeric, safe_load, substitute_idx
+from .utils import parse_factory, safe_load, substitute_idx
+from .expression import resolve_numeric
 from .validation import (
     SpecValidationError,
     validate_marginal,

--- a/src/uqtestfuns/core/registry/parser/parameters.py
+++ b/src/uqtestfuns/core/registry/parser/parameters.py
@@ -11,7 +11,8 @@ from typing import Any, Dict
 
 from uqtestfuns.core.registry.specs import UQParametersSpec
 
-from .utils import parse_factory, resolve_generic
+from .utils import parse_factory
+from .expression import resolve_generic
 from .validation import SpecValidationError, validate_required_keys
 
 

--- a/src/uqtestfuns/core/registry/parser/utils.py
+++ b/src/uqtestfuns/core/registry/parser/utils.py
@@ -5,12 +5,8 @@ values from YAML specification files used to define UQ test functions. It
 includes utilities for:
 
 - Safe loading of YAML files
-- Resolving generic and numeric values with support for mathematical constants
 - Parsing callable specifications (module paths and function names)
 - Parsing factory function specifications
-
-The module supports expression syntax (e.g., '$(pi)', '$(-e)') for embedding
-mathematical constants in YAML specifications.
 """
 
 import math
@@ -18,10 +14,11 @@ import yaml
 
 from pathlib import Path
 from string import Template
-from typing import Any, Dict, Optional, Tuple, Union
+from typing import Any, Dict, Optional, Tuple
 
 from uqtestfuns.core.registry.specs import CallableSpec
 
+from .expression import resolve_generic
 from .validation import SpecValidationError, validate_callable_string
 
 NAMED_CONSTANTS = {
@@ -60,148 +57,6 @@ def safe_load(yaml_file: Path) -> dict:
         data = yaml.safe_load(f)
 
     return data
-
-
-def resolve_generic(value: Any) -> Any:
-    """Resolve generic value to either numeric or string value.
-
-    This function resolves values from YAML specifications by:
-    - Returning numeric values (float, int) unchanged
-    - Extracting and resolving expressions wrapped in '$()' syntax
-    - Substituting named mathematical constants with their numeric values
-    - Handling negative constants (e.g., '$(-pi)')
-
-    Parameters
-    ----------
-    value : Union[str, float, int]
-        The value to resolve.
-
-    Returns
-    -------
-    Union[str, float, int]
-        The resolved value. Expressions wrapped in '$()' are substituted
-        with their numeric equivalents. Numeric values are returned unchanged.
-        Non-expression strings are returned as-is.
-
-    Raises
-    ------
-    SpecValidationError
-        If the value is a string expression and cannot be evaluated.
-
-    Notes
-    -----
-    - Expression syntax requires both '$(' prefix and ')' suffixes.
-    - Currently, only named constants are supported for the expression.
-    - Supported named constants are defined in the NAMED_CONSTANTS dictionary
-    - Negative constants are handled by prefixing with '-'
-      inside the expression.
-    - Non-expression strings are returned unchanged (not validated).
-
-    Examples
-    --------
-    >>> resolve_generic(3.14)
-    3.14
-    >>> resolve_generic("value")
-    'value'
-    >>> resolve_generic('$(pi)')
-    3.141592653589793
-    >>> resolve_generic('$(-pi)')
-    -3.141592653589793
-    >>> resolve_generic('$(e)')
-    2.718281828459045
-    """
-    if isinstance(value, str) and _is_expression(value):
-        # Evaluate the expression
-        value = _resolve_expression(value)
-
-    return value
-
-
-def resolve_numeric(value: Union[str, float, int]) -> Union[float, int]:
-    """Resolve a value to a numeric type.
-
-    Parameters
-    ----------
-    value : Union[str, float, int]
-        The value to resolve. Can be a numeric value or a string expression.
-
-    Returns
-    -------
-    Union[float, int]
-        The resolved numeric value.
-
-    Raises
-    ------
-    SpecValidationError
-        If the value is a string that is not a valid expression.
-    """
-    if isinstance(value, (float, int)):
-        return value
-
-    if not _is_expression(value):
-        raise SpecValidationError(
-            f"Unrecognized string value: {value!r}, "
-            f"numeric value is expected."
-        )
-
-    return _resolve_expression(value)
-
-
-def _is_expression(value: str) -> bool:
-    """Check if a value is an expression wrapped in '$()' syntax.
-
-    Parameters
-    ----------
-    value : str
-        The value to check.
-
-    Returns
-    -------
-    bool
-        True if the value is a string starting with '$(' and ending with ')',
-        False otherwise.
-    """
-    return value.startswith("$(") and value.endswith(")")
-
-
-def _resolve_expression(value: str) -> Union[float, int]:
-    """Resolve an expression wrapped in '$()' syntax.
-
-    This function extracts and evaluates an expression from a string value
-    that is wrapped in the '$()' syntax. It supports named mathematical
-    constants and their negations.
-
-    Parameters
-    ----------
-    value : str
-        A string expression wrapped in '$()' syntax (e.g., '$(pi)', '$(-e)').
-
-    Returns
-    -------
-    Union[float, int]
-        The numeric value of the resolved expression. Returns the value
-        of the named constant, potentially negated if prefixed with '-'.
-
-    Raises
-    ------
-    SpecValidationError
-        If the expression does not match any supported named constant.
-
-    Notes
-    -----
-    - The function assumes the input is already validated to have '$()' syntax.
-    """
-    expression = value[2:-1].strip()
-
-    # Handle negative constants
-    is_negative = expression.startswith("-")
-    constant_name = expression[1:] if is_negative else expression
-
-    if constant_name in NAMED_CONSTANTS:
-        result = NAMED_CONSTANTS[constant_name]
-        return -result if is_negative else result
-
-    raise SpecValidationError(f"Unrecognized string value: {expression!r}")
 
 
 def parse_factory(

--- a/tests/test_parser_expression.py
+++ b/tests/test_parser_expression.py
@@ -1,0 +1,24 @@
+import pytest
+
+from uqtestfuns.core.registry.parser.expression import resolve_generic
+from uqtestfuns.core.registry.parser.validation import SpecValidationError
+
+
+@pytest.mark.parametrize(
+    "invalid_expression", ["$(x = 5)", "$('foo')", "$(True)", "$(5 * pi)"]
+)
+def test_invalid_expression(invalid_expression):
+    """Test parsing of invalid expression syntax."""
+    with pytest.raises(SpecValidationError):
+        _ = resolve_generic(invalid_expression)
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_value", [("$(5)", 5), ("$(3.14)", 3.14)]
+)
+def test_valid_literal(input_value, expected_value):
+    """Test parsing of valid literal expressions."""
+    resolved = resolve_generic(input_value)
+
+    # Assertion
+    assert resolved == expected_value


### PR DESCRIPTION
Replace manual `$()` expression parsing with a recursive AST walker that handles the same node types as before (i.e., numeric Constant, Name, and UnaryOp(USub)) and rejects everything else with a `SpecValidationError` naming the offending node type.

Behavior is unchanged: all currently valid expressions continue to resolve to the same values, and previously rejected inputs continue to raise an exception.

This is a structural prerequisite for adding arithmetic expressions (e.g., `$(2 * pi)`, `$(pi / 2)`) and whitelisted function calls (`$(sqrt(5))`) in follow-up PRs without hand-rolling a parser.

---

Closes: #512
Ref: #502