### PR TITLE
refactor(parser): group input/parameter variants into structured types

### DIFF
--- a/src/uqtestfuns/core/registry/entries.py
+++ b/src/uqtestfuns/core/registry/entries.py
@@ -7,12 +7,10 @@ function discovery and instantiation.
 """
 
 from dataclasses import dataclass
-from typing import List, Optional, Dict, Any
-
 from pathlib import Path
-from typing_extensions import TypedDict
+from typing import Any, Dict, List, Optional, TypedDict
 
-from .specs import CallableSpec, UQInputSpec, UQParametersSpec
+from .specs import CallableSpec, InputVariants, ParametersVariants
 
 
 class KeywordInfo(TypedDict):
@@ -104,23 +102,22 @@ class UQTestFunSpec:
     including the evaluation callable, input configurations, and optional
     parameter configurations.
 
-    Parameters
+    Attributes
     ----------
     name : str
         Unique identifier for the test function.
     evaluate : CallableSpec
         Specification of the callable that evaluates the test function,
         including module path and function name.
-    inputs : Dict[str, UQInputSpec]
+    inputs : InputVariants
         Mapping of input IDs to their complete specifications, including
         marginal distributions and other input-related metadata.
-    parameters : Optional[Dict[str, UQParametersSpec]], optional
-        Mapping of parameter IDs to their complete specifications
-        (default is None). Used for test functions that support
-        multiple parameter configurations.
+    parameters : Optional[ParametersVariants]
+        Mapping of parameter IDs to their complete specifications.
+        Used for test functions that support multiple parameter configurations.
     """
 
     name: str
     evaluate: CallableSpec
-    inputs: Dict[str, UQInputSpec]
-    parameters: Optional[Dict[str, UQParametersSpec]]
+    inputs: InputVariants
+    parameters: Optional[ParametersVariants]

