### PR TITLE
refactor(marginal): update `repr` of `Marginal` for round-tripping

### DIFF
--- a/src/uqtestfuns/core/prob_input/marginal.py
+++ b/src/uqtestfuns/core/prob_input/marginal.py
@@ -392,7 +392,7 @@ class Marginal:
         # Get the value of the constructor arguments
         attrs = {
             "distribution": self.distribution,
-            "parameters": self.parameters,
+            "parameters": self.parameters.tolist(),
             "name": self.name,
             "description": self.description,
         }

--- a/tests/test_marginal.py
+++ b/tests/test_marginal.py
@@ -10,7 +10,7 @@ from uqtestfuns.core.prob_input.utils import SUPPORTED_MARGINALS
 
 
 def _id_distribution(distribution):
-    return f"{distribution:<12}"
+    return f"{distribution:>12}"
 
 
 @pytest.fixture(params=SUPPORTED_MARGINALS, ids=_id_distribution)
@@ -83,3 +83,12 @@ def test_str(marginal: Marginal):
     name = marginal.name
     if name is not None:
         assert name in my_str
+
+
+def test_repr_round_trip(marginal: Marginal):
+    """Test that the repr of a Marginal instance can be round-tripped."""
+    my_repr = repr(marginal)
+    marginal_from_repr = eval(my_repr)
+
+    # Assertion
+    assert marginal_from_repr == marginal


### PR DESCRIPTION
Update `parameters` in `attrs` to call `.tolist()` within the `Marginal` class to ensure round-tripping of `repr` of the instances.

---

Closes: #545
Ref: #544