### PR TITLE
refactor(factory): accept ProbInput and Parameters objects directly

### DIFF
--- a/src/uqtestfuns/api.py
+++ b/src/uqtestfuns/api.py
@@ -4,6 +4,8 @@ from typing import Dict, List, Optional, Union
 
 from tabulate import tabulate as tbl
 
+from uqtestfuns.core.prob_input.probabilistic_input_new import ProbInput
+from uqtestfuns.core.parameters import Parameters
 from uqtestfuns.core.uqtestfun import UQTestFun
 from uqtestfuns.core.registry.entries import UQTestFunInfo
 from uqtestfuns.core.registry import get_registry
@@ -23,12 +25,13 @@ def create(
     *,
     input_id: Optional[str] = None,
     parameters_id: Optional[str] = None,
+    prob_input: Optional[ProbInput] = None,
+    parameters: Optional[Parameters] = None,
 ) -> UQTestFun:
     """Create a UQ test function instance by name.
 
     This function retrieves a factory from the registry and uses it to
     instantiate a UQTestFun object with the specified configuration.
-    It supports both fixed-dimension and variable-dimension test functions.
 
     Parameters
     ----------
@@ -43,11 +46,24 @@ def create(
     input_id : str, optional
         Identifier for selecting the probabilistic input configuration.
         If not specified, the default input ID from the function's
-        specification will be used. Default is None.
+        specification will be used. ``input_id`` and ``prob_input`` are
+        mutually exclusive; both cannot be specified at the same time.
+        Default is None.
     parameters_id : str, optional
         Identifier for selecting parameter configuration. Required for
         parameterized functions if no default is specified. Ignored for
-        non-parameterized functions. Default is None.
+        non-parameterized functions. ``parameters_id`` and ``parameters`` are
+        mutually exclusive; both cannot be specified at the same time.
+        Default is None.
+    prob_input : ProbInput, optional
+        Custom probabilistic input specification to override the default
+        or selected input configuration. ``prob_input`` and ``input_id`` are
+        mutually exclusive; both cannot be specified at the same time.
+        Default is None.
+    parameters : Parameters, optional
+        Custom parameters object to override the default or selected parameter
+        configuration. ``parameters`` and ``parameters_id`` are mutually
+        exclusive; both cannot be specified at the same time. Default is None.
 
     Returns
     -------
@@ -57,11 +73,12 @@ def create(
 
     factory = get_registry().get_factory(name)
 
-    kwargs = {}
-    if input_id is not None:
-        kwargs["input_id"] = input_id
-    if parameters_id is not None:
-        kwargs["parameters_id"] = parameters_id
+    kwargs = {
+        "input_id": input_id,
+        "parameters_id": parameters_id,
+        "prob_input": prob_input,
+        "parameters": parameters,
+    }
 
     if input_dimension is not None:
         return factory(input_dimension, **kwargs)
@@ -77,7 +94,69 @@ def list_functions(
     tabulate: bool = True,
     tablefmt: str = "grid",
 ) -> Optional[Union[List[str], str]]:
-    """List available test functions from a registry entries dictionary."""
+    """List available UQ test functions with optional filtering.
+
+    This function queries the registry and returns a list of available
+    test functions, optionally filtered by various criteria. Results can
+    be displayed as a formatted table or returned as a list of function names.
+
+    Parameters
+    ----------
+    input_dimension : int or str, optional
+        Filter by number of input dimensions. Accepts an integer for
+        fixed-dimension functions or 'M' (case-insensitive)
+        for variable-dimension functions. If None, no filtering
+        by input dimension is applied. Default is None.
+    output_dimension : int, optional
+        Filter by number of output dimensions. Must be a positive integer.
+        If None, no filtering by output dimension is applied. Default is None.
+    parameterized : bool, optional
+        Filter by parameterization status. If True, only parameterized
+        functions are listed. If False, only non-parameterized functions
+        are listed. If None, no filtering by parameterization is applied.
+        Default is None.
+    tag : str, optional
+        Filter by application tag. Must be one of the supported tags:
+        'sensitivity', 'optimization', 'metamodeling', 'reliability', or
+        'integration'. If None, no filtering by tag is applied.
+        Default is None.
+    tabulate : bool, optional
+        If True, print results as a formatted table and return None. If False,
+        return a sorted list of function constructor names. Default is True.
+    tablefmt : str, optional
+        Format for the table output when `tabulate` is True. Follows the
+        formats supported by the `tabulate` library (e.g., 'grid', 'html',
+        'latex'). Default is 'grid'.
+
+    Returns
+    -------
+    None, list of str, or str
+        - If `tabulate` is True and `tablefmt` is not 'html': prints the table
+          and returns None.
+        - If `tabulate` is True and `tablefmt` is 'html': returns the table
+          as an HTML string.
+        - If `tabulate` is False: returns a sorted list of function constructor
+          names with parentheses (e.g., ['FunctionName()', ...]).
+        - If no functions match the filters: returns None
+          (when `tabulate` is True) or an empty list
+          (when `tabulate` is False).
+
+    Raises
+    ------
+    ValueError
+        If `tag` is not one of the supported tags, or if `input_dimension` or
+        `output_dimension` contains invalid values.
+    TypeError
+        If any parameter is provided with an incorrect type.
+
+    Notes
+    -----
+    The table columns displayed depend on the filtering criteria:
+    - '# Input' column is shown unless `input_dimension` is specified.
+    - '# Output' column is shown only if `output_dimension` is specified.
+    - 'Param.' column is shown only if `parameterized` is specified.
+    - 'Application' column is shown unless `tag` is specified.
+    """
 
     entries = get_registry().entries
 

--- a/src/uqtestfuns/core/registry/factory.py
+++ b/src/uqtestfuns/core/registry/factory.py
@@ -16,6 +16,8 @@ from uqtestfuns.core.registry.resolver import (
     resolve_prob_input,
     resolve_parameters,
 )
+from uqtestfuns.core.prob_input.probabilistic_input_new import ProbInput
+from uqtestfuns.core.parameters import Parameters
 
 
 def make_factory(spec: UQTestFunSpec, info: UQTestFunInfo) -> Callable:
@@ -42,42 +44,49 @@ def make_factory(spec: UQTestFunSpec, info: UQTestFunInfo) -> Callable:
         signature depends on whether the input dimension is fixed or variable.
     """
 
