### PR TITLE
refactor(parameters): add copy methods and protected instances

### DIFF
--- a/src/uqtestfuns/core/parameters.py
+++ b/src/uqtestfuns/core/parameters.py
@@ -10,6 +10,7 @@ import textwrap
 import warnings
 
 from collections.abc import Mapping, Iterator
+from copy import copy, deepcopy
 from tabulate import tabulate
 from typing import Any, Dict, List, Optional
 
@@ -369,11 +370,13 @@ class Parameters(Mapping):
         self,
         values: Mapping[str, Any],
         name: Optional[str] = None,
-        keyword_descriptions: Optional[Mapping[str, str]] = None,
+        keyword_descriptions: Optional[Mapping[str, Optional[str]]] = None,
+        _protected: bool = False,
     ):
         # --- Assign values
         self._values = dict(values)
         self._name = name
+        self._protected = _protected
 
         # --- Process the keyword descriptions
         kw_desc = dict(keyword_descriptions or {})
@@ -400,6 +403,28 @@ class Parameters(Mapping):
         return self._name
 
     # --- Public methods
+    def copy(self, name: str | None = None) -> "Parameters":
+        """Return an independent, unprotected copy safe to modify.
+
+        All values are deep-copied, so editing the returned instance never
+        affects the source. Use an explicit ``copy.copy(obj)`` if you
+        specifically want a shallow copy.
+
+        Parameters
+        ----------
+        name : str, optional
+            Name for the new instance. Defaults to None (unnamed).
+
+        Returns
+        -------
+        Parameters
+            A new, unprotected Parameters instance.
+        """
+        new = deepcopy(self)  # routes through __deepcopy__
+        if name is not None:
+            new._name = name
+        return new
+
     def describe(self, key: str) -> Optional[str]:
         """Get the description of a parameter.
 
@@ -420,6 +445,44 @@ class Parameters(Mapping):
             raise KeyError(f"Unknown parameter '{key}'") from exc
 
     # --- Dunder methods
+    def __copy__(self) -> "Parameters":
+        """Create a shallow copy of the Parameters instance.
+
+        Returns
+        -------
+        Parameters
+            A new Parameters instance with shallow copies of the values
+            and keyword descriptions dictionaries.
+        """
+        values_ = {k: copy(v) for k, v in self._values.items()}
+        kw_descriptions = copy(self._keyword_descriptions)
+        return Parameters(
+            values=values_,
+            keyword_descriptions=kw_descriptions,
+        )
+
+    def __deepcopy__(self, memo) -> "Parameters":
+        """Create a deep copy of the Parameters instance.
+
+        Parameters
+        ----------
+        memo : dict
+            A dictionary of objects already copied during the current
+            copying pass.
+
+        Returns
+        -------
+        Parameters
+            A new Parameters instance with deep copies of all values
+            and keyword descriptions.
+        """
+        values_ = {k: deepcopy(v, memo) for k, v in self._values.items()}
+        kw_descriptions = deepcopy(self._keyword_descriptions, memo)
+        return Parameters(
+            values=values_,
+            keyword_descriptions=kw_descriptions,
+        )
+
     def __getitem__(self, key: str) -> Any:
         """Get the value of a parameter by name.
 