--- a/src/uqtestfuns/core/registry/factory.py
+++ b/src/uqtestfuns/core/registry/factory.py
@@ -131,9 +131,9 @@ def _instantiate(
     if input_id not in info.available_input_ids:
         raise ValueError(
             f"Input ID '{input_id}' is not available "
-            f"for function '{info.name}'"
+            f"for function '{spec.name}'"
         )
-    input_spec = spec.inputs[input_id]
+    input_spec = spec.inputs.by_id[input_id]
     prob_input = resolve_prob_input(input_spec, input_dimension)
 
     # Resolve parameters
@@ -144,12 +144,12 @@ def _instantiate(
             raise ValueError(
                 f"Parameter ID must be specified for function '{info.name}'"
             )
-        if parameters_id not in info.available_parameters_ids:
+        if parameters_id not in spec.parameters.by_id.keys():
             raise ValueError(
                 f"Parameter ID '{parameters_id}' is not available "
-                f"for function '{info.name}'"
+                f"for function '{spec.name}'"
             )
-        parameters_spec = spec.parameters[parameters_id]
+        parameters_spec = spec.parameters.by_id[parameters_id]
         parameters = resolve_parameters(parameters_spec, input_dimension)
 
     # Resolve evaluate

--- a/src/uqtestfuns/core/registry/parser/parameters.py
+++ b/src/uqtestfuns/core/registry/parser/parameters.py
@@ -1,15 +1,30 @@
 """Parser for the parameters section in the YAML specifications.
 
 This module provides functionality to parse and validate parameter sets
-from YAML configuration files. It processes parameter specifications,
-resolves factory references for dynamically created parameter values,
-and handles generic parameter values including expressions.
+from YAML configuration files used to define UQ test function parameters.
+It processes parameter specifications, resolves factory references for
+dynamically created parameter values, and handles generic parameter values
+including expressions.
+
+The parser supports:
+- Multiple parameter sets within a single specification
+- Factory-based parameter generation using callable references
+- Generic parameter values with expression resolution
+- Parameter keyword descriptions for documentation
+- Default parameter set selection
+
+The main entry point is the `parse_parameters` function which returns
+a ParametersVariants object containing all parsed parameter sets.
 """
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Dict
 
-from uqtestfuns.core.registry.specs import UQParametersSpec
+from uqtestfuns.core.registry.specs import (
+    UQParametersSpec,
+    ParametersVariants,
+    ParametersSection,
+)
 
 from .utils import parse_factory
 from .expression import resolve_generic
@@ -17,38 +32,50 @@ from .validation import SpecValidationError, validate_required_keys
 
 
 def parse_parameters(
-    parameters_value: Dict[str, Dict[str, Any]],
+    parameters_section: ParametersSection,
     spec_file: Path,
     pkg_root: Path,
-) -> Dict[str, UQParametersSpec]:
+) -> ParametersVariants:
     """Parse the 'parameters' section from a YAML configuration.
 
     This function processes the parameter sets defined in a YAML configuration,
     resolving factory references and generic values to create structured
-    parameter specifications.
+    parameter specifications. It validates the structure of the parameters
+    section and creates UQParametersSpec objects for each parameter set.
 
     Parameters
     ----------
-    parameters_value : Dict[str, Any]
-        Dictionary containing parameter sets under a "sets" key. Each set
-        contains keyword-value pairs defining parameters.
+    parameters_section : ParametersSection
+        Dictionary containing parameter specifications in the YAML file.
     spec_file : Path
         Path to the YAML file being parsed, used for resolving relative
-        references in factory definitions.
+        references in factory definitions and for error reporting.
     pkg_root : Path
         Root directory of the package, used for resolving module paths
         in factory definitions.
 
     Returns
     -------
-    Dict[str, UQParametersSpec]
-        Dictionary mapping parameter set names to their corresponding
-        UQParametersSpec objects, which contain parameter descriptions
-        and parsed values.
+    ParametersVariants
+        Object containing a dictionary of parameter specifications by ID
+        and the default parameter set ID. Each specification includes
+        parameter values (either resolved generics or factory callables)
+        and optional keyword descriptions.
+
+    Raises
+    ------
+    SpecValidationError
+        If the "sets" key is missing from parameters_value, or if any
+        parameter set is not a dictionary mapping.
+
+    Notes
+    -----
+    - If no default_parameters is specified in the YAML, the first parameter
+      set in iteration order is used as the default.
     """
     # Check for mandatory field
     validate_required_keys(
-        parameters_value,
+        parameters_section,
         required_keys={"sets"},
         context=f"parameters section of {str(spec_file)}",
     )
@@ -59,10 +86,14 @@ def parse_parameters(
     parameters_specs: Dict[str, UQParametersSpec] = {}
 
     # keywords_descriptions is repeated for each specification
-    keyword_descriptions = parameters_value.get("keyword_descriptions", None)
+    keyword_descriptions = parameters_section.get("keyword_descriptions", None)
+
+    default_id = parameters_section.get("default_parameters")
 
     # Iterate over available parameters sets
-    parameters_sets = parameters_value["sets"]
+    parameters_sets = parameters_section["sets"]
+    if default_id is None:
+        default_id = next(iter(parameters_sets))
     for key, parameters_set in parameters_sets.items():
         if not isinstance(parameters_set, dict):
             raise SpecValidationError(
@@ -92,4 +123,7 @@ def parse_parameters(
             values=parsed_values,
         )
 
-    return parameters_specs
+    return ParametersVariants(
+        by_id=parameters_specs,
+        default_id=default_id,
+    )

--- a/src/uqtestfuns/core/registry/parser/spec_file.py
+++ b/src/uqtestfuns/core/registry/parser/spec_file.py
@@ -8,6 +8,7 @@ from uqtestfuns.core.registry.entries import (
     UQTestFunSpec,
     KeywordInfo,
 )
+from uqtestfuns.core.registry.specs import InputVariants
 from .evaluate import parse_evaluate
 from .inputs import parse_inputs
 from .parameters import parse_parameters
@@ -226,18 +227,33 @@ def parse_spec(spec_file: Path, pkg_root: Path) -> UQTestFunSpec:
     # Parse the "evaluate" section and return a CallableSpec
     evaluate = parse_evaluate(data.get("evaluate"), spec_file, pkg_root)
 
-    # Parse the "inputs" section and return a dictionary of UQInputSpec
+    # Parse the "inputs" section
     inputs = parse_inputs(data["inputs"], spec_file, pkg_root)
 
-    # Parse the "parameters" section & return a dictionary of UQParametersSpec
-    if "parameters" not in data:
-        parameters = None
+    # Get the default input ID
+    if len(inputs) > 1:
+        default_input = data["default_input"]
     else:
-        parameters = parse_parameters(data["parameters"], spec_file, pkg_root)
+        default_input = next(iter(inputs))
+
+    input_specs = InputVariants(
+        by_id=inputs,
+        default_id=default_input,
+    )
+
+    # Parse the "parameters" section
+    if "parameters" not in data:
+        parameters_specs = None
+    else:
+        parameters_specs = parse_parameters(
+            data["parameters"],
+            spec_file,
+            pkg_root,
+        )
 
     return UQTestFunSpec(
         name=name,
         evaluate=evaluate,
-        inputs=inputs,
-        parameters=parameters,
+        inputs=input_specs,
+        parameters=parameters_specs,
     )

--- a/src/uqtestfuns/core/registry/parser/validation.py
+++ b/src/uqtestfuns/core/registry/parser/validation.py
@@ -8,7 +8,8 @@ validation with required keys.
 
 import re
 
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, Union
+from uqtestfuns.core.registry.specs import ParametersSection
 
 
 class SpecValidationError(Exception):
@@ -94,7 +95,7 @@ def validate_callable_string(callable_string: str) -> None:
 
 
 def validate_required_keys(
-    data: dict,
+    data: Union[dict, ParametersSection],
     required_keys: Iterable[str],
     context: str,
 ) -> None:

--- a/src/uqtestfuns/core/registry/specs.py
+++ b/src/uqtestfuns/core/registry/specs.py
@@ -5,7 +5,7 @@ managing callable objects in the UQTestFuns registry system.
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, TypedDict
 
 
 @dataclass(frozen=True)
@@ -168,16 +168,73 @@ class UQParametersSpec:
     ----------
     name : str, optional
         The name of the parameters set. Default is None.
-    descriptions : Dict[str, str], optional
-        Optional dictionary mapping parameter names to their human-readable
+    keyword_descriptions : Dict[str, str], optional
+        Dictionary that maps parameter names to their human-readable
         descriptions. This provides documentation for what each parameter
         represents and how it affects the test function. Default is None.
     values : Dict[str, Any]
         Dictionary mapping parameter names to their values. The keys are
-        parameter names (strings) and the values can be of any type
+        parameter names (strings), and the values can be of any type
         appropriate for the parameter (e.g., float, int, str, list).
     """
 
-    name: Optional[str]
+    name: str
     keyword_descriptions: Optional[Dict[str, str]]
     values: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class InputVariants:
+    """Specification for multiple input variants of a UQ test function.
+
+    This immutable dataclass represents a collection of input specifications
+    for a UQ test function, allowing different input configurations to be
+    registered and accessed by unique identifiers. It is used in the registry
+    system to manage test functions that support multiple input variants
+    (e.g., probabilistic input models).
+
+    Parameters
+    ----------
+    by_id : Dict[str, UQInputSpec]
+        Dictionary mapping unique identifiers to their corresponding
+        UQInputSpec instances. Each key is a string identifier
+        and each value is a complete input specification.
+    default_id : str
+        The identifier of the default input variant to use when no specific
+        variant is requested. This key must exist in the by_id dictionary.
+    """
+
+    by_id: Dict[str, UQInputSpec]
+    default_id: str
+
+
+@dataclass(frozen=True)
+class ParametersVariants:
+    """Specification for multiple parameter variants of a UQ test function.
+
+    This immutable dataclass represents a collection of parameter
+    specifications for a UQ test function,
+    allowing different parameter configurations to be registered
+    and accessed by unique identifiers. It is used in the registry system
+    to manage test functions that support multiple parameter variants
+    (e.g., different parameterization of the same function).
+
+    Parameters
+    ----------
+    by_id : Dict[str, UQParametersSpec]
+        Dictionary mapping unique identifiers to their corresponding
+        UQParametersSpec instances. Each key is a string identifier
+        and each value is a complete parameter specification.
+    default_id : str
+        The identifier of the default parameter variant to use when no specific
+        variant is requested. This key must exist in the by_id dictionary.
+    """
+
+    by_id: Dict[str, UQParametersSpec]
+    default_id: str
+
+
+class ParametersSection(TypedDict, total=False):
+    sets: Dict[str, Dict[str, Any]]
+    keyword_descriptions: Dict[str, str]
+    default_parameters: str

--- a/tests/test_registry_parser.py
+++ b/tests/test_registry_parser.py
@@ -9,6 +9,8 @@ from uqtestfuns.core.registry.specs import (
     MarginalTemplate,
     UQInputSpec,
     UQParametersSpec,
+    ParametersVariants,
+    InputVariants,
 )
 from uqtestfuns.core.registry.parser import parse_spec, SpecValidationError
 from uqtestfuns.core.registry.entries import UQTestFunSpec
@@ -107,16 +109,16 @@ def test_parse_spec_structural(valid_spec_file):
     assert isinstance(spec.evaluate, CallableSpec)
 
     # Parsed inputs
-    assert isinstance(spec.inputs, dict)
-    for input_id, input_spec in spec.inputs.items():
+    assert isinstance(spec.inputs, InputVariants)
+    for input_id, input_spec in spec.inputs.by_id.items():
         assert isinstance(input_id, str)
         assert isinstance(input_spec, UQInputSpec)
         assert isinstance(input_spec.marginals, MARGINALS_SPECS)
 
     # Parsed parameters (optional, may be None)
     if spec.parameters is not None:
-        assert isinstance(spec.parameters, dict)
-        for parameters_id, parameters_spec in spec.parameters.items():
+        assert isinstance(spec.parameters, ParametersVariants)
+        for parameters_id, parameters_spec in spec.parameters.by_id.items():
             assert isinstance(parameters_id, str)
             assert isinstance(parameters_spec, UQParametersSpec)
             assert isinstance(parameters_spec.name, str)
@@ -154,14 +156,14 @@ class TestResolverCallableSpec:
         # Assertions
         assert callable(evaluate)
 
-        for input_spec in spec.inputs.values():
+        for input_spec in spec.inputs.by_id.values():
             if isinstance(input_spec.marginals, CallableSpec):
                 marginal_factory = resolve_callable(input_spec.marginals)
 
                 assert callable(marginal_factory)
 
         if spec.parameters is not None:
-            for parameters_spec in spec.parameters.values():
+            for parameters_spec in spec.parameters.by_id.values():
                 if isinstance(parameters_spec.values, CallableSpec):
                     parameter_factory = resolve_callable(
                         parameters_spec.values
@@ -195,7 +197,7 @@ class TestResolveProbInput:
         if input_dimension == "variable":
             input_dimension = 5  # Arbitrary input dimension for testing
 
-        for input_spec in spec.inputs.values():
+        for input_spec in spec.inputs.by_id.values():
             prob_input = resolve_prob_input(input_spec, input_dimension)
             assert isinstance(prob_input, ProbInput)
             assert prob_input.dimension == input_dimension
@@ -206,7 +208,7 @@ class TestResolveProbInput:
         spec_file = VALID_ROOT / "circular_bar_2d.yaml"
         spec = parse_spec(spec_file, VALID_ROOT)
 
-        for input_spec in spec.inputs.values():
+        for input_spec in spec.inputs.by_id.values():
             with pytest.raises(SpecValidationError):
                 # Dimension is 2, but input is 3
                 _ = resolve_prob_input(input_spec, input_dimension=3)
@@ -241,8 +243,8 @@ class TestResolveParameters:
 
         # Parsed parameters (optional, may be None)
         if spec.parameters is not None:
-            assert isinstance(spec.parameters, dict)
-            for parameters_spec in spec.parameters.values():
+            assert isinstance(spec.parameters, ParametersVariants)
+            for parameters_spec in spec.parameters.by_id.values():
                 parameters = resolve_parameters(
                     parameters_spec,
                     input_dimension,
@@ -267,5 +269,5 @@ class TestResolveParameters:
 
         assert spec.parameters is not None
         with pytest.raises(SpecValidationError):
-            for parameters_spec in spec.parameters.values():
+            for parameters_spec in spec.parameters.by_id.values():
                 _ = resolve_parameters(parameters_spec, input_dimension)


### PR DESCRIPTION
Wrap the bare `inputs` and `parameters` dicts on `UQTestFunSpec` in `InputVariants` and `ParametersVariants`, each pairing the variant mapping with its `default_id`. This makes the spec self-sufficient for resolution: the default variant ID is now carried on the spec rather than read from `UQTestFunInfo`, so the resolver no longer reaches into the discovery object to pick a default. The default is resolved once in the parser (explicit when multiple variants exist, the sole key otherwise) and fed to both spec and info.

- Add `InputVariants` and `ParametersVariants` frozen dataclasses with `variants` and non-optional `default_id` fields
- Change `UQTestFunSpec.inputs` to `InputVariants` and `parameters` to `Optional[ParametersVariants]`
- Resolve and validate parameter IDs against `spec.parameters` instead of `info`; drop the now-unreachable missing-ID guard
- Update the test registry fixtures to the new structure

Closes: #526
Ref: #502