### PR TITLE
feat(registry): suggest similar names for invalid function keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   suffix, so results compose directly with `create()`/`getattr()`; the
   `"()"` suffix still appears in the printed table's Constructor
   column.
-- The string representation of `ProbInput` now tabulates its marginals
+T- The string representation of `ProbInput` now tabulates its marginals
   (variable, distribution, parameters), including a description column
   only when at least one marginal has a description; `Marginal`'s
   `display()` method has been renamed to the `notation` property.
@@ -66,7 +66,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Looking up an unknown function name in the registry now raises a
   `KeyError` with a consistent, informative message instead of an
-  unhandled exception.
+  unhandled exception, including a "did you mean ...?" suggestion when
+  the name looks like a typo of a known one.
 
 ### Removed
 

--- a/src/uqtestfuns/core/registry/registry.py
+++ b/src/uqtestfuns/core/registry/registry.py
@@ -14,8 +14,10 @@ The Registry class acts as a container that:
 - Prevents duplicate function registrations
 """
 
+import difflib
+
 from pathlib import Path
-from typing import Dict, Callable
+from typing import Dict, Callable, Optional
 
 from uqtestfuns.core.registry.entries import UQTestFunInfo
 from uqtestfuns.core.registry.factory import make_factory
@@ -169,7 +171,11 @@ class Registry:
             If the function name is not found in the registry.
         """
         if key not in self._infos:
-            raise KeyError(f"Test function '{key!r}' not available")
+            msg = f"Test function {key!r} not available."
+            matches = _suggest_name(key, self._infos.keys())
+            if matches is not None:
+                msg += f" Did you mean {matches!r}?"
+            raise KeyError(msg)
 
         return self._infos[key]
 
@@ -189,9 +195,14 @@ class Registry:
         -------
         Callable
             A factory function that creates UQTestFun instances.
+
+        Raises
+        ------
+        KeyError
+            If the function name is not found in the registry.
         """
         if name not in self._factories:
-            info = self._infos[name]
+            info = self[name]
             spec = parse_spec(info.spec_path, self._pkg_root)
             factory = make_factory(spec, info)
             self._factories[name] = factory
@@ -224,3 +235,9 @@ def is_inputs_yaml(filename: str) -> bool:
         or (filename.startswith("inputs_") and filename.endswith(".yaml"))
         or filename == "inputs.yaml"
     )
+
+
+def _suggest_name(name: str, candidates) -> Optional[str]:
+    matches = difflib.get_close_matches(name, candidates, n=1, cutoff=0.6)
+
+    return matches[0] if matches else None

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,5 +1,6 @@
 import pytest
 
+from uqtestfuns.core.registry.entries import UQTestFunInfo
 from uqtestfuns.core.registry.registry import Registry, is_inputs_yaml
 from uqtestfuns.core.registry.parser import SpecValidationError
 
@@ -52,6 +53,18 @@ class TestScan:
         with pytest.raises(KeyError):
             _ = registry["invalid_key"]
 
+    def test_getitem_invalid_suggestion(self):
+        """Test getting an invalid entry from the registry with suggestion."""
+        registry = Registry(PKG_ROOT)
+        registry.scan(VALID_YAML_DIR)
+
+        with pytest.raises(KeyError) as excinfo:
+            _ = registry["ActiveInert15D"]  # See VALID_YAML_DIR
+
+        # Assertions
+        assert "Did you mean" in str(excinfo.value)
+        assert "ActiveInert10D" in str(excinfo.value)
+
     def test_duplicate_keys(self):
         """Test that duplicate keys are not allowed."""
         registry = Registry(PKG_ROOT)
@@ -60,3 +73,12 @@ class TestScan:
         with pytest.raises(SpecValidationError):
             # Rescan the same directory
             registry.scan(VALID_YAML_DIR)
+
+    def test_values(self):
+        """Test getting the values from the registry."""
+        registry = Registry(PKG_ROOT)
+        registry.scan(VALID_YAML_DIR)
+
+        # Assertion
+        for value in registry.values():
+            assert isinstance(value, UQTestFunInfo)


### PR DESCRIPTION
`Registry.__getitem__()` now raises a descriptive KeyError instead of a bare one, and appends a "did you mean ...?" hint via `difflib` when an unknown name is a likely typo of a real one. `get_factory()` no longer duplicates its own "not available" check; it delegates via self[name].

Additionally:

- Unmatched names still raise the same "not available" message, just without the hint.
- Add tests: a one-character-off typo surfaces a suggestion; a no-match name doesn't.

---

Closes: #556
Ref: #544