### PR TITLE
feat(helpers): add list_parameters() discovery helper

### DIFF
--- a/src/uqtestfuns/__init__.py
+++ b/src/uqtestfuns/__init__.py
@@ -26,6 +26,7 @@ from .meta import UQMetaTestFun
 from .helpers import list_functions
 
 from . import api
+from .api import create, list_parameters
 
 if sys.version_info >= (3, 8):
     from importlib import metadata
@@ -49,6 +50,8 @@ __all__ = [
     "UQMetaTestFun",
     "list_functions",
     "api",
+    "create",
+    "list_parameters",
 ]
 
 

--- a/src/uqtestfuns/api.py
+++ b/src/uqtestfuns/api.py
@@ -7,8 +7,8 @@ from tabulate import tabulate as tbl
 from uqtestfuns.core.prob_input.probabilistic_input_new import ProbInput
 from uqtestfuns.core.parameters import Parameters
 from uqtestfuns.core.uqtestfun import UQTestFun
-from uqtestfuns.core.registry.entries import UQTestFunInfo
 from uqtestfuns.core.registry import get_registry
+from uqtestfuns.core.registry.entries import UQTestFunInfo
 
 SUPPORTED_TAGS = (
     "sensitivity",
@@ -84,6 +84,106 @@ def create(
         return factory(input_dimension, **kwargs)
     else:
         return factory(**kwargs)
+
+
+def list_parameters(
+    name: str,
+    show: str = "all",
+    *,
+    parameters_id: str | None = None,
+):
+    """Display parameter information for a UQ test function.
+
+    This function prints information about the parameters of a specified
+    test function, including parameter keywords and available parameter sets.
+
+    Parameters
+    ----------
+    name : str
+        The name of the test function to query.
+    show : str, optional
+        Controls which information to display. Options are:
+        - 'all': Display both parameter keywords and available sets.
+        - 'keywords': Display only parameter keywords.
+        - 'sets': Display only available parameter sets.
+        Default is 'all'.
+    parameters_id : str, optional
+        Identifier for a specific parameter set. If specified, only the
+        keywords for that parameter set are shown (show is set to 'keywords').
+        If None, uses the default parameter set. Default is None.
+
+    Returns
+    -------
+    None
+        This function prints directly to stdout and does not return a value.
+    """
+
+    # Get the test function information
+    reg = get_registry()
+    info = reg[name]
+
+    # Skip if the function is not parameterized
+    if info.default_parameters_id is None:
+        print(f"\n{name} has no parameters.")
+        return
+
+    header = f"Parameters for {name}"
+    print(f"\n{header}")
+    print("=" * len(header))
+
+    # Get default parameter, if not specified
+    if parameters_id is None:
+        parameters_id = info.default_parameters_id
+    else:
+        show = "keywords"
+
+    parameters_keywords = info.parameters_keywords[parameters_id]
+
+    # Print the tabulated keyword descriptions
+    if show in ("all", "keywords"):
+        headers = ["No", "Name", "Type", "Description"]
+        rows = [
+            [
+                i + 1,
+                k,
+                "callable" if v["type"] is callable else v["type"].__name__,
+                v["description"] or "—",
+            ]
+            for i, (k, v) in enumerate(parameters_keywords.items())
+        ]
+        print("\nKeywords:")
+
+        out = tbl(
+            rows,
+            headers=headers,
+            tablefmt="simple",
+            colalign=("center", "center", "center", "left"),
+            maxcolwidths=[None, None, None, 50],
+            disable_numparse=True,
+        )
+
+        print(out)
+
+    if show in ("all", "sets"):
+        available_ids = info.available_parameters_ids
+        headers = ["No", "ID", "Description"]
+        rows = [
+            [i + 1, param_id, desc or "—"]
+            for i, (param_id, desc) in enumerate(available_ids.items())
+        ]
+        print("\nAvailable sets:")
+
+        out = tbl(
+            rows,
+            headers=headers,
+            tablefmt="simple",
+            colalign=("center", "left", "left"),
+            maxcolwidths=[None, None, 50],
+            disable_numparse=True,
+        )
+        out += f"\nDefault: {info.default_parameters_id}"
+
+        print(out)
 
 
 def list_functions(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,9 +5,13 @@ All global fixtures are defined here.
 """
 
 import numpy as np
+import pytest
 import string
+
 from typing import List, Callable, Any, Dict
 
+from uqtestfuns.core.registry import get_registry
+from uqtestfuns.core.registry.entries import UQTestFunInfo
 from uqtestfuns.core.prob_input.utils import SUPPORTED_MARGINALS
 from uqtestfuns.core.prob_input.marginal import Marginal
 
@@ -125,3 +129,14 @@ def assert_call(fct: Callable[..., Any], *args: Any, **kwargs: Any) -> None:
             f"The function was not called properly. "
             f"It raised the exception:\n\n {e.__class__.__name__}: {e}"
         )
+
+
+@pytest.fixture(params=list(get_registry()))
+def builtin_name(request) -> str:
+
+    return request.param
+
+
+@pytest.fixture
+def info(builtin_name: str) -> UQTestFunInfo:
+    return get_registry()[builtin_name]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,32 @@
+import pytest
+import uqtestfuns as uqtf
+
+from uqtestfuns.core.registry.entries import UQTestFunInfo
+
+from conftest import assert_call
+
+
+class TestListParameters:
+    """All tests related to the list_parameters function."""
+
+    def test_list_parameters(self, builtin_name: str):
+        """Test calling list_parameters with a builtin function name."""
+        assert_call(uqtf.list_parameters, builtin_name)
+
+    @pytest.mark.parametrize("show", ["keywords", "all", "sets"])
+    def test_list_parameters_show(self, builtin_name: str, show: str):
+        """Test calling list_parameters showing keywords only."""
+        assert_call(uqtf.list_parameters, builtin_name, show=show)
+
+    def test_list_parameters_id(self, builtin_name: str, info: UQTestFunInfo):
+        """Test calling list_parameters with id."""
+        if info.default_parameters_id is None:
+            pytest.skip("No default parameters available for this function")
+
+        for param_id in info.available_parameters_ids:
+            assert_call(
+                uqtf.list_parameters,
+                builtin_name,
+                show="id",
+                parameters_id=param_id,
+            )

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -19,7 +19,6 @@ from uqtestfuns.core.parameters import Parameters, ParametersProtectedError
 from uqtestfuns.core.prob_input.probabilistic_input_new import ProbInput
 from uqtestfuns.api import create
 from uqtestfuns.core.registry.entries import UQTestFunInfo
-from uqtestfuns.core.registry import get_registry
 
 
 def random_string(length):
@@ -53,17 +52,6 @@ def assert_equal(f1: UQTestFun, f2: UQTestFun) -> None:
                 assert np.array_equal(v_1, v_2)
             else:
                 assert v_1 == v_2
-
-
-@pytest.fixture(params=list(get_registry()))
-def builtin_name(request) -> str:
-
-    return request.param
-
-
-@pytest.fixture
-def info(builtin_name: str) -> UQTestFunInfo:
-    return get_registry()[builtin_name]
 
 
 @pytest.fixture(params=[1, 3, 5])


### PR DESCRIPTION
Add `list_parameters(name)`, which prints a function's parameter specifications from its registry entry: a keywords table (name, type, description) and a table of available parameter sets with the default flagged. Display-only, mirroring `list_functions()` so users never query the registry directly.

- Add `list_parameters()` to `helpers.py` and export it from `__init__.py`
- Export the existing `create()` at top level (`uqtf.create(...)`)
- Move the shared `builtin_name` and `info` fixtures into `conftest.py` so they are reusable across test modules
- Update the test suite to use the shared fixtures

Closes: #530
Ref: #502