### PR TITLE
feat(api): add list_inputs() for input-specification discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with the default ID; `tabulate=False` returns a sorted list of bare
   IDs usable directly as `uqtf.<Name>(*, parameters_id=<id>)` or
   `uqtf.create(<Name>, *, parameters_id=<id>)`.
+- `list_inputs(name)`, the analog to `list_parameters()` for browsing
+  a function's available probabilistic input specifications:
+  `tabulate=True` (default) prints a table of input-spec IDs and
+  descriptions along with the default ID; `tabulate=False` returns a
+  sorted list of bare IDs usable directly as
+  `uqtf.create(<Name>, input_id=<id>)`.
 
 ### Changed
 

--- a/src/uqtestfuns/__init__.py
+++ b/src/uqtestfuns/__init__.py
@@ -18,7 +18,7 @@ from .meta import UQMetaFunSpec
 from .meta import UQMetaTestFun
 
 from . import api
-from .api import create, list_functions, list_parameters
+from .api import create, list_functions, list_inputs, list_parameters
 
 if sys.version_info >= (3, 8):
     from importlib import metadata
@@ -39,6 +39,7 @@ __all__ = [
     "api",
     "create",
     "list_functions",
+    "list_inputs",
     "list_parameters",
 ]
 

--- a/src/uqtestfuns/api.py
+++ b/src/uqtestfuns/api.py
@@ -12,7 +12,7 @@ system.
 
 from __future__ import annotations
 
-from typing import Dict, List, Literal, Optional, overload, Union
+from typing import Dict, List, Literal, Mapping, Optional, overload, Union
 
 from tabulate import tabulate as tbl
 
@@ -23,7 +23,7 @@ from uqtestfuns.core.registry.entries import UQTestFunInfo
 from uqtestfuns.core.uqtestfun import UQTestFun
 from uqtestfuns.global_settings import SUPPORTED_TAGS
 