-    # Get default input_id
-    default_input_id = info.default_input_id
-
-    # Get default parameters_id
-    default_parameters_id = info.default_parameters_id
-
     def factory(
         input_dimension: Optional[int] = None,
         *,
-        input_id: str = default_input_id,
-        parameters_id: Optional[str] = default_parameters_id,
+        input_id: Optional[str] = None,
+        parameters_id: Optional[str] = None,
+        prob_input: Optional[ProbInput] = None,
+        parameters: Optional[Parameters] = None,
     ) -> UQTestFun:
 
-        default_input_dim = info.input_dimension
-        if default_input_dim is None:
-            # Variable-dimension: dimension is required
-            if input_dimension is None:
-                raise ValueError(
-                    f"'{info.name}' is a variable-dimension function; "
-                    f"input_dimension must be provided"
-                )
-            input_dim = input_dimension
-        else:
-            # Fixed-dimension: ignore or validate user-supplied value
-            if input_dimension is not None:
-                input_dim = input_dimension
-            else:
-                input_dim = default_input_dim
+        # --- Select or validate input dimension
+        input_dim = _select_or_validate_input_dimension(
+            info,
+            input_dimension,
+            prob_input,
+        )
 
-            if input_dim != default_input_dim:
-                raise ValueError(
-                    f"'{info.name}' has fixed input dimension "
-                    f"{default_input_dim}, got {input_dim}"
-                )
+        # --- Select or validate probabilistic input model
+        prob_input = _select_or_validate_prob_input(
+            spec,
+            input_dim,
+            input_id,
+            prob_input,
+        )
 
-        return _instantiate(spec, info, input_dim, input_id, parameters_id)
+        # --- Select or validate parameters
+        parameters = _select_or_validate_parameters(
+            spec,
+            input_dim,
+            parameters_id,
+            parameters,
+        )
+
+        # --- Resolve evaluate
+        evaluate = resolve_evaluate(spec.evaluate, parameters)
+
+        return UQTestFun(
+            evaluate=evaluate,
+            prob_input=prob_input,
+            parameters=parameters,
+            name=info.name,
+            description=info.description,
+            output_dimension=info.output_dimension,
+        )
 
     factory.__name__ = info.name
     factory.__qualname__ = info.name
@@ -86,81 +95,214 @@ def make_factory(spec: UQTestFunSpec, info: UQTestFunInfo) -> Callable:
     return factory
 
 
-def _instantiate(
-    spec: UQTestFunSpec,
+def _select_or_validate_input_dimension(
     info: UQTestFunInfo,
-    input_dimension: int,
-    input_id: str,
-    parameters_id: Optional[str],
-) -> UQTestFun:
-    """Create a UQTestFun instance from specification and metadata.
+    input_dimension: int | None,
+    prob_input: ProbInput | None,
+) -> int:
+    """Select or validate the input dimension for a test function.
 
-    This helper function resolves and validates all components needed to
-    instantiate a UQTestFun object, including the evaluation callable,
-    probabilistic input, and optional parameters.
+    The dimension may be specified by up to three sources: the test function's
+    default (``info.input_dimension``), an explicitly requested
+    ``input_dimension``, and the dimension of a pre-configured ``prob_input``.
+    All sources that are present must agree.
+
+    For fixed-dimension functions (``info.input_dimension`` is not ``None``),
+    the default is the source of truth; any provided ``input_dimension`` or
+    ``prob_input`` dimension must match it. For variable-dimension functions
+    (``info.input_dimension`` is ``None``), the dimension must come from
+    ``input_dimension`` and/or ``prob_input``, which must agree if both given.
 
     Parameters
     ----------
-    spec : UQTestFunSpec
-        The specification containing callable definitions and configurations.
     info : UQTestFunInfo
-        Metadata about the test function including dimension constraints.
-    input_dimension : int
-        The number of input dimensions for the test function.
-    input_id : str
-        Identifier for selecting the probabilistic input configuration.
-    parameters_id : Optional[str]
-        Identifier for selecting parameter configuration, or None if no
-        parameters are needed.
+        Test function metadata, including the default dimension which is
+        ``None`` for variable-dimension functions.
+    input_dimension : int, optional
+        The requested input dimension, or ``None`` if not specified.
+    prob_input : ProbInput, optional
+        A pre-configured probabilistic input instance, or ``None`` if not
+        given. Its dimension is treated as another source.
 
     Returns
     -------
-    UQTestFun
-        A fully configured UQTestFun instance.
+    int
+        The validated input dimension.
 
     Raises
     ------
     ValueError
-        If input_dimension does not match the fixed dimension,
-        if input_id is not among the available inputs,
-        or if parameters_id is missing or invalid for a parameterized
-        function.
+        For a variable-dimension function, if neither ``input_dimension`` nor
+        ``prob_input`` is provided, or if both are provided but disagree.
+        For a fixed-dimension function, if ``input_dimension`` or the
+        ``prob_input`` dimension is provided but does not match the default.
+    """
+    default = info.input_dimension
+    given = input_dimension
+    from_obj = prob_input.dimension if prob_input is not None else None
+
+    if given is not None and given < 1:
+        raise ValueError(
+            f"Input dimension must be positive, got {input_dimension}"
+        )
+
+    if default is None:
+        # Variable-dimension: no anchor, candidates must agree and exist.
+        if given is not None and from_obj is not None and given != from_obj:
+            raise ValueError(
+                f"'{info.name}' is variable-dimension, but 'input_dimension' "
+                f"({given}) and 'prob_input' dimension ({from_obj}) disagree"
+            )
+        resolved = given if given is not None else from_obj
+        if resolved is None:
+            raise ValueError(
+                f"'{info.name}' is variable-dimension; "
+                f"'input_dimension' or 'prob_input' must be provided"
+            )
+        return resolved
+
+    # Fixed-dimension: 'default' is the anchor; anything present must match it.
+    if given is not None and given != default:
+        raise ValueError(
+            f"'{info.name}' has fixed input dimension {default}, "
+            f"but 'input_dimension' is {given}"
+        )
+    if from_obj is not None and from_obj != default:
+        raise ValueError(
+            f"'{info.name}' has fixed input dimension {default}, "
+            f"but 'prob_input' dimension is {from_obj}"
+        )
+    return default
+
+
+def _select_or_validate_prob_input(
+    spec: UQTestFunSpec,
+    input_dimension: int,
+    input_id: str | None,
+    prob_input: ProbInput | None,
+) -> ProbInput:
+    """Select or validate the probabilistic input for a test function.
+
+    This helper either uses a provided ``ProbInput`` instance or creates one
+    from the specification based on the ``input_id``. When creating from the
+    specification, it falls back to ``spec.inputs.default_id`` if no
+    ``input_id`` is given, and validates that the resolved probabilistic
+    input matches the requested ``input_dimension``.
+
+    Parameters
+    ----------
+    spec : UQTestFunSpec
+        The specification containing the available input configurations and
+        their default ID.
+    input_dimension : int
+        The expected input dimension, used to resolve and validate the
+        probabilistic input.
+    input_id : str, optional
+        Identifier for selecting the probabilistic input configuration.
+        If ``None``, uses ``spec.inputs.default_id``.
+    prob_input : ProbInput, optional
+        A pre-configured probabilistic input instance. Mutually exclusive
+        with ``input_id``.
+
+    Returns
+    -------
+    ProbInput
+        The resolved and validated probabilistic input.
+
+    Raises
+    ------
+    ValueError
+        If both ``input_id`` and ``prob_input`` are specified, or if the
+        resolved ``input_id`` is not available for the function.
     """
 
-    # Resolve probabilistic input
-    if input_id not in info.available_input_ids:
+    # 'input_id' and 'prob_input' are mutually exclusive
+    if input_id is not None and prob_input is not None:
         raise ValueError(
-            f"Input ID '{input_id}' is not available "
-            f"for function '{spec.name}'"
+            "Specify either 'input_id' or 'prob_input', not both."
         )
-    input_spec = spec.inputs.by_id[input_id]
-    prob_input = resolve_prob_input(input_spec, input_dimension)
 
-    # Resolve parameters
-    if spec.parameters is None:
-        parameters = None
-    else:
-        if parameters_id is None:
+    # 'prob_input' is not provided and must be created
+    if prob_input is None:
+        default_id = spec.inputs.default_id
+        resolved_id = input_id if input_id is not None else default_id
+        if resolved_id not in spec.inputs.by_id.keys():
             raise ValueError(
-                f"Parameter ID must be specified for function '{info.name}'"
-            )
-        if parameters_id not in spec.parameters.by_id.keys():
-            raise ValueError(
-                f"Parameter ID '{parameters_id}' is not available "
+                f"Input ID '{resolved_id}' is not available "
                 f"for function '{spec.name}'"
             )
-        parameters_spec = spec.parameters.by_id[parameters_id]
-        parameters = resolve_parameters(parameters_spec, input_dimension)
+        input_spec = spec.inputs.by_id[resolved_id]
+        prob_input = resolve_prob_input(input_spec, input_dimension)
 
-    # Resolve evaluate
-    evaluate = resolve_evaluate(spec.evaluate, parameters)
+    return prob_input
 
-    # Create an instance of UQTestFun
-    return UQTestFun(
-        evaluate=evaluate,
-        prob_input=prob_input,
-        parameters=parameters,
-        name=info.name,
-        description=info.description,
-        output_dimension=info.output_dimension,
-    )
+
+def _select_or_validate_parameters(
+    spec: UQTestFunSpec,
+    input_dimension: int,
+    parameters_id: str | None,
+    parameters_: Parameters | None,
+) -> Parameters | None:
+    """Select or validate parameters for a test function.
+
+    This helper either uses a provided ``Parameters`` instance or creates one
+    from the specification based on the ``parameters_id``. It handles
+    functions that take no parameters (``spec.parameters is None``) and, when
+    resolving from the specification, falls back to
+    ``spec.parameters.default_id`` if no ``parameters_id`` is given.
+
+    Parameters
+    ----------
+    spec : UQTestFunSpec
+        The specification containing the parameter configurations and their
+        default ID. ``spec.parameters`` is ``None`` for non-parameterized
+        functions.
+    input_dimension : int
+        The input dimension used for parameter resolution.
+    parameters_id : str, optional
+        Identifier for selecting the parameter configuration.
+        If ``None``, uses ``spec.parameters.default_id``.
+    parameters_ : Parameters, optional
+        A pre-configured parameters instance. Mutually exclusive with
+        ``parameters_id``.
+
+    Returns
+    -------
+    Parameters or None
+        The resolved parameters, or ``None`` if the function takes no
+        parameters.
+
+    Raises
+    ------
+    ValueError
+        If both ``parameters_id`` and ``parameters_`` are specified, if
+        either is provided for a non-parameterized function, or if the
+        resolved ``parameters_id`` is not available for the function.
+    """
+    # --- Basic checks
+    # 'parameters_id' and 'parameters' are mutually exclusive
+    if parameters_id is not None and parameters_ is not None:
+        raise ValueError(
+            "Specify either 'parameters_id' or 'parameters', not both."
+        )
+
+    # --- The function is not parameterized
+    if spec.parameters is None:
+        # 'parameters_id' and 'parameters_' must not be provided simultaneously
+        if parameters_id is not None or parameters_ is not None:
+            raise ValueError(f"'{spec.name}' takes no parameters")
+        return None
+
+    # --- The function is parameterized
+    if parameters_ is not None:
+        # 'parameters' is provided, return as-is
+        return parameters_
+    # 'parameters' is not provided, resolve from ID
+    default_id = spec.parameters.default_id
+    rid = parameters_id if parameters_id is not None else default_id
+    if rid not in spec.parameters.by_id.keys():
+        raise ValueError(
+            f"Parameters ID '{rid}' is not available for '{spec.name}'"
+        )
+
+    return resolve_parameters(spec.parameters.by_id[rid], input_dimension)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -6,6 +6,7 @@ parameter/input ID handling, dimension validation,
 function evaluation, sampling, input transformation, and string representation.
 """
 
+import copy
 import numpy as np
 import pytest
 import random
@@ -13,7 +14,9 @@ import string
 
 import uqtestfuns as uqtf
 
-from uqtestfuns import UQTestFun
+from uqtestfuns import UQTestFun, Marginal
+from uqtestfuns.core import Parameters
+from uqtestfuns.core.prob_input.probabilistic_input_new import ProbInput
 from uqtestfuns.api import create
 from uqtestfuns.core.registry.entries import UQTestFunInfo
 from uqtestfuns.core.registry import get_registry
@@ -179,6 +182,14 @@ class TestConstruction:
         else:
             pytest.skip(f"No parameters IDs available for {builtin_name}")
 
+    def test_invalid_dim_neg(self, builtin_name: str, info: UQTestFunInfo):
+        """Test creating a UQ test function with negative dimension."""
+        with pytest.raises(ValueError):
+            _ = create(builtin_name, input_dimension=-1)
+
+        with pytest.raises(ValueError):
+            _ = getattr(uqtf, builtin_name)(input_dimension=-1)
+
     def test_invalid_var_dim(self, builtin_name: str, info: UQTestFunInfo):
         """Test creating a UQ test function with an invalid var dimension."""
 
@@ -211,10 +222,6 @@ class TestConstruction:
         else:
             input_dim = info.input_dimension
 
-        # None is valid in create() but should be rejected by the factory
-        with pytest.raises(ValueError):
-            _ = getattr(uqtf, builtin_name)(input_dim, input_id=None)
-
         random_id = random_string(5)
         with pytest.raises(ValueError):
             _ = create(builtin_name, input_dim, input_id=random_id)
@@ -231,10 +238,6 @@ class TestConstruction:
 
         if not info.available_parameters_ids:
             pytest.skip(f"{builtin_name} is not parameterized")
-
-        # None is valid in create() but should be rejected by the factory
-        with pytest.raises(ValueError):
-            _ = getattr(uqtf, builtin_name)(input_dim, parameters_id=None)
 
         random_id = random_string(5)
         with pytest.raises(ValueError):
@@ -338,3 +341,161 @@ class TestStr:
         default_parameters_id = info.default_parameters_id
         if default_parameters_id is not None:
             assert default_parameters_id in r
+
+
+class TestProbInputObject:
+    """Test using an instance of ProbInput for a test function construction."""
+
+    def test_valid(self, builtin_name: str, info: UQTestFunInfo):
+        """Test that the ProbInput object is valid for construction."""
+        if info.input_dimension is None:
+            input_dim = 5
+        else:
+            input_dim = info.input_dimension
+        f_1 = create(builtin_name, input_dimension=input_dim)
+        prob_input = copy.copy(f_1.prob_input)
+
+        # Construct a new instance
+        f_2 = create(builtin_name, prob_input=prob_input)
+
+        # Generate function values
+        sample_size = 1000
+        seed = 42
+        yy_1 = f_1.get_sample(sample_size, seed)
+        yy_2 = f_2.get_sample(sample_size, seed)
+
+        # Assertion
+        assert np.array_equal(yy_1, yy_2)
+
+    def test_invalid_dim(self, builtin_name: str, info: UQTestFunInfo):
+        """Test invalid dimension with ProbInput for construction."""
+        if info.input_dimension is None:
+            input_dim = 5
+        else:
+            input_dim = info.input_dimension
+        f_1 = create(builtin_name, input_dimension=input_dim)
+        prob_input = copy.copy(f_1.prob_input)
+
+        # Assertion
+        with pytest.raises(ValueError):
+            _ = create(
+                builtin_name,
+                input_dimension=input_dim + 1,
+                prob_input=prob_input,
+            )
+
+    def test_invalid_prob_input(self, builtin_name: str, info: UQTestFunInfo):
+        """Test creating a UQ test function with invalid ProbInput."""
+        if info.input_dimension is None:
+            pytest.skip()
+        else:
+            input_dim = info.input_dimension
+
+        # Create ProbInput with mismatched dimension
+        marginals = []
+        for _ in range(input_dim + 1):
+            marginals.append(Marginal("uniform", [0, 1]))
+        prob_input = ProbInput(marginals)
+
+        # Assert
+        with pytest.raises(ValueError):
+            _ = create(
+                builtin_name,
+                input_dimension=input_dim,
+                prob_input=prob_input,
+            )
+
+    def test_invalid_exclusive(self, builtin_name: str, info: UQTestFunInfo):
+        """Test invalid exclusive arguments for construction."""
+        if info.input_dimension is None:
+            input_dim = 5
+        else:
+            input_dim = info.input_dimension
+
+        f_1 = create(builtin_name, input_dimension=input_dim)
+        prob_input = copy.copy(f_1.prob_input)
+
+        # Assert
+        with pytest.raises(ValueError):
+            _ = create(
+                builtin_name,
+                input_dimension=input_dim,
+                input_id=info.default_input_id,
+                prob_input=prob_input,
+            )
+
+
+class TestParametersObject:
+    """Test the Parameters class for a test function construction."""
+
+    def test_invalid_exclusive(self, builtin_name: str, info: UQTestFunInfo):
+        """Test invalid exclusive parameters arguments for construction."""
+
+        if info.input_dimension is None:
+            input_dim = 5
+        else:
+            input_dim = info.input_dimension
+
+        if info.default_parameters_id is None:
+            pytest.skip(
+                "Non-parameterized functions do not support parameters"
+            )
+
+        f_1 = create(builtin_name, input_dim)
+        parameters = copy.copy(f_1.parameters)
+
+        # Construct a new instance
+        f_2 = create(builtin_name, input_dim, parameters=parameters)
+
+        # Generate function values
+        sample_size = 1000
+        seed = 42
+        yy_1 = f_1.get_sample(sample_size, seed)
+        yy_2 = f_2.get_sample(sample_size, seed)
+
+        # Assertion
+        assert np.array_equal(yy_1, yy_2)
+
+    def test_no_parameters(self, builtin_name: str, info: UQTestFunInfo):
+        """Test passing parameters for non-parameterized functions."""
+        if info.input_dimension is None:
+            input_dim = 5
+        else:
+            input_dim = info.input_dimension
+
+        if info.default_parameters_id is not None:
+            pytest.skip(
+                "Non-parameterized functions do not support parameters"
+            )
+
+        # Create a dummpy Parameters
+        params = Parameters({})
+
+        with pytest.raises(ValueError):
+            _ = create(builtin_name, input_dim, parameters=params)
+
+        with pytest.raises(ValueError):
+            _ = create(builtin_name, input_dim, parameters_id="123")
+
+    def test_valid(self, builtin_name: str, info: UQTestFunInfo):
+        """Test invalid exclusive parameters arguments for construction."""
+
+        if info.input_dimension is None:
+            input_dim = 5
+        else:
+            input_dim = info.input_dimension
+
+        if info.default_parameters_id is None:
+            pytest.skip()
+
+        f = create(builtin_name, input_dimension=input_dim)
+        parameters = copy.copy(f.parameters)
+
+        # Assert
+        with pytest.raises(ValueError):
+            _ = create(
+                builtin_name,
+                input_dimension=input_dim,
+                parameters_id=info.default_parameters_id,
+                parameters=parameters,
+            )


### PR DESCRIPTION
Allow the factory and `create()` to take a pre-built `ProbInput` or `Parameters` object, alongside the existing `input_id`/`parameters_id` named-spec forms. Within each pair the two forms are mutually exclusive. This gives users a construction path for custom inputs and parameters without bypassing the factory.

- Add `prob_input` and `parameters` keyword arguments to the factory and `create()`
- Raise `ValueError` when `input_id` and `prob_input` (or `parameters_id` and `parameters`) are both supplied
- Extract dimension, input, and parameter resolution into helper functions
- Validate that a supplied prob_input's dimension agrees with the requested or fixed dimension
- Type-check supplied prob_input and parameters at the factory entrance
- Remove helper function `_instantiate()`; the factory now builds the UQTestFun directly from resolved components
- Update the test suite to cover the object-form construction paths

---

Closes: #525
Ref: #502