@@ -434,6 +497,32 @@ class Parameters(Mapping):
             The value of the parameter.
         """
         return self._values[key]
+
+    def __setitem__(self, key: str, value: Any):
+        """Set the value of a parameter by name.
+
+        Parameters
+        ----------
+        key : str
+            The name of the parameter.
+        value : Any
+            The new value for the parameter.
+
+        Raises
+        ------
+        ParametersProtectedError
+            If the parameter set is protected (i.e., comes from the library).
+            Protected parameter sets cannot be modified directly; use
+            `.copy()` to create an editable copy first.
+        KeyError
+            If the parameter name does not exist in the parameter set.
+        """
+        if self._protected:
+            raise ParametersProtectedError(
+                _format_protection_message(self._name, key)
+            )
+
+        self._values[key] = value
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._values)
@@ -460,6 +549,7 @@ class Parameters(Mapping):
             "values": self._values,  # Avoid returning a copy
             "name": self.name,
             "keyword_descriptions": descriptions,
+            "_protected": self._protected,
         }
         attrs_str = ", ".join(f"{k}={v!r}" for k, v in attrs.items())
 
@@ -484,7 +574,8 @@ class Parameters(Mapping):
         table += tabulate(
             rows,
             headers=header_names,
-            stralign="center",
+            colalign=("center", "center", "center", "left"),
+            maxcolwidths=[None, None, None, 30],
             disable_numparse=True,
         )
 
@@ -530,3 +621,40 @@ def _create_list(
         )
 
     return list_values
+
+
+class ParametersProtectedError(TypeError):
+    """Raised when modifying a library-supplied (protected) parameter set.
+
+    Obtain an editable copy via create_parameters() or .copy() first.
+    """
+
+
+def _format_protection_message(name: str | None, key: str) -> str:
+    """Format an error message for protected parameter modification attempts.
+
+    Parameters
+    ----------
+    name : str, optional
+        The name of the parameter set. If None, "<unnamed>" is used.
+    key : str
+        The name of the parameter that was attempted to be modified.
+
+    Returns
+    -------
+    str
+        A formatted error message explaining why the modification failed
+        and how to create an editable copy of the parameter set.
+    """
+    set_name = name or "<unnamed>"
+    return (
+        f"\nCannot modify parameter {key!r} of {set_name!r}:\n"
+        f"this parameter set comes from the library and is protected\n"
+        f"to preserve its correspondence with the published source.\n"
+        f"\n"
+        f"To experiment with different values, get a working copy \n"
+        f"from a an existing function instance:\n"
+        f"\n"
+        f"    p = f.parameters.copy()\n"
+        f"    p[{key!r}] = <new value>\n"
+    )

--- a/src/uqtestfuns/core/registry/resolver.py
+++ b/src/uqtestfuns/core/registry/resolver.py
@@ -208,6 +208,7 @@ def resolve_parameters(
         name=name,
         keyword_descriptions=kw_descriptions,
         values=values,
+        _protected=True,  # This parameter instance is protected
     )
 
 

--- a/tests/builtin_test_functions/test_coffee_cup.py
+++ b/tests/builtin_test_functions/test_coffee_cup.py
@@ -11,7 +11,6 @@ import pytest
 
 from conftest import assert_call
 from uqtestfuns import CoffeeCup
-from uqtestfuns.core.parameters import Parameters
 
 
 @pytest.mark.parametrize(
@@ -21,18 +20,10 @@ def test_solve_ivp_kwargs(solve_ivp_kwargs):
     """Test passing additional kwargs for solve_ivp."""
 
     # Create an instance
-    fun = CoffeeCup()
+    fun = CoffeeCup(parameters=CoffeeCup().parameters.copy())
 
-    # Add the new parameter
-    params = Parameters(
-        {
-            "temp_0": fun.parameters["temp_0"],
-            "solve_ivp_kwargs": solve_ivp_kwargs,
-        }
-    )
-
-    # TODO: This is a temporary solution, should be better accessed
-    fun._parameters = params
+    # Create the new parameter
+    fun.parameters["solve_ivp_kwargs"] = solve_ivp_kwargs
 
     # Generate test points
     xx = fun.prob_input.get_sample(10)
@@ -44,18 +35,10 @@ def test_solve_ivp_kwargs(solve_ivp_kwargs):
 @pytest.mark.parametrize("temp_0", [50.0, 60.0, 70.0])
 def test_parameter_temp0(temp_0):
     # Create an instance
-    fun = CoffeeCup()
+    fun = CoffeeCup(parameters=CoffeeCup().parameters.copy())
 
     # Add the new parameter
-    params = Parameters(
-        {
-            "temp_0": temp_0,
-            "solve_ivp_kwargs": None,
-        }
-    )
-
-    # TODO: This is a temporary solution, should be better accessed
-    fun._parameters = params
+    fun.parameters["temp_0"] = temp_0
 
     # Generate test points
     xx = fun.prob_input.get_sample(10)

--- a/tests/builtin_test_functions/test_rosenbrock.py
+++ b/tests/builtin_test_functions/test_rosenbrock.py
@@ -10,7 +10,6 @@ import numpy as np
 import pytest
 
 from uqtestfuns import Rosenbrock
-from uqtestfuns.core.parameters import Parameters
 
 
 def test_one_dimensional():
@@ -45,15 +44,15 @@ def test_optimum_value_a_eq_1(input_dimension):
 @pytest.mark.parametrize("input_dimension", [2, 3, 10])
 def test_optimum_value_a_eq_0(input_dimension):
     """Test the optimum value, regardless of the dimension, when a == 0"""
-    my_fun = Rosenbrock(input_dimension=input_dimension)
+    my_fun = Rosenbrock(input_dimension)
+    # Create an editable parameter values
+    params = my_fun.parameters.copy()
+    my_fun = Rosenbrock(input_dimension, parameters=params)
 
-    # TODO: This is a workaround
-    params = {**my_fun.parameters}
-    params["a"] = 0
-    params_ = Parameters(params)
-    my_fun._parameters = params_
+    # Change the parameter value
+    my_fun.parameters["a"] = 0
 
-    # The optima of the function when a = 0 is not at 1.0's
+    # The optimum of the function when a = 0 is not at 1.0's
     xx = np.ones((1, my_fun.input_dimension))
     yy = my_fun(xx)
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -15,7 +15,7 @@ import string
 import uqtestfuns as uqtf
 
 from uqtestfuns import UQTestFun, Marginal
-from uqtestfuns.core import Parameters
+from uqtestfuns.core.parameters import Parameters, ParametersProtectedError
 from uqtestfuns.core.prob_input.probabilistic_input_new import ProbInput
 from uqtestfuns.api import create
 from uqtestfuns.core.registry.entries import UQTestFunInfo
@@ -245,6 +245,26 @@ class TestConstruction:
         with pytest.raises(ValueError):
             _ = getattr(uqtf, builtin_name)(input_dim, parameters_id=random_id)
 
+    def test_set_parameter(self, builtin_name: str, info: UQTestFunInfo):
+        """Test setting a value of a parameter raises an exception."""
+        if info.default_parameters_id is None:
+            pytest.skip(f"{builtin_name} does not support parameterization")
+
+        if info.input_dimension is None:
+            input_dim = 5
+        else:
+            input_dim = info.input_dimension
+
+        # Create an instance
+        f = create(builtin_name, input_dim)
+
+        # Assertion
+        assert f.parameters is not None
+        assert isinstance(f.parameters, Parameters)
+        key = next(iter(f.parameters.keys()))
+        with pytest.raises(ParametersProtectedError):
+            f.parameters[key] = 1.0
+
 
 class TestCall:
 
@@ -359,7 +379,7 @@ class TestProbInputObject:
         f_2 = create(builtin_name, prob_input=prob_input)
 
         # Generate function values
-        sample_size = 1000
+        sample_size = 100
         seed = 42
         yy_1 = f_1.get_sample(sample_size, seed)
         yy_2 = f_2.get_sample(sample_size, seed)
@@ -448,7 +468,7 @@ class TestParametersObject:
         f_2 = create(builtin_name, input_dim, parameters=parameters)
 
         # Generate function values
-        sample_size = 1000
+        sample_size = 100
         seed = 42
         yy_1 = f_1.get_sample(sample_size, seed)
         yy_2 = f_2.get_sample(sample_size, seed)

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -2,6 +2,7 @@
 Test suite for the Parameters class.
 """
 
