### PR TITLE
feat(spec_parser): support function calls in $() expressions

### DIFF
--- a/src/uqtestfuns/core/registry/parser/expression.py
+++ b/src/uqtestfuns/core/registry/parser/expression.py
@@ -1,8 +1,24 @@
+"""Expression parsing and evaluation for YAML specification values.
+
+This module provides functionality to parse and evaluate mathematical
+expressions embedded in YAML specification files using the '$()' syntax.
+
+It supports:
+
+- Named mathematical constants (pi, e, inf)
+- Basic arithmetic operations (add, subtract, multiply, divide, power)
+- Mathematical functions (sqrt, log, exp, trigonometric functions, etc.)
+- Safe evaluation through restricted AST parsing
+
+The module ensures secure expression evaluation by limiting allowed operations
+and preventing arbitrary code execution.
+"""
+
 import ast
 import math
 import operator
 
-from typing import Any
+from typing import Any, Callable, Dict, Union
 
 from .validation import SpecValidationError
 
@@ -18,6 +34,18 @@ BINOP_OPS = {
     ast.Mult: operator.mul,
     ast.Div: operator.truediv,
     ast.Pow: operator.pow,
+}
+
+FUNCTIONS: Dict[str, Callable[..., Union[int, float]]] = {
+    "sqrt": math.sqrt,
+    "log": math.log,  # log(x) for natural log; log(x, base) for arbitrary
+    "log2": math.log2,
+    "log10": math.log10,
+    "exp": math.exp,
+    "sin": math.sin,
+    "cos": math.cos,
+    "tan": math.tan,
+    "abs": abs,  # builtin, not a math function
 }
 
 
@@ -230,6 +258,50 @@ def _eval_node(node: ast.AST, expression: str) -> float | int:
     # --- Unary positive
     if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.UAdd):
         return _eval_node(node.operand, expression)
+
+    # --- Math function call
+    if isinstance(node, ast.Call):
+        # Reject attribute access in function position: foo.bar(...)
+        if not isinstance(node.func, ast.Name):
+            raise SpecValidationError(
+                f"Unsupported call target in expression {expression!r}: "
+                f"{type(node.func).__name__}"
+            )
+
+        # Reject keyword arguments: sqrt(x=5)
+        if node.keywords:
+            raise SpecValidationError(
+                f"Keyword arguments are not supported in expression "
+                f"{expression!r}"
+            )
+
+        # Reject *args splatting: sqrt(*xs)
+        for arg in node.args:
+            if isinstance(arg, ast.Starred):
+                raise SpecValidationError(
+                    f"Argument unpacking is not supported in expression "
+                    f"{expression!r}"
+                )
+
+        # Whitelist lookup
+        func = FUNCTIONS.get(node.func.id)
+        if func is None:
+            raise SpecValidationError(
+                f"Unknown function {node.func.id!r} in expression "
+                f"{expression!r}"
+            )
+
+        # Recursively evaluate positional arguments
+        args = [_eval_node(a, expression) for a in node.args]
+
+        # Call the whitelisted function, wrapping math errors
+        try:
+            return func(*args)
+        except (ValueError, OverflowError, ZeroDivisionError) as exc:
+            raise SpecValidationError(
+                f"Error evaluating {node.func.id!r} in expression "
+                f"{expression!r}: {exc}"
+            ) from exc
 
     raise SpecValidationError(
         f"Unsupported syntax in expression {expression!r}: "

--- a/tests/test_parser_expression.py
+++ b/tests/test_parser_expression.py
@@ -1,3 +1,10 @@
+"""
+Tests for the expression parser in the UQTestFuns registry.
+
+This module contains tests for validating the parsing and resolution of
+generic expressions, including literals, binary operations, and function calls.
+"""
+
 import math
 import pytest
 
@@ -55,3 +62,64 @@ def test_valid_binary_op(input_value, expected_value):
 
     # Assertion
     assert resolved == expected_value
+
+
+class TestFunctionCalls:
+    """Test parsing of valid function calls."""
+
+    @pytest.mark.parametrize(
+        "expression, reference",
+        [
+            ("$(sqrt(4))", math.sqrt(4)),
+            ("$(log(100))", math.log(100)),
+            ("$(log(100, 10))", math.log(100, 10)),
+            ("$(log2(8))", math.log2(8)),
+            ("$(log10(1000))", math.log10(1000)),
+            ("$(exp(1))", math.e),
+            ("$(sin(pi/2))", math.sin(math.pi / 2)),
+            ("$(cos(0))", math.cos(0)),
+            ("$(tan(pi/4))", math.tan(math.pi / 4)),
+            ("$(abs(-5))", abs(-5)),
+        ],
+        ids=[
+            "sqrt",
+            "log",
+            "log_with_base",
+            "log2",
+            "log10",
+            "exp",
+            "sin",
+            "cos",
+            "tan",
+            "abs",
+        ],
+    )
+    def test_valid_expression(self, expression, reference):
+        """Test parsing valid function calls with supported functions."""
+        assert resolve_generic(expression) == reference
+
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "$(sqrt(x = 5))",  # With keyword argument
+            "$(foo.bar(5))",  # Attribute access
+            "$(max(*[5, 2, 1]))",  # Starred argument
+            "$(max([10, 5]))",  # Unsupported function
+            "$(exp(1000))",  # OverflowError
+            "$(log(-5))",  # ValueError
+            "$(log(1/0))",  # ZeroDivisionError
+        ],
+        ids=[
+            "w/ keyword",
+            "attribute",
+            "starred",
+            "unsupported",
+            "overflow",
+            "value_error",
+            "zero_division",
+        ],
+    )
+    def test_invalid_expression(self, expression):
+        """Test parsing invalid function calls."""
+        with pytest.raises(SpecValidationError):
+            _ = resolve_generic(expression)


### PR DESCRIPTION
Extend the AST walker to handle `ast.Call` nodes against a whitelist of math functions (e.g., `sqrt`, `log`, `log2`), so expressions like `$(sqrt(5))`, `$(log(10))`, and `$(2 * sqrt(pi))` now work directly in YAML specs. Arguments are evaluated recursively through the walker, so calls compose freely with arithmetic and nested calls.

The call branch rejects:
- attribute access in the function position (e.g., `math.sqrt(5)`)
- keyword arguments (e.g., `sqrt(x=5)`)
- *args splatting (e.g., `sqrt(*xs)`)

`ValueError`, `OverflowError`, and `ZeroDivisionError` raised during function evaluation are wrapped as `SpecValidationError` with the offending expression for context.

---

Closes: #514
Ref: #502