### PR TITLE
refactor(prob_input): improve `__str__` of `ProbInput`

### DIFF
--- a/src/uqtestfuns/core/prob_input/marginal.py
+++ b/src/uqtestfuns/core/prob_input/marginal.py
@@ -167,14 +167,14 @@ class Marginal:
         """
         return self._upper
 
-    # --- Public methods
-    def display(self) -> str:
+    @property
+    def notation(self) -> str:
         """Display the distribution formula.
 
         Returns
         -------
         str
-            The distribution formula, e.g., "Normal(mu=0.0, sigma=1.0)".
+            The distribution notation, e.g., "Normal(mu=0.0, sigma=1.0)".
         """
         display_name = get_display_name(self.distribution)
         param_names = get_parameter_names(self.distribution)
@@ -183,10 +183,11 @@ class Marginal:
             f"{name}={value:.6g}"
             for name, value in zip(param_names, self.parameters, strict=True)
         ]
-        distribution = f"{display_name}({', '.join(items)})"
+        notation_ = f"{display_name}({', '.join(items)})"
 
-        return distribution
+        return notation_
 
+    # --- Public methods
     def pdf(self, xx: Union[float, np.ndarray]) -> np.ndarray:
         """Compute the probability density function of the distribution.
 
@@ -374,11 +375,10 @@ class Marginal:
             The human-readable summary of the instance.
         """
         name = self.name
-        distribution = self.display()
         if name is None:
-            return distribution
+            return self.notation
 
-        return f"{name} ~ {distribution}"
+        return f"{name} ~ {self.notation}"
 
     def __repr__(self) -> str:
         """Return the unambiguous string representation of the instance.

--- a/src/uqtestfuns/core/prob_input/probabilistic_input.py
+++ b/src/uqtestfuns/core/prob_input/probabilistic_input.py
@@ -15,7 +15,7 @@ import numpy as np
 from tabulate import tabulate
 from typing import Any, List, Optional, Sequence, Tuple, Union
 
-from uqtestfuns.core.prob_input.marginal import FIELD_NAMES, Marginal
+from uqtestfuns.core.prob_input.marginal import Marginal
 
 __all__ = ["ProbInput"]
 
@@ -361,36 +361,49 @@ class ProbInput:
 
         return f"{class_name}({attrs_str})"
 
-    def __str__(self):
-        """Return a human-readable string representation of the instance."""
-        if self.name is None or self.name == "":
+    def __str__(self) -> str:
+        """Return a human-readable string representation of the instance.
+
+        Returns
+        -------
+        str
+            The tabulated summary of the probabilistic input
+            and its constituent marginals.
+        """
+        name = self.name
+        if name is None or name == "":
             table = f"Dimension : {self.dimension}\n"
         else:
-            table = f"Name      : {self.name}\n"
+            table = f"Name      : {name}\n"
             table += f"Dimension : {self.dimension}\n"
         table += "Marginals :\n\n"
 
-        # Get the header names
-        header_names = [name.capitalize() for name in FIELD_NAMES]
-        header_names.insert(0, "No.")
+        # Check if the description is empty for all marginals
+        empty_description = all(not m.description for m in self.marginals)
 
         # Get the values for each field as a list
         rows = []
         for i, m in enumerate(self.marginals):
-            row: List[Any] = [i + 1]
-            for field_name in FIELD_NAMES:
-                attr_value = getattr(m, field_name)
-                if attr_value is None:
-                    attr_value = "-"
-                row.append(attr_value)
+            row: List[Any] = [
+                i + 1,
+                m.name,
+                m.notation,
+            ]
+            # Append description if one is available
+            if not empty_description:
+                row.append(m.description or "-")
             rows.append(row)
 
-        # Create a table of marginals details
+        # Create a table of marginals
+        header_names = ["No.", "Variable", "Distribution"]
+        col_alignment = ["center", "center", "left"]
+        if not empty_description:
+            header_names.append("Description")
+            col_alignment.append("left")
         table += tabulate(
             rows,
             headers=header_names,
-            colalign=["center" for _ in range(len(header_names) - 1)]
-            + ["left"],
+            colalign=col_alignment,
             disable_numparse=True,
         )
 

--- a/tests/test_prob_input.py
+++ b/tests/test_prob_input.py
@@ -628,7 +628,7 @@ class TestPrint:
         prob_input = ProbInput(marginals)
 
         # Assertion
-        assert str(prob_input).count("   -") == dimension
+        assert "Description" not in str(prob_input)
 
 
 class TestValidation:


### PR DESCRIPTION
The string representation now tabulates the marginals, showing each variable alongside its distribution and parameters, and includes the description column only when at least one marginal has a description.

The `display()` method of `Marginal` becomes the `notation` property, which returns the distribution and its parameters without the variable name; a property reads as a value rather than as a command to print.

Additionally:

- Treat an empty description as absent when deciding whether to include the column.
- Update the tests to match the new representation.

---

Closes: #464
Ref: #544