-__all__ = ["create", "list_functions", "list_parameters"]
+__all__ = ["create", "list_functions", "list_inputs", "list_parameters"]
 
 
 def create(
@@ -283,6 +283,69 @@ def list_functions(
 
 
 @overload
+def list_inputs(
+    name: str,
+    *,
+    tabulate: Literal[True] = True,
+    tablefmt: str = "simple",
+) -> None: ...
+
+
+@overload
+def list_inputs(
+    name: str,
+    *,
+    tabulate: Literal[False],
+) -> List[str]: ...
+
+
+def list_inputs(
+    name: str,
+    *,
+    tabulate: bool = True,
+    tablefmt: str = "simple",
+) -> Optional[List[str]]:
+    """List all available probabilistic input specifications of a function.
+
+    Parameters
+    ----------
+    name : str
+        The name of the test function to query.
+    tabulate : bool, optional
+        If ``True``, print results as a formatted table and return ``None``.
+        If ``False``, return a sorted list of input specification names.
+        Default is ``True``.
+    tablefmt : str, optional
+        Format for the table output when ``tabulate`` is True. Follows the
+        formats supported by the ``tabulate`` library. Default is 'simple'.
+
+    Returns
+    -------
+    None or List[str]
+        If ``tabulate`` is ``True`` the function prints the result directly
+        to stdout. If ``tabulate`` is ``False``, it returns a sorted list of
+        input specification names for the given function.
+    """
+
+    # Get the test function information
+    reg = get_registry()
+    info = reg[name]
+
+    if not tabulate:
+        return sorted(info.available_input_ids.keys())
+
+    out = _create_table(
+        info.available_input_ids,
+        info.default_input_id,
+        tablefmt,
+    )
+
+    print(out)
+
+    return None
+
+
+@overload
 def list_parameters(
     name: str,
     *,
@@ -305,7 +368,7 @@ def list_parameters(
     tabulate: bool = True,
     tablefmt: str = "simple",
 ) -> Optional[List[str]]:
-    """Display parameter information for a UQ test function.
+    """List all available parameter sets of a UQ test function.
 
     This function prints information about the parameters of a specified
     test function, including parameter keywords and available parameter sets.
@@ -342,26 +405,12 @@ def list_parameters(
         print(f"\n{name} has no parameters.")
         return None
 
-    header = f"Parameters for {name}"
-    print(f"\n{header}")
-    print("=" * len(header))
-
-    available_ids = info.available_parameters_ids
-    headers = ["No", "ID", "Description"]
-    rows = [
-        [i + 1, param_id, desc or "—"]
-        for i, (param_id, desc) in enumerate(available_ids.items())
-    ]
-
-    out = tbl(
-        rows,
-        headers=headers,
-        tablefmt=tablefmt,
-        colalign=("center", "left", "left"),
-        maxcolwidths=[None, None, 50],
-        disable_numparse=True,
+    # Create a string table
+    out = _create_table(
+        info.available_parameters_ids,
+        info.default_parameters_id,
+        tablefmt,
     )
-    out += f"\nDefault: {info.default_parameters_id}"
 
     print(out)
 
@@ -465,3 +514,29 @@ def _verify_input_args(
         raise TypeError(
             f"'tabulate' argument must be of bool type! Got {type(tabulate)}."
         )
+
+
+def _create_table(
+    available_ids: Mapping[str, str],
+    default_id: str,
+    tablefmt: str,
+) -> str:
+    """Create a string table of available inputs or parameter sets."""
+
+    headers = ["No", "ID", "Description"]
+    rows = [
+        [i + 1, variant_id, desc or "—"]
+        for i, (variant_id, desc) in enumerate(available_ids.items())
+    ]
+
+    out = tbl(
+        rows,
+        headers=headers,
+        tablefmt=tablefmt,
+        colalign=("center", "left", "left"),
+        maxcolwidths=[None, None, 50],
+        disable_numparse=True,
+    )
+    out += f"\nDefault: {default_id}"
+
+    return out

--- a/tests/test_list_inputs.py
+++ b/tests/test_list_inputs.py
@@ -1,0 +1,38 @@
+"""
+The test module for the high-level function 'list_inputs()'
+"""
+
+from conftest import assert_call
+
+from uqtestfuns.api import create, list_functions, list_inputs
+from uqtestfuns.core.registry import get_registry
+
+
+def test_default_call():
+    """Test function call without any arguments."""
+    list_names = list_functions(tabulate=False)
+    for name in list_names:
+        assert_call(list_inputs, name)
+
+
+def test_create_function():
+    """Test creating a function with inputs IDs supplied by the function."""
+    list_names = list_functions(tabulate=False)
+    reg = get_registry()
+    for name in list_names:
+        input_ids = list_inputs(name, tabulate=False)
+        for input_id in input_ids:
+            if reg[name].variable_dimension:
+                assert_call(create, name, 2, input_id=input_id)
+            else:
+                assert_call(create, name, input_id=input_id)
+
+
+def test_number_of_specification():
+    """Test at least one specification is available."""
+    function_names = list_functions(tabulate=False)
+    for function_name in function_names:
+        input_ids = list_inputs(function_name, tabulate=False)
+
+        # Assertion
+        assert len(input_ids) > 0


### PR DESCRIPTION
Add `list_inputs(name)` to `api.py`, the analog to `list_parameters()` for browsing a function's input specifications.
The function follows the same `tabulate`/`tablefmt` convention:

- `tabulate=True` (default) prints a table of input-spec IDs and descriptions plus the default ID, returning `None`.
- `tabulate=False` returns a sorted list of bare IDs directly usable with `create(..., input_id=<input_id>)`.

Additionally:

- `@overload` signatures are included for precise return types.
- Relevant unit tests are added for validation.
- Drop the decorative header from `list_parameters()` for consistency, since `list_inputs()` has none.

---

Closes: #554
Ref: #544