+import copy
 import numpy as np
 import pytest
 
@@ -178,3 +179,45 @@ class TestPrint:
 
         # Assertion
         assert f"{array_value.shape} array" in str(params)
+
+
+class TestCopy:
+    """Test the copy functionality of Parameters class."""
+
+    def test_shallow(self, num_params):
+        """Test making shallow copy."""
+        # Create a test instance
+        values, descriptions = create_values(num_params)
+        values["mutable"] = [[1, 2], [3, 4]]
+        name_ori = "original"
+        params = Parameters(values, name_ori, descriptions)
+
+        # Create a copy
+        params_cp = copy.copy(params)
+        # Mutate mutable nested value
+        params_cp["mutable"][0].append(99)
+
+        # Assertions
+        assert params.name == name_ori
+        assert params is not params_cp
+        assert params_cp["mutable"] == params["mutable"]
+
+    def test_deep(self, num_params):
+        """Test making deep copy."""
+        # Create a test instance
+        values, descriptions = create_values(num_params)
+        values["mutable"] = [[1, 2], [3, 4]]
+        name_ori = "original"
+        params = Parameters(values, name_ori, descriptions)
+
+        # Create a deep copy
+        name_cp = "copy"
+        params_cp = params.copy(name_cp)
+        # Mutate mutable nested value
+        params_cp["mutable"][0].append(99)
+
+        # Assertions
+        assert params.name == name_ori
+        assert params_cp.name == name_cp
+        assert params is not params_cp
+        assert params_cp["mutable"] != params["mutable"]


### PR DESCRIPTION
Add copy support to the `Parameters` class and a protection flag that guards library-supplied parameter sets from modification, preserving their correspondence with the published values they represent. Protected sets cannot be modified in place; users obtain an editable copy to experiment with different values.

- Implement `__copy__` (shallow) and `__deepcopy__` (deep) honoring the standard copy protocol
- Add `copy()` returning an independent, unprotected copy safe to modify (deep by default, so edits never affect the source), with an optional `name` argument
- Block item assignment on protected instances in `__setitem__`
- Introduce `ParametersProtectedError`, pointing users to `copy()` for an editable working copy
- Mark instances built from a registered spec as protected in the resolver
- Update the test suite

Closes: #524
Ref: #502