### PR TITLE
refactor(core): add parameter names to Marginal __str__

### DIFF
--- a/src/uqtestfuns/core/prob_input/marginal.py
+++ b/src/uqtestfuns/core/prob_input/marginal.py
@@ -34,6 +34,8 @@ from .utils import (
     get_pdf_values,
     get_cdf_values,
     get_icdf_values,
+    get_display_name,
+    get_parameter_names,
 )
 
 __all__ = ["Marginal"]
@@ -166,6 +168,25 @@ class Marginal:
         return self._upper
 
     # --- Public methods
+    def display(self) -> str:
+        """Display the distribution formula.
+
+        Returns
+        -------
+        str
+            The distribution formula, e.g., "Normal(mu=0.0, sigma=1.0)".
+        """
+        display_name = get_display_name(self.distribution)
+        param_names = get_parameter_names(self.distribution)
+
+        items = [
+            f"{name}={value:.6g}"
+            for name, value in zip(param_names, self.parameters, strict=True)
+        ]
+        distribution = f"{display_name}({', '.join(items)})"
+
+        return distribution
+
     def pdf(self, xx: Union[float, np.ndarray]) -> np.ndarray:
         """Compute the probability density function of the distribution.
 
@@ -343,6 +364,21 @@ class Marginal:
             return False
 
         return True
+
+    def __str__(self) -> str:
+        """Return a human-readable summary of the Marginal instance.
+
+        Returns
+        -------
+        str
+            The human-readable summary of the instance.
+        """
+        name = self.name
+        distribution = self.display()
+        if name is None:
+            return distribution
+
+        return f"{name} ~ {distribution}"
 
     def __repr__(self) -> str:
         """Return the unambiguous string representation of the instance.

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/beta.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/beta.py
@@ -28,8 +28,9 @@ from .utils import verify_param_nums, postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "beta"
-
+DISPLAY_NAME = "Beta"
 NUM_PARAMS = 4
+PARAM_NAMES = ("alpha", "beta", "a", "b")
 
 
 def verify_parameters(parameters: ARRAY_FLOAT) -> None:
@@ -58,7 +59,7 @@ def verify_parameters(parameters: ARRAY_FLOAT) -> None:
     # Check validity of values
     if parameters[0] <= 0.0 or parameters[1] <= 0.0:
         raise ValueError(
-            f"The shape parameters {parameters[0]} and {parameters[1]}"
+            f"The shape parameters {parameters[0]} and {parameters[1]} "
             f"must be larger than 0.0 (positive)!"
         )
 

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/exponential.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/exponential.py
@@ -16,8 +16,9 @@ from .utils import verify_param_nums, postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "exponential"
-
+DISPLAY_NAME = "Exp"
 NUM_PARAMS = 1
+PARAM_NAMES = ("lambda",)
 
 
 def verify_parameters(parameters: ARRAY_FLOAT) -> None:

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/gumbel.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/gumbel.py
@@ -19,8 +19,9 @@ from .utils import verify_param_nums, postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "gumbel"
-
+DISPLAY_NAME = "Gumbel"
 NUM_PARAMS = 2
+PARAM_NAMES = ("mu", "beta")
 
 
 def verify_parameters(parameters: ARRAY_FLOAT) -> None:

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/logitnormal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/logitnormal.py
@@ -23,8 +23,9 @@ from .utils import verify_param_nums, postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "logitnormal"
-
+DISPLAY_NAME = "LogitNormal"
 NUM_PARAMS = 2
+PARAM_NAMES = ("mu", "sigma")
 
 
 def verify_parameters(parameters: ARRAY_FLOAT) -> None:

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/lognormal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/lognormal.py
@@ -25,8 +25,9 @@ from .utils import verify_param_nums, postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "lognormal"
-
+DISPLAY_NAME = "LogNormal"
 NUM_PARAMS = 2
+PARAM_NAMES = ("mu", "sigma")
 
 
 def verify_parameters(parameters: ARRAY_FLOAT) -> None:

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/normal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/normal.py
@@ -16,8 +16,9 @@ from .utils import verify_param_nums, postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "normal"
-
+DISPLAY_NAME = "Normal"
 NUM_PARAMS = 2
+PARAM_NAMES = ("mu", "sigma")
 
 
 def verify_parameters(parameters: ARRAY_FLOAT) -> None:

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/triangular.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/triangular.py
@@ -16,8 +16,9 @@ from .utils import verify_param_nums, postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "triangular"
-
+DISPLAY_NAME = "Triangular"
 NUM_PARAMS = 3
+PARAM_NAMES = ("a", "b", "c")
 
 
 def verify_parameters(parameters: ARRAY_FLOAT) -> None:

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/trunc_gumbel.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/trunc_gumbel.py
@@ -19,8 +19,9 @@ from .utils import verify_param_nums, postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "trunc-gumbel"
-
+DISPLAY_NAME = "Trunc-Gumbel"
 NUM_PARAMS = 4
+PARAM_NAMES = ("mu", "beta", "a", "b")
 
 
 def _get_parameters(

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/trunc_normal.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/trunc_normal.py
@@ -43,8 +43,9 @@ from .utils import verify_param_nums, postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "trunc-normal"
-
+DISPLAY_NAME = "Trunc-Normal"
 NUM_PARAMS = 4
+PARAM_NAMES = ("mu", "sigma", "a", "b")
 
 
 def _get_parameters(

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/uniform.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/uniform.py
@@ -11,8 +11,9 @@ from .utils import postprocess_icdf, verify_param_nums
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "uniform"
-
+DISPLAY_NAME = "Unif"
 NUM_PARAMS = 2
+PARAM_NAMES = ("a", "b")
 
 
 def verify_parameters(parameters: ARRAY_FLOAT) -> None:

--- a/src/uqtestfuns/core/prob_input/utils.py
+++ b/src/uqtestfuns/core/prob_input/utils.py
@@ -152,3 +152,39 @@ def get_icdf_values(
     )
 
     return out
+
+
+def get_display_name(distribution: str) -> str:
+    """Get the display name of the distribution.
+
+    Parameters
+    ----------
+    distribution : str
+        Name of the distribution.
+
+    Returns
+    -------
+    str
+        Display name of the distribution.
+    """
+    distribution_module = get_distribution_module(distribution)
+
+    return distribution_module.DISPLAY_NAME
+
+
+def get_parameter_names(distribution: str) -> Tuple[str]:
+    """Get the parameter names of the distribution.
+
+    Parameters
+    ----------
+    distribution : str
+        Name of the distribution.
+
+    Returns
+    -------
+    Tuple[str]
+        Parameter names of the distribution.
+    """
+    distribution_module = get_distribution_module(distribution)
+
+    return distribution_module.PARAM_NAMES


### PR DESCRIPTION
Improve string representation for the `Marginal` class to display the parameter names closer to the mathematical notation.

---

Closes: #463
Ref: #544