### PR TITLE
docs: overhaul the fundamentals section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prerequisite.
 - Citation instructions have been simplified in README and `CITATION.cff`
   now includes a preferred citation for the JOSS paper.
+- The `docs/fundamentals/` pages have been overhauled: corrected function
+  tables, added the missing narrative sections, and unified the table
+  format across all five pages.
 
 ### Fixed
 

--- a/docs/fundamentals/integration.md
+++ b/docs/fundamentals/integration.md
@@ -15,32 +15,56 @@ kernelspec:
 (fundamentals:integration)=
 # Test Functions for Numerical Integration
 
-The table below listed the available test functions typically used
+The table below lists the available test functions typically used
 in the testing and comparison of numerical integration method.
 
-|                              Name                               | Input Dimension |      Constructor       |
-|:---------------------------------------------------------------:|:---------------:|:----------------------:|
-|    {ref}`Bratley et al. (1992) A <test-functions:bratley-a>`    |        M        |    `Bratley1992a()`    |
-|    {ref}`Bratley et al. (1992) B <test-functions:bratley-b>`    |        M        |    `Bratley1992b()`    |
-|    {ref}`Bratley et al. (1992) C <test-functions:bratley-c>`    |        M        |    `Bratley1992c()`    |
-|    {ref}`Bratley et al. (1992) D <test-functions:bratley-d>`    |        M        |    `Bratley1992d()`    |
-|    {ref}`Genz (Continuous) <test-functions:genz-continuous>`    |        M        |   `GenzContinuous()`   |
-|   {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`   |        M        |   `GenzCornerPeak()`   |
-| {ref}`Genz (Discontinuous) <test-functions:genz-discontinuous>` |        M        | `GenzDiscontinuous()`  |
-|      {ref}`Genz (Gaussian) <test-functions:genz-gaussian>`      |        M        |    `GenzGaussian()`    |
-|   {ref}`Genz (Oscillatory) <test-functions:genz-oscillatory>`   |        M        |  `GenzOscillatory()`   |
-|  {ref}`Genz (Product Peak) <test-functions:genz-product-peak>`  |        M        |  `GenzProductPeak()`   |
-|            {ref}`Sobol'-G <test-functions:sobol-g>`             |        M        |       `SobolG()`       |
-|      {ref}`Welch et al. (1992) <test-functions:welch1992>`      |       20        |     `Welch1992()`      |
+|          Name          | Input Dimension |                            Description                             |
+|:----------------------:|:---------------:|:------------------------------------------------------------------:|
+|      ``BratleyA``      |        M        |     {ref}`Bratley et al. (1992) A <test-functions:bratley-a>`      |
+|      ``BratleyB``      |        M        |     {ref}`Bratley et al. (1992) B <test-functions:bratley-b>`      |
+|      ``BratleyC``      |        M        |     {ref}`Bratley et al. (1992) C <test-functions:bratley-c>`      |
+|      ``BratleyD``      |        M        |     {ref}`Bratley et al. (1992) D <test-functions:bratley-d>`      |
+|   ``GenzContinuous``   |        M        |     {ref}`Genz (Continuous) <test-functions:genz-continuous>`      |
+|   ``GenzCornerPeak``   |        M        |    {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`     |
+| ``GenzDiscontinuous``  |        M        |  {ref}`Genz (Discontinuous) <test-functions:genz-discontinuous>`   |
+|    ``GenzGaussian``    |        M        |       {ref}`Genz (Gaussian) <test-functions:genz-gaussian>`        |
+|  ``GenzOscillatory``   |        M        |    {ref}`Genz (Oscillatory) <test-functions:genz-oscillatory>`     |
+|  ``GenzProductPeak``   |        M        |   {ref}`Genz (Product Peak) <test-functions:genz-product-peak>`    |
+|       ``SobolG``       |        M        |              {ref}`Sobol'-G <test-functions:sobol-g>`              |
+|      ``Welch20D``      |       20        |     {ref}`Welch et al. (1992) 20D <test-functions:welch1992>`      |
 
 In a Python terminal, you can list all the available functions relevant
-for metamodeling applications using ``list_functions()`` and filter the results
-using the ``tag`` parameter:
+for integration applications using ``list_functions()``
+and filter the results using the ``tag`` parameter:
 
-```{code-cell} ipython3
-:tags: ["output_scroll"]
-
+```python
 import uqtestfuns as uqtf
 
-uqtf.list_functions(tag="integration", tablefmt="html")
+uqtf.list_functions(tag="integration")
+```
+
+## About integration
+
+Two of the other analyses in this framework are themselves integration
+problems in disguise. The failure probability $P_f$ in
+{ref}`reliability analysis <fundamentals:reliability>` is defined as an
+integral of the joint {term}`PDF` over the (implicitly defined) failure domain,
+and variance-based sensitivity measures in
+{ref}`sensitivity analysis <fundamentals:sensitivity>` are moments of
+$\mathcal{M}$ computed as integrals over the input distribution
+{cite}`Sobol1993`. Framing these as integration problems opens them up to a
+common set of numerical techniques, from classical quadrature to Monte
+Carlo and its variants.
+
+What sets UQTestFuns' integration test functions apart from the rest of the
+collection is that their integrals over the input domain are (usually) known
+analytically. This makes them suited for benchmarking the accuracy of a
+numerical integration scheme directly, rather than only comparing methods
+against each other {cite}`Genz1984`.
+
+## References
+
+```{bibliography}
+:style: unsrtalpha
+:filter: docname in docnames
 ```

--- a/docs/fundamentals/metamodeling.md
+++ b/docs/fundamentals/metamodeling.md
@@ -15,89 +15,87 @@ kernelspec:
 (fundamentals:metamodeling)=
 # Test Functions for Metamodeling
 
-The table below listed the available test functions typically used
+The table below lists the available test functions typically used
 in the comparison of metamodeling approaches.
 
-|                                              Name                                              | Input Dimension |       Constructor       |
-|:----------------------------------------------------------------------------------------------:|:---------------:|:-----------------------:|
-|                          {ref}`Ackley (1987) <test-functions:ackley>`                          |        M        |       `Ackley()`        |
-|              {ref}`Alemazkoor & Meidani (2018) 2D <test-functions:alemazkoor-2d>`              |        2        |    `Alemazkoor2D()`     |
-|             {ref}`Alemazkoor & Meidani (2018) 20D <test-functions:alemazkoor-20d>`             |       20        |    `Alemazkoor20D()`    |
-|                           {ref}`Borehole <test-functions:borehole>`                            |        8        |      `Borehole()`       |
-|                   {ref}`Cheng and Sandu (2010) 2D <test-functions:cheng2d>`                    |        2        |        `Cheng2D`        |
-|                      {ref}`Coffee Cup Model <test-functions:coffee-cup>`                       |        2        |      `CoffeeCup()`      |
-|                 {ref}`Currin et al. (1988) Sine <test-functions:currin-sine>`                  |        1        |     `CurrinSine()`      |
-|                      {ref}`Damped Cosine <test-functions:damped-cosine>`                       |        1        |    `DampedCosine()`     |
-|                  {ref}`Damped Oscillator <test-functions:damped-oscillator>`                   |        7        |  `DampedOscillator()`   |
-|                 {ref}`Dette & Pepelyshev (2010) 8D <test-functions:dette-8d>`                  |        3        |       `Dette8D()`       |
-|             {ref}`Dette & Pepelyshev (2010) Curved <test-functions:dette-curved>`              |        3        |     `DetteCurved()`     |
-|            {ref}`Dette & Pepelyshev (2010) Exponential <test-functions:dette-exp>`             |        3        |      `DetteExp()`       |
-|                              {ref}`Flood <test-functions:flood>`                               |        8        |        `Flood()`        |
-|                {ref}`Forrester et al. (2008) 1D <test-functions:forrester-1d>`                 |        1        |    `Forrester2008()`    |
-|                         {ref}`(1st) Franke <test-functions:franke-1>`                          |        2        |       `Franke1()`       |
-|                         {ref}`(2nd) Franke <test-functions:franke-2>`                          |        2        |       `Franke2()`       |
-|                         {ref}`(3rd) Franke <test-functions:franke-3>`                          |        2        |       `Franke3()`       |
-|                         {ref}`(4th) Franke <test-functions:franke-4>`                          |        2        |       `Franke4()`       |
-|                         {ref}`(5th) Franke <test-functions:franke-5>`                          |        2        |       `Franke5()`       |
-|                         {ref}`(6th) Franke <test-functions:franke-6>`                          |        2        |       `Franke6()`       |
-|                       {ref}`Friedman (6D) <test-functions:friedman-6d>`                        |        6        |     `Friedman6D()`      |
-|                      {ref}`Friedman (10D) <test-functions:friedman-10d>`                       |       10        |     `Friedman10D()`     |
-|                  {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`                   |        M        |   `GenzCornerPeak()`    |
-|                    {ref}`Gramacy (2007) Sine <test-functions:gramacy-sine>`                    |        1        |     `GramacySine()`     |
-|                     {ref}`Higdon (2002) Sine <test-functions:higdon-sine>`                     |        1        |     `HigdonSine()`      |
-|               {ref}`Holsclaw et al. (2013) Sine <test-functions:holsclaw-sine>`                |        1        |    `HolsclawSine()`     |
-|             {ref}`Lim et al. (2002) Non-Polynomial <test-functions:lim-non-poly>`              |        2        |     `LimNonPoly()`      |
-|                 {ref}`Lim et al. (2002) Polynomial <test-functions:lim-poly>`                  |        2        |       `LimPoly()`       |
-| {ref}`Linkletter et al. (2006) Decreasing Coefficients <test-functions:linkletter-dec-coeffs>` |       10        | `LinkletterDecCoeffs()` |
-|           {ref}`Linkletter et al. (2006) Linear <test-functions:linkletter-linear>`            |       10        |  `LinkletterLinear()`   |
-|             {ref}`Linkletter et al. (2006) Sine <test-functions:linkletter-sine>`              |       10        |   `LinkletterSine()`    |
-|                          {ref}`McLain S1 <test-functions:mclain-s1>`                           |        2        |      `McLainS1()`       |
-|                          {ref}`McLain S2 <test-functions:mclain-s2>`                           |        2        |      `McLainS2()`       |
-|                          {ref}`McLain S3 <test-functions:mclain-s3>`                           |        2        |      `McLainS3()`       |
-|                          {ref}`McLain S4 <test-functions:mclain-s4>`                           |        2        |      `McLainS4()`       |
-|                          {ref}`McLain S5 <test-functions:mclain-s5>`                           |        2        |      `McLainS5()`       |
-|                  {ref}`Oakley & O'Hagan (2002) 1D <test-functions:oakley-1d>`                  |        1        |      `Oakley1D()`       |
-|                        {ref}`OTL Circuit <test-functions:otl-circuit>`                         |     6 / 20      |     `OTLCircuit()`      |
-|                        {ref}`Piston Simulation <test-functions:piston>`                        |     7 / 20      |       `Piston()`        |
-|                 {ref}`An and Owen (2001) Robot Arm <test-functions:robot-arm>`                 |        8        |      `RobotArm()`       |
-|                         {ref}`Rosenbrock <test-functions:rosenbrock>`                          |        M        |     `Rosenbrock()`      |
-|            {ref}`Constantine et al. (2015) Solar Cell <test-functions:solar-cell>`             |        5        |      `SolarCell()`      |
-|                  {ref}`Charlson et al. (1992) Sulfur <test-functions:sulfur>`                  |        9        |       `Sulfur()`        |
-|                {ref}`Undamped Oscillator <test-functions:undamped-oscillator>`                 |        6        | `UndampedOscillator()`  |
-|                  {ref}`Webster et al. (1996) 2D <test-functions:webster-2d>`                   |        2        |      `Webster2D()`      |
-|                     {ref}`Welch et al. (1992) <test-functions:welch1992>`                      |       20        |      `Welch1992()`      |
-|                        {ref}`Wing Weight <test-functions:wing-weight>`                         |       10        |     `WingWeight()`      |
+|          Name           | Input Dimension |                                          Description                                           |
+|:-----------------------:|:---------------:|:----------------------------------------------------------------------------------------------:|
+|       ``Ackley``        |        M        |                          {ref}`Ackley (1987) <test-functions:ackley>`                          |
+|    ``Alemazkoor2D``     |        2        |              {ref}`Alemazkoor & Meidani (2018) 2D <test-functions:alemazkoor-2d>`              |
+|    ``Alemazkoor20D``    |       20        |             {ref}`Alemazkoor & Meidani (2018) 20D <test-functions:alemazkoor-20d>`             |
+|      ``Borehole``       |        8        |                           {ref}`Borehole <test-functions:borehole>`                            |
+|       ``Cheng2D``       |        2        |                   {ref}`Cheng and Sandu (2010) 2D <test-functions:cheng2d>`                    |
+|      ``CoffeeCup``      |        2        |                      {ref}`Coffee Cup Model <test-functions:coffee-cup>`                       |
+|     ``CurrinSine``      |        1        |                 {ref}`Currin et al. (1988) Sine <test-functions:currin-sine>`                  |
+|    ``DampedCosine``     |        1        |                      {ref}`Damped Cosine <test-functions:damped-cosine>`                       |
+|  ``DampedOscillator``   |        7        |                  {ref}`Damped Oscillator <test-functions:damped-oscillator>`                   |
+|       ``Dette8D``       |        3        |                 {ref}`Dette & Pepelyshev (2010) 8D <test-functions:dette-8d>`                  |
+|     ``DetteCurved``     |        3        |             {ref}`Dette & Pepelyshev (2010) Curved <test-functions:dette-curved>`              |
+|      ``DetteExp``       |        3        |            {ref}`Dette & Pepelyshev (2010) Exponential <test-functions:dette-exp>`             |
+|        ``Flood``        |        8        |                              {ref}`Flood <test-functions:flood>`                               |
+|     ``Forrester1D``     |        1        |                {ref}`Forrester et al. (2008) 1D <test-functions:forrester-1d>`                 |
+|       ``Franke1``       |        2        |                         {ref}`(1st) Franke <test-functions:franke-1>`                          |
+|       ``Franke2``       |        2        |                         {ref}`(2nd) Franke <test-functions:franke-2>`                          |
+|       ``Franke3``       |        2        |                         {ref}`(3rd) Franke <test-functions:franke-3>`                          |
+|       ``Franke4``       |        2        |                         {ref}`(4th) Franke <test-functions:franke-4>`                          |
+|       ``Franke5``       |        2        |                         {ref}`(5th) Franke <test-functions:franke-5>`                          |
+|       ``Franke6``       |        2        |                         {ref}`(6th) Franke <test-functions:franke-6>`                          |
+|     ``Friedman6D``      |        6        |                       {ref}`Friedman (6D) <test-functions:friedman-6d>`                        |
+|     ``Friedman10D``     |       10        |                      {ref}`Friedman (10D) <test-functions:friedman-10d>`                       |
+|   ``GenzCornerPeak``    |        M        |                  {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`                   |
+|     ``GramacySine``     |        1        |                    {ref}`Gramacy (2007) Sine <test-functions:gramacy-sine>`                    |
+|     ``HigdonSine``      |        1        |                     {ref}`Higdon (2002) Sine <test-functions:higdon-sine>`                     |
+|    ``HolsclawSine``     |        1        |               {ref}`Holsclaw et al. (2013) Sine <test-functions:holsclaw-sine>`                |
+|     ``LimNonPoly``      |        2        |             {ref}`Lim et al. (2002) Non-Polynomial <test-functions:lim-non-poly>`              |
+|       ``LimPoly``       |        2        |                 {ref}`Lim et al. (2002) Polynomial <test-functions:lim-poly>`                  |
+| ``LinkletterDecCoeffs`` |       10        | {ref}`Linkletter et al. (2006) Decreasing Coefficients <test-functions:linkletter-dec-coeffs>` |
+|  ``LinkletterLinear``   |       10        |           {ref}`Linkletter et al. (2006) Linear <test-functions:linkletter-linear>`            |
+|   ``LinkletterSine``    |       10        |             {ref}`Linkletter et al. (2006) Sine <test-functions:linkletter-sine>`              |
+|      ``McLainS1``       |        2        |                          {ref}`McLain S1 <test-functions:mclain-s1>`                           |
+|      ``McLainS2``       |        2        |                          {ref}`McLain S2 <test-functions:mclain-s2>`                           |
+|      ``McLainS3``       |        2        |                          {ref}`McLain S3 <test-functions:mclain-s3>`                           |
+|      ``McLainS4``       |        2        |                          {ref}`McLain S4 <test-functions:mclain-s4>`                           |
+|      ``McLainS5``       |        2        |                          {ref}`McLain S5 <test-functions:mclain-s5>`                           |
+|      ``Oakley1D``       |        1        |                  {ref}`Oakley & O'Hagan (2002) 1D <test-functions:oakley-1d>`                  |
+|     ``OTLCircuit``      |        6        |                      {ref}`OTL Circuit (6D) <test-functions:otl-circuit>`                      |
+|       ``Piston``        |        7        |                     {ref}`Piston Simulation (7D) <test-functions:piston>`                      |
+|      ``RobotArm``       |        8        |                 {ref}`An and Owen (2001) Robot Arm <test-functions:robot-arm>`                 |
+|     ``Rosenbrock``      |        M        |                         {ref}`Rosenbrock <test-functions:rosenbrock>`                          |
+|      ``SolarCell``      |        5        |            {ref}`Constantine et al. (2015) Solar Cell <test-functions:solar-cell>`             |
+|       ``Sulfur``        |        9        |                  {ref}`Charlson et al. (1992) Sulfur <test-functions:sulfur>`                  |
+| ``UndampedOscillator``  |        6        |                {ref}`Undamped Oscillator <test-functions:undamped-oscillator>`                 |
+|      ``Webster2D``      |        2        |                  {ref}`Webster et al. (1996) 2D <test-functions:webster-2d>`                   |
+|      ``Welch20D``       |       20        |                   {ref}`Welch et al. (1992) 20D <test-functions:welch1992>`                    |
+|     ``WingWeight``      |       10        |                        {ref}`Wing Weight <test-functions:wing-weight>`                         |
 
 In a Python terminal, you can list all the available functions relevant
 for metamodeling applications using ``list_functions()``
-and filter the results using the ``tag`` parameter
-(shown below in the HTML format):
+and filter the results using the ``tag`` parameter:
 
-```{code-cell} ipython3
-:tags: ["output_scroll"]
-
+```python
 import uqtestfuns as uqtf
 
-uqtf.list_functions(tag="metamodeling", tablefmt="html")
+uqtf.list_functions(tag="metamodeling")
 ```
 
 ## About metamodeling
 
 In practice, the computational model $\mathcal{M}$ (see {ref}`fundamentals:overview`)
 is typically complex.
-Since an uncertainty quantification (UQ) analysis usually require numerous
+Since an uncertainty quantification (UQ) analysis usually requires many
 evaluations of $\mathcal{M}$ ($\sim 10^2$---$10^6$ or more!), the process
 may become computationally intractable if $\mathcal{M}$ is expensive to evaluate.
 
-To address this challenge, many UQ analyses employ a metamodel (surrogate model).
-Constructed on a limited number of model $\mathcal{M}$ evaluations,
-such a metamodel should be able to capture the most important aspects
+To address this challenge, many UQ analyses turn to **metamodeling**: the
+activity of constructing a metamodel (or surrogate model) from a limited
+number of evaluations of the full computational model $\mathcal{M}$.
+Such a metamodel should be able to capture the most important aspects
 of the input/output mapping while being significantly cheaper to evaluate.
-This metamodel can then replace $\mathcal{M}$ in the analysis,
+It can then replace $\mathcal{M}$ in the analysis,
 providing a significant reduction in computational cost without
-sacrificing the accuracy of the analysis much.
+significantly sacrificing the accuracy of the analysis.
 
-While not a goal of UQ analyse per se, metamodeling is nowadays an indispensable
+While not a goal of UQ analysis per se, metamodeling is nowadays an indispensable
 component of the UQ framework {cite}`Sudret2012, Sudret2017`.
 
 ## References

--- a/docs/fundamentals/optimization.md
+++ b/docs/fundamentals/optimization.md
@@ -15,23 +15,62 @@ kernelspec:
 (fundamentals:optimization)=
 # Test Functions for Optimization
 
-The table below listed the available test functions typically used
+The table below lists the available test functions typically used
 in the comparison of global optimization methods.
 
-|                              Name                               | Input Dimension |    Constructor    |
-|:---------------------------------------------------------------:|:---------------:|:-----------------:|
-|          {ref}`Ackley (1987) <test-functions:ackley>`           |        M        |    `Ackley()`     |
-| {ref}`Forrester et al. (2008) 1D <test-functions:forrester-1d>` |        1        | `Forrester2008()` |
-|          {ref}`Rosenbrock <test-functions:rosenbrock>`          |        M        |  `Rosenbrock()`   |
+|      Name       | Input Dimension |                              Description                              |
+|:---------------:|:---------------:|:---------------------------------------------------------------------:|
+|   ``Ackley``    |        M        |             {ref}`Ackley (1987) <test-functions:ackley>`              |
+| ``Forrester1D`` |        1        |    {ref}`Forrester et al. (2008) 1D <test-functions:forrester-1d>`    |
+| ``Rosenbrock``  |        M        |             {ref}`Rosenbrock <test-functions:rosenbrock>`             |
 
 In a Python terminal, you can list all the available functions relevant
-for optimization applications using ``list_functions()`` and filter the results
-using the ``tag`` parameter:
+for optimization applications using ``list_functions()``
+and filter the results using the ``tag`` parameter:
 
-```{code-cell} ipython3
-:tags: ["output_scroll"]
-
+```python
 import uqtestfuns as uqtf
 
-uqtf.list_functions(tag="optimization", tablefmt="html")
+uqtf.list_functions(tag="optimization")
+```
+
+## About optimization
+
+Unlike reliability, sensitivity, and integration, optimization test
+functions don't reduce to the same probabilistic framework.
+As {ref}`fundamentals:overview` notes, they're included "for completeness"
+rather than as a core UQ analysis[^opt-scope1].
+UQTestFuns still wraps them in the same `ProbInput`/`Marginal` machinery
+as every other function, but here the "distribution"
+typically just encodes the search space's box constraints (a uniform range),
+not genuine input uncertainty[^opt-scope2].
+
+The closest connection to the rest of the framework is with metamodeling.
+What makes a good optimization test function, a deliberately deceptive
+landscape with multiple local optima or a narrow curved valley, is also
+what makes a good metamodeling stress test: a surrogate has to capture the
+same difficult features an optimizer has to navigate.
+For example, Ackley's {cite}`Ackley1987` function
+and Rosenbrock's {cite}`Rosenbrock1960` function
+are both tagged for metamodeling and optimization in UQTestFuns.
+The connection runs deeper still:
+fitting many metamodeling techniques is itself an optimization problem,
+such as tuning a Gaussian process's kernel hyperparameters by maximizing the
+likelihood. Optimization is thus perhaps quietly embedded in UQ analyses
+far more often than the "for completeness" framing above might suggest.
+
+[^opt-scope1]: Specifically, these are classical, deterministic global
+optimization benchmarks. Reliability-based design optimization and other
+forms of optimization under uncertainty are a related but distinct topic,
+not currently covered by UQTestFuns.
+
+[^opt-scope2]: In optimization under uncertainty problems, the input
+(or part of it) is genuinely probabilistic,
+unlike the box-constraint search spaces used here.
+
+## References
+
+```{bibliography}
+:style: unsrtalpha
+:filter: docname in docnames
 ```

--- a/docs/fundamentals/overview.md
+++ b/docs/fundamentals/overview.md
@@ -1,11 +1,16 @@
 (fundamentals:overview)=
 # Uncertainty Quantification Framework
 
-Consider a computational model that is represented as an $M$-dimensional
+```{margin}
+For a gentler, example-driven introduction to what UQ test functions are,
+see {ref}`About UQ Test Functions <getting-started:about-uq-test-functions>`.
+```
+
+Consider a computational model represented as an $M$-dimensional
 black-box function:
 
 $$
-\mathcal{M}: \boldsymbol{x} \in \mathcal{D}_{\boldsymbol{X}} \subseteq \mathbb{R}^M \mapsto \boldsymbol{y} = \mathcal{M}(\boldsymbol{x}) \subseteq \mathbb{R}^P,
+\mathcal{M}: \boldsymbol{x} \in \mathcal{D}_{\boldsymbol{X}} \subseteq \mathbb{R}^M \to \boldsymbol{y} = \mathcal{M}(\boldsymbol{x}) \subseteq \mathbb{R}^P,
 $$
 
 where $\mathcal{D}_{\boldsymbol{X}}$, $\boldsymbol{y}$, $P$ denote
@@ -34,8 +39,13 @@ by a random vector equipped with a joint probability density function
 (PDF)
 
 $$
-f_{\boldsymbol{X}}: \boldsymbol{x} \in \mathcal{D}_{\boldsymbol{X}} \subseteq \mathbb{R}^M \mapsto \mathbb{R}.
+f_{\boldsymbol{X}}: \boldsymbol{x} \in \mathcal{D}_{\boldsymbol{X}} \subseteq \mathbb{R}^M \to \mathbb{R}.
 $$
+
+```{note}
+See {ref}`Probabilistic Input Modeling <prob-input:overview>` for how this
+is specified in UQTestFuns.
+```
 
 Subsequently, the uncertainties of the input variables are propagated through
 the computational model $\mathcal{M}$. As a result, the quantity of interest
@@ -61,8 +71,22 @@ Additionally, many global sensitivity analysis problems reduce to solving
 an {ref}`integration <fundamentals:integration>` problem, which explains the
 extra category.
 For completeness, UQTestFuns also includes test functions commonly
-used for benchmarking testing
+used for benchmarking and testing
 {ref}`optimization <fundamentals:optimization>` methods.
+
+## From framework to UQTestFuns
+
+This framework maps directly onto {ref}`three objects <api-reference:overview>`.
+The computational model $\mathcal{M}$ is a {ref}`UQTestFun <api_reference_uqtestfun>` instance,
+called directly to evaluate $\boldsymbol{y} = \mathcal{M}(\boldsymbol{x})$.
+The probabilistic input $f_{\boldsymbol{X}}$ is a
+{ref}`ProbInput <api_reference_probabilistic_input>` instance,
+composed of one-dimensional {ref}`Marginal <api_reference_marginal_distribution>`
+distributions. Sampling $\boldsymbol{X} \sim f_{\boldsymbol{X}}$ is
+`get_sample()`.
+
+See the {ref}`Create Built-in Test Functions <getting-started:tutorial-built-in-functions>`
+tutorial for a hands-on walkthrough of using these objects in code.
 
 ## References
 

--- a/docs/fundamentals/reliability.md
+++ b/docs/fundamentals/reliability.md
@@ -15,34 +15,31 @@ kernelspec:
 (fundamentals:reliability)=
 # Test Functions for Reliability Analysis
 
-The table below listed the available test functions typically used
+The table below lists the available test functions typically used
 in the comparison of reliability analysis methods.
 
-|                                                        Name                                                        | Input Dimension |       Constructor       |
-|:------------------------------------------------------------------------------------------------------------------:|:---------------:|:-----------------------:|
-|                          {ref}`Cantilever Beam (2D) <test-functions:cantilever-beam-2d>`                           |        2        |   `CantileverBeam2D `   |
-|                         {ref}`Circular Pipe Crack <test-functions:rs-circular-pipe-crack>`                         |        2        |  `CircularPipeCrack()`  |
-|                          {ref}`Convex Failure Domain <test-functions:convex-fail-domain>`                          |        2        |  `ConvexFailDomain()`   |
-|                    {ref}`Katsuki and Frangopol (1994) Four-Branch <test-functions:four-branch>`                    |        2        |     `FourBranch()`      |
-|                                   {ref}`Gayton Hat <test-functions:gayton-hat>`                                    |        2        |      `GaytonHat()`      |
-|                              {ref}`Hyper-sphere Bound <test-functions:hyper-sphere>`                               |        2        |     `HyperSphere()`     |
-|                    {ref}`Verma et al. (2015) RS Circular Bar <test-functions:rs-circular-bar>`                     |        2        |    `RSCircularBar()`    |
-|             {ref}`Verma et al. (2015) RS Circular Pipe Crack <test-functions:rs-circular-pipe-crack>`              |        2        | `RSCircularPipeCrack()` |
-| {ref}`Der Kiureghian and De Stefano (1990) RS Damped Oscillator <test-functions:rs-damped-oscillator-reliability>` |        8        | `RSDampedOscillator()`  |
-|                          {ref}`Waarts (2000) RS Quadratic <test-functions:rs-quadratic>`                           |        2        |     `RSQuadratic()`     |
-|           {ref}`Du and Sudjianto (2004) RS Speed Reducer Shaft <test-functions:rs-speed-reducer-shaft>`            |        5        | `RSSpeedReducerShaft()` |
-|                          {ref}`Undamped Oscillator <test-functions:undamped-oscillator>`                           |        6        | `UndampedOscillator()`  |
+|            Name             | Input Dimension |                                                     Description                                                      |
+|:---------------------------:|:---------------:|:--------------------------------------------------------------------------------------------------------------------:|
+|    ``CantileverBeam2D``     |        2        |                           {ref}`Cantilever Beam (2D) <test-functions:cantilever-beam-2d>`                            |
+|    ``ConvexFailDomain``     |        2        |                           {ref}`Convex Failure Domain <test-functions:convex-fail-domain>`                           |
+|       ``FourBranch``        |        2        |                     {ref}`Katsuki and Frangopol (1994) Four-Branch <test-functions:four-branch>`                     |
+|        ``GaytonHat``        |        2        |                                    {ref}`Gayton Hat <test-functions:gayton-hat>`                                     |
+|       ``HyperSphere``       |        2        |                               {ref}`Hyper-sphere Bound <test-functions:hyper-sphere>`                                |
+|      ``RSCircularBar``      |        2        |                     {ref}`Verma et al. (2015) RS Circular Bar <test-functions:rs-circular-bar>`                      |
+|   ``RSCircularPipeCrack``   |        2        |              {ref}`Verma et al. (2015) RS Circular Pipe Crack <test-functions:rs-circular-pipe-crack>`               |
+|   ``RSDampedOscillator``    |        8        |  {ref}`Der Kiureghian and De Stefano (1990) RS Damped Oscillator <test-functions:rs-damped-oscillator-reliability>`  |
+|       ``RSQuadratic``       |        2        |                           {ref}`Waarts (2000) RS Quadratic <test-functions:rs-quadratic>`                            |
+|   ``RSSpeedReducerShaft``   |        5        |            {ref}`Du and Sudjianto (2004) RS Speed Reducer Shaft <test-functions:rs-speed-reducer-shaft>`             |
+|   ``UndampedOscillator``    |        6        |                           {ref}`Undamped Oscillator <test-functions:undamped-oscillator>`                            |
 
 In a Python terminal, you can list all the available functions relevant
-for metamodeling applications using ``list_functions()`` and filter the results
-using the ``tag`` parameter:
+for reliability analysis applications using ``list_functions()``
+and filter the results using the ``tag`` parameter:
 
-```{code-cell} ipython3
-:tags: ["output_scroll"]
-
+```python
 import uqtestfuns as uqtf
 
-uqtf.list_functions(tag="reliability", tablefmt="html")
+uqtf.list_functions(tag="reliability")
 ```
 
 ## About reliability analysis
@@ -51,7 +48,7 @@ Consider a system whose performance is defined by a _performance function_[^lsf]
 $g$ whose values, in turn, depend on:
 
 - $\boldsymbol{x}_p$: the (uncertain) input variables of the underlying computational model $\mathcal{M}$
-- $\boldsymbol{x}_s$: additional (uncertain) input variables that affects
+- $\boldsymbol{x}_s$: additional (uncertain) input variables that affect
   the performance of the system, but not part of inputs to $\mathcal{M}$ 
 - $\boldsymbol{p}$: an additional set of _deterministic_ parameters of the system
 
@@ -86,7 +83,7 @@ the system is in safe state if the maximum temperature
 does not exceed the regulatory limit.
 ```
 
-**Reliability analysis**[^rare-event] concerns with estimating
+**Reliability analysis**[^rare-event] is concerned with estimating
 the failure probability of a system with a given performance function $g$. 
 For a given joint probability density function (PDF) $f_{\boldsymbol{X}}$
 of the uncertain input variables $\boldsymbol{X} = \{ \boldsymbol{X}_p, \boldsymbol{X}_s \}$,
@@ -119,6 +116,7 @@ accurately with as few function/model evaluations as possible.
 
 import numpy as np
 import matplotlib.pyplot as plt
+import uqtestfuns as uqtf
 
 my_fun = uqtf.RSCircularPipeCrack()
 rng = np.random.default_rng(237324)

--- a/docs/fundamentals/sensitivity.md
+++ b/docs/fundamentals/sensitivity.md
@@ -15,51 +15,50 @@ kernelspec:
 (fundamentals:sensitivity)=
 # Test Functions for Sensitivity Analysis
 
-The table below listed the available test functions typically used
+The table below lists the available test functions typically used
 in the comparison of sensitivity analysis methods.
 
-|                                              Name                                              | Input Dimension |       Constructor       |
-|:----------------------------------------------------------------------------------------------:|:---------------:|:-----------------------:|
-|                           {ref}`Borehole <test-functions:borehole>`                            |        8        |      `Borehole()`       |
-|                   {ref}`Bratley et al. (1992) A <test-functions:bratley-a>`                    |        M        |    `Bratley1992a()`     |
-|                   {ref}`Bratley et al. (1992) B <test-functions:bratley-b>`                    |        M        |    `Bratley1992b()`     |
-|                   {ref}`Bratley et al. (1992) C <test-functions:bratley-c>`                    |        M        |    `Bratley1992c()`     |
-|                   {ref}`Bratley et al. (1992) D <test-functions:bratley-d>`                    |        M        |    `Bratley1992d()`     |
-|                  {ref}`Damped Oscillator <test-functions:damped-oscillator>`                   |        7        |  `DampedOscillator()`   |
-|                              {ref}`Flood <test-functions:flood>`                               |        8        |        `Flood()`        |
-|                       {ref}`Friedman (6D) <test-functions:friedman-6d>`                        |        6        |     `Friedman6D()`      |
-|                  {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`                   |        M        |   `GenzCornerPeak()`    |
-|                {ref}`Genz (Discontinuous) <test-functions:genz-discontinuous>`                 |        M        |  `GenzDiscontinuous()`  |
-|                           {ref}`Ishigami <test-functions:ishigami>`                            |        3        |      `Ishigami()`       |
-| {ref}`Linkletter et al. (2006) Decreasing Coefficients <test-functions:linkletter-dec-coeffs>` |       10        | `LinkletterDecCoeffs()` |
-|            {ref}`Linkletter et al. (2006) Inert <test-functions:linkletter-inert>`             |       10        |   `LinkletterInert()`   |
-|           {ref}`Linkletter et al. (2006) Linear <test-functions:linkletter-linear>`            |       10        |  `LinkletterLinear()`   |
-|             {ref}`Linkletter et al. (2006) Sine <test-functions:linkletter-sine>`              |       10        |   `LinkletterSine()`    |
-|                         {ref}`Moon (2010) 3D <test-functions:moon3d>`                          |        3        |       `Moon3D()`        |
-|                    {ref}`Morris et al. (2006) <test-functions:morris2006>`                     |        M        |     `Morris2006()`      |
-|                        {ref}`OTL Circuit <test-functions:otl-circuit>`                         |     6 / 20      |     `OTLCircuit()`      |
-|                        {ref}`Piston Simulation <test-functions:piston>`                        |     7 / 20      |       `Piston()`        |
-|                  {ref}`Simple Portfolio Model <test-functions:portfolio-3d>`                   |        3        |     `Portfolio3D()`     |
-|                     {ref}`SaltelliLinear <test-functions:saltelli-linear>`                     |        M        |   `SaltelliLinear()`    |
-|                            {ref}`Sobol'-G <test-functions:sobol-g>`                            |        M        |       `SobolG()`        |
-|                         {ref}`Sobol'-G* <test-functions:sobol-g-star>`                         |        M        |     `SobolGStar()`      |
-|                      {ref}`Sobol'-Levitan <test-functions:sobol-levitan>`                      |        M        |    `SobolLevitan()`     |
-|            {ref}`Constantine et al. (2015) Solar Cell <test-functions:solar-cell>`             |        5        |      `SolarCell()`      |
-|                  {ref}`Charlson et al. (1992) Sulfur <test-functions:sulfur>`                  |        9        |       `Sulfur()`        |
-|                     {ref}`Welch et al. (1992) <test-functions:welch1992>`                      |       20        |      `Welch1992()`      |
-|                        {ref}`Wing Weight <test-functions:wing-weight>`                         |       10        |     `WingWeight()`      |
+|           Name           | Input Dimension  |                                                    Description                                                    |
+|:------------------------:|:----------------:|:-----------------------------------------------------------------------------------------------------------------:|
+|       ``Borehole``       |        8         |                                     {ref}`Borehole <test-functions:borehole>`                                     |
+|       ``BratleyA``       |        M         |                             {ref}`Bratley et al. (1992) A <test-functions:bratley-a>`                             |
+|       ``BratleyB``       |        M         |                             {ref}`Bratley et al. (1992) B <test-functions:bratley-b>`                             |
+|       ``BratleyC``       |        M         |                             {ref}`Bratley et al. (1992) C <test-functions:bratley-c>`                             |
+|       ``BratleyD``       |        M         |                             {ref}`Bratley et al. (1992) D <test-functions:bratley-d>`                             |
+|   ``DampedOscillator``   |        7         |                            {ref}`Damped Oscillator <test-functions:damped-oscillator>`                            |
+|        ``Flood``         |        8         |                                        {ref}`Flood <test-functions:flood>`                                        |
+|      ``Friedman6D``      |        6         |                                 {ref}`Friedman (6D) <test-functions:friedman-6d>`                                 |
+|    ``GenzCornerPeak``    |        M         |                            {ref}`Genz (Corner Peak) <test-functions:genz-corner-peak>`                            |
+|  ``GenzDiscontinuous``   |        M         |                          {ref}`Genz (Discontinuous) <test-functions:genz-discontinuous>`                          |
+|       ``Ishigami``       |        3         |                                     {ref}`Ishigami <test-functions:ishigami>`                                     |
+| ``LinkletterDecCoeffs``  |        10        |          {ref}`Linkletter et al. (2006) Decreasing Coefficients <test-functions:linkletter-dec-coeffs>`           |
+|   ``LinkletterInert``    |        10        |                      {ref}`Linkletter et al. (2006) Inert <test-functions:linkletter-inert>`                      |
+|   ``LinkletterLinear``   |        10        |                     {ref}`Linkletter et al. (2006) Linear <test-functions:linkletter-linear>`                     |
+|    ``LinkletterSine``    |        10        |                       {ref}`Linkletter et al. (2006) Sine <test-functions:linkletter-sine>`                       |
+|        ``Moon3D``        |        3         |                                   {ref}`Moon (2010) 3D <test-functions:moon3d>`                                   |
+|       ``MorrisM``        |        M         |                              {ref}`Morris et al. (2006) <test-functions:morris2006>`                              |
+|      ``OTLCircuit``      |        6         |                               {ref}`OTL Circuit (6D) <test-functions:otl-circuit>`                                |
+|    ``OTLCircuit20D``     |        20        |                             {ref}`OTL Circuit (20D) <test-functions:otl-circuit-20d>`                             |
+|        ``Piston``        |        7         |                               {ref}`Piston Simulation (7D) <test-functions:piston>`                               |
+|      ``Piston20D``       |        20        |                            {ref}`Piston Simulation (20D) <test-functions:piston-20d>`                             |
+|     ``Portfolio3D``      |        3         |                            {ref}`Simple Portfolio Model <test-functions:portfolio-3d>`                            |
+|    ``SaltelliLinear``    |        M         |                              {ref}`SaltelliLinear <test-functions:saltelli-linear>`                               |
+|        ``SobolG``        |        M         |                                     {ref}`Sobol'-G <test-functions:sobol-g>`                                      |
+|      ``SobolGStar``      |        M         |                                  {ref}`Sobol'-G* <test-functions:sobol-g-star>`                                   |
+|     ``SobolLevitan``     |        M         |                               {ref}`Sobol'-Levitan <test-functions:sobol-levitan>`                                |
+|      ``SolarCell``       |        5         |                      {ref}`Constantine et al. (2015) Solar Cell <test-functions:solar-cell>`                      |
+|        ``Sulfur``        |        9         |                           {ref}`Charlson et al. (1992) Sulfur <test-functions:sulfur>`                            |
+|       ``Welch20D``       |        20        |                             {ref}`Welch et al. (1992) 20D <test-functions:welch1992>`                             |
+|      ``WingWeight``      |        10        |                                  {ref}`Wing Weight <test-functions:wing-weight>`                                  |
 
 In a Python terminal, you can list all the available functions relevant
-for metamodeling applications using ``list_functions()``
-and filter the results  using the ``tag`` parameter
-(shown below in the HTML format):
+for sensitivity analysis applications using ``list_functions()``
+and filter the results  using the ``tag`` parameter:
 
-```{code-cell} ipython3
-:tags: ["output_scroll"]
-
+```python
 import uqtestfuns as uqtf
 
-uqtf.list_functions(tag="sensitivity", tablefmt="html")
+uqtf.list_functions(tag="sensitivity")
 ```
 
 ## About sensitivity analysis
@@ -75,17 +74,17 @@ by the uncertainty of the inputs.
 While understanding the input-output relationship is valuable on its own[^model-building],
 sensitivity analysis often focuses on more practical tasks, including:
 
-- **Identifying of input variables that primarily drives the output uncertainty**:
+- **Identifying input variables that primarily drive the output uncertainty**:
   This knowledge enables _factor prioritization_, where efforts are concentrated
   on reducing the uncertainty of the most influential inputs (if possible)
   to significantly decrease the uncertainty of the outputs
-- **Identifying of non-influential input variables**:
+- **Identifying non-influential input variables**:
   This knowledge enables _factor fixing/screening_, where non-influential
   inputs are fixed to arbitrary value without 
   affecting significantly (or at all) the uncertainty of the outputs.
   In essence, factor fixing reduces the dimensionality of the problem.
 
-Sensitivity analysis within the UQ framework are typically carried out in
+Sensitivity analysis within the UQ framework is typically carried out in
 a black-box manner, relying solely on model evaluations at carefully
 selected input points.
 The goal is then to achieve the aforementioned tasks with as few model

--- a/docs/test-functions/available.md
+++ b/docs/test-functions/available.md
@@ -25,10 +25,10 @@ regardless of their typical applications.
 |    ``Alemazkoor2D``     |        2        |                       {ref}`Alemazkoor and Meidani (2018) 2D <test-functions:alemazkoor-2d>`                       |
 |    ``Alemazkoor20D``    |       20        |                      {ref}`Alemazkoor and Meidani (2018) 20D <test-functions:alemazkoor-20d>`                      |
 |      ``Borehole``       |        8        |                                     {ref}`Borehole <test-functions:borehole>`                                      |
-|    ``Bratley1992a``     |        M        |                             {ref}`Bratley et al. (1992) A <test-functions:bratley-a>`                              |
-|    ``Bratley1992b``     |        M        |                             {ref}`Bratley et al. (1992) B <test-functions:bratley-b>`                              |
-|    ``Bratley1992c``     |        M        |                             {ref}`Bratley et al. (1992) C <test-functions:bratley-c>`                              |
-|    ``Bratley1992d``     |        M        |                             {ref}`Bratley et al. (1992) D <test-functions:bratley-d>`                              |
+|      ``BratleyA``       |        M        |                             {ref}`Bratley et al. (1992) A <test-functions:bratley-a>`                              |
+|      ``BratleyB``       |        M        |                             {ref}`Bratley et al. (1992) B <test-functions:bratley-b>`                              |
+|      ``BratleyC``       |        M        |                             {ref}`Bratley et al. (1992) C <test-functions:bratley-c>`                              |
+|      ``BratleyD``       |        M        |                             {ref}`Bratley et al. (1992) D <test-functions:bratley-d>`                              |
 |  ``CantileverBeam2D``   |        2        |          {ref}` Rajashekhar and Ellingwood (1993) Cantilever Beam 2D <test-functions:cantilever-beam-2d>`          |
 |       ``Cheng2D``       |        2        |                             {ref}`Cheng and Sandu (2010) 2D <test-functions:cheng2d>`                              |
 |      ``CoffeeCup``      |        2        |                         {ref}`Tennøe et al. (2018) Coffee Cup <test-functions:coffee-cup>`                         |
@@ -96,17 +96,14 @@ regardless of their typical applications.
 |       ``Sulfur``        |        9        |                            {ref}`Charlson et al. (1992) Sulfur <test-functions:sulfur>`                            |
 | ``UndampedOscillator``  |        6        |                {ref}`Gayton et al. (2003) Undamped Oscillator <test-functions:undamped-oscillator>`                |
 |      ``Webster2D``      |        2        |                            {ref}`Webster et al. (1996) 2D <test-functions:webster-2d>`                             |
-|       ``Welch2D``       |       20        |                             {ref}`Welch et al. (1992) 20D <test-functions:welch1992>`                              |
+|      ``Welch20D``       |       20        |                             {ref}`Welch et al. (1992) 20D <test-functions:welch1992>`                              |
 |     ``WingWeight``      |       10        |                      {ref}`Forrester et al. (2008) Wing Weight <test-functions:wing-weight>`                       |
 
 In a Python terminal, you can list all the available functions
-along with the corresponding constructor using ``list_functions()``
-(shown below in the HTML format):
+along with the corresponding constructor using ``list_functions()``:
 
-```{code-cell} ipython3
-:tags: ["output_scroll"]
-
+```python
 import uqtestfuns as uqtf
 
-uqtf.list_functions(tablefmt="html")
+uqtf.list_functions()
 ```


### PR DESCRIPTION
This overhauls the `docs/fundamentals/` section end to end: fixes accuracy issues found by cross-checking every function table against the live registry, restructures tables to match the site-wide column convention,
and fills in the two pages that were missing narrative content.

Specific changes:

- Add missing "About" narrative sections and trailing "References" blocks to `integration.md` and `optimization.md`, matching the other three pages.
- Fix stale and incorrect function tables across all five pages.
- Convert `list_functions()` examples from executed, HTML-output code cells to plain illustrative snippets, avoiding a rendering regression from a recent breaking API change.
- Restructure every function table to the "Name", "Input Dimension", "Description" column convention used in `test-functions/available.md`.
- Expand `overview.md` with cross-links to the conceptual introduction and the probabilistic-input docs, plus a new section bridging the mathematical framework to UQTestFuns' actual objects.
- Fix assorted copy-paste and grammar errors across the five pages.

---

Closes: #568
Ref: #546