### PR TITLE
refactor(api)!: remove tablefmt="html" special case from list_functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for function discovery without importing any Python modules eagerly.
 - `list_functions()` now supports filtering by `input_dimension`,
   `output_dimension`, `parameterized`, and `tag`, and can render its
-  output as a grid or HTML table (`tablefmt`) or return a plain list of
-  function names (`tabulate=False`).
+  output as a table in any `tabulate`-supported format (`tablefmt`) or
+  return a plain list of bare function names (`tabulate=False`).
 - `list_parameters(name)`, the companion to `list_functions()` for
   browsing a function's available parameter sets: `tabulate=True`
   (default) prints a table of parameter-set IDs and descriptions along
@@ -32,6 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Registry` instead of walking `UQTestFunABC` subclasses; `helpers.py`
   has been removed with `api.py` now the sole home for user-facing
   discovery functions.
+- **Breaking:** `list_functions(tablefmt="html")` no longer returns an
+  HTML string as a special case; `tabulate=True` now always prints the
+  table and returns `None`, regardless of `tablefmt`.
+- **Breaking:** `list_functions(tabulate=False)` now returns bare
+  function names instead of constructor-style strings with a `"()"`
+  suffix, so results compose directly with `create()`/`getattr()`; the
+  `"()"` suffix still appears in the printed table's Constructor
+  column.
 - The string representation of `ProbInput` now tabulates its marginals
   (variable, distribution, parameters), including a description column
   only when at least one marginal has a description; `Marginal`'s

--- a/src/uqtestfuns/api.py
+++ b/src/uqtestfuns/api.py
@@ -1,3 +1,15 @@
+"""Public API for creating and discovering UQ test functions.
+
+This module provides the main user-facing entry points for working with the
+built-in UQTestFuns registry. It exposes utilities to instantiate
+test functions by name, inspect the available function catalog,
+list the available probabilistic input specifications,
+and list predefined parameter sets for parameterized functions.
+
+The functions in this module are thin convenience wrappers around the registry
+system.
+"""
+
 from __future__ import annotations
 
 from typing import Dict, List, Literal, Optional, overload, Union
@@ -81,14 +93,50 @@ def create(
         return factory(**kwargs)
 
 
+@overload
 def list_functions(
     input_dimension: Optional[Union[str, int]] = None,
     output_dimension: Optional[int] = None,
     parameterized: Optional[bool] = None,
     tag: Optional[str] = None,
+    *,
+    tabulate: Literal[True] = True,
+    tablefmt: str = "grid",
+) -> None: ...
+
+
+@overload
+def list_functions(
+    input_dimension: Optional[Union[str, int]] = None,
+    output_dimension: Optional[int] = None,
+    parameterized: Optional[bool] = None,
+    tag: Optional[str] = None,
+    *,
+    tabulate: Literal[False],
+) -> List[str]: ...
+
+
+@overload
+def list_functions(
+    input_dimension: Optional[Union[str, int]] = None,
+    output_dimension: Optional[int] = None,
+    parameterized: Optional[bool] = None,
+    tag: Optional[str] = None,
+    *,
     tabulate: bool = True,
     tablefmt: str = "grid",
-) -> Optional[Union[List[str], str]]:
+) -> Optional[List[str]]: ...
+
+
+def list_functions(
+    input_dimension: Optional[Union[str, int]] = None,
+    output_dimension: Optional[int] = None,
+    parameterized: Optional[bool] = None,
+    tag: Optional[str] = None,
+    *,
+    tabulate: bool = True,
+    tablefmt: str = "grid",
+) -> Optional[List[str]]:
     """List available UQ test functions with optional filtering.
 
     This function queries the registry and returns a list of available
@@ -116,22 +164,20 @@ def list_functions(
         'integration'. If None, no filtering by tag is applied.
         Default is None.
     tabulate : bool, optional
-        If True, print results as a formatted table and return None. If False,
-        return a sorted list of function constructor names. Default is True.
+        If ``True``, print results as a formatted table and return ``None``.
+        If ``False``, return a sorted list of function names.
+        Default is ``True``.
     tablefmt : str, optional
-        Format for the table output when `tabulate` is True. Follows the
-        formats supported by the `tabulate` library (e.g., 'grid', 'html',
-        'latex'). Default is 'grid'.
+        Format for the table output when ``tabulate`` is True. Follows the
+        formats supported by the `tabulate` library (e.g., 'grid', 'simple',
+        'github'). Default is 'grid'.
 
     Returns
     -------
-    None, list of str, or str
-        - If `tabulate` is True and `tablefmt` is not 'html': prints the table
-          and returns None.
-        - If `tabulate` is True and `tablefmt` is 'html': returns the table
-          as an HTML string.
-        - If `tabulate` is False: returns a sorted list of function constructor
-          names with parentheses (e.g., ['FunctionName()', ...]).
+    None or List[str]
+        - If ``tabulate`` is ``True``: prints the table and returns ``None``.
+        - If ``tabulate`` is ``False``: returns a sorted list of qualified
+          function names (e.g., ['FunctionName1', ...]).
         - If no functions match the filters: returns None
           (when `tabulate` is True) or an empty list
           (when `tabulate` is False).
@@ -140,7 +186,7 @@ def list_functions(
     ------
     ValueError
         If `tag` is not one of the supported tags, or if `input_dimension` or
-        `output_dimension` contains invalid values.
+        `output_dimension` contain invalid values.
     TypeError
         If any parameter is provided with an incorrect type.
 
@@ -158,11 +204,6 @@ def list_functions(
     _verify_input_args(
         input_dimension, tag, output_dimension, parameterized, tabulate
     )
-
-    if tag is not None and tag not in SUPPORTED_TAGS:
-        raise ValueError(
-            f"Tag {tag!r} is not supported. Choose from {SUPPORTED_TAGS}."
-        )
 
     # Filter entries
     filtered: Dict[str, UQTestFunInfo] = {}
@@ -213,16 +254,14 @@ def list_functions(
         entry = filtered[name]
         row: List[str] = [str(i + 1), name + "()"]
         if show_input_dim:
-            if entry.variable_dimension:
+            entry_input_dimension = entry.input_dimension
+            if entry_input_dimension is None:
                 dim_str = "M"
             else:
-                dim_str = str(entry.input_dimension)
+                dim_str = str(entry_input_dimension)
             row.append(dim_str)
         if show_output_dim:
-            if entry.output_dimension is None:
-                output_dim = "1"
-            else:
-                output_dim = str(entry.output_dimension)
+            output_dim = str(entry.output_dimension)
             row.append(output_dim)
         if show_param:
             row.append(str(bool(entry.available_parameters_ids)))
@@ -238,9 +277,6 @@ def list_functions(
         maxcolwidths=[None, None] + [20] * (len(headers) - 3) + [30],
     )
 
-    if tablefmt == "html":
-        return table
-
     print(table)
 
     return None
@@ -250,7 +286,7 @@ def list_functions(
 def list_parameters(
     name: str,
     *,
-    tabulate: Literal[True],
+    tabulate: Literal[True] = True,
     tablefmt: str,
 ) -> None: ...
 

--- a/tests/test_list_functions.py
+++ b/tests/test_list_functions.py
@@ -124,12 +124,3 @@ def test_untabulated_call():
             assert_call(create, my_class, 2)
         else:
             assert_call(create, my_class)
-
-
-def test_tablefmt_html():
-    """Test function call with 'html' as tablefmt."""
-
-    table = list_functions(tablefmt="html")
-
-    # Assertion
-    assert isinstance(table, str)

--- a/tests/test_list_parameters.py
+++ b/tests/test_list_parameters.py
@@ -11,7 +11,7 @@ from uqtestfuns.core.registry import get_registry
 def test_default_call():
     """Test function call without any arguments."""
     list_names = list_functions(tabulate=False)
-    for name in list_names:  # type: ignore
+    for name in list_names:
         assert_call(list_parameters, name)
 
 
@@ -19,7 +19,7 @@ def test_create_function():
     """Test creating a function with parameter IDs supplied by the function."""
     list_names = list_functions(tabulate=False)
     reg = get_registry()
-    for name in list_names:  # type: ignore
+    for name in list_names:
         param_ids = list_parameters(name, tabulate=False)
         for param_id in param_ids:
             if reg[name].input_dimension is None:
@@ -31,7 +31,7 @@ def test_create_function():
 def test_no_parameter():
     """Test listing parameters when no parameter is available."""
     function_names = list_functions(parameterized=False, tabulate=False)
-    for function_name in function_names:  # type: ignore
+    for function_name in function_names:
         param_ids = list_parameters(function_name, tabulate=False)
 
         # Assertion
@@ -41,7 +41,7 @@ def test_no_parameter():
 def test_with_parameter():
     """Test listing parameters when one or more parameter is available."""
     function_names = list_functions(parameterized=True, tabulate=False)
-    for function_name in function_names:  # type: ignore
+    for function_name in function_names:
         param_ids = list_parameters(function_name, tabulate=False)
 
         # Assertion


### PR DESCRIPTION
`tabulate=True` now always prints a table and returns `None`, regardless of `tablefmt` value. The return type simplifies from `Optional[Union[List[str], str]]` to `Optional[List[str]]`. This is a breaking change as `list_functions(tablefmt="html")` no longer returns an HTML string and instead it prints like any other table format.

Additionally:

- `tabulate=False` now returns bare function names instead of constructor-style strings with a `"()"` suffix, so results compose directly with `create()`/`getattr()`. `"()"` still appears in the printed table's "Constructor" column. This is a breaking change; callers relying on the old suffix need to append `"()"` themselves.
- Add `@overload` signatures for `list_functions()`, giving precise return types per `tabulate` value.
- Update/remove tests referencing `tablefmt="html"` and the old `"()"`- suffixed return values.

---

Closes: #559
Ref: #544