### PR TITLE
docs: overhaul the probabilistic input section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   only when at least one marginal has a description; `Marginal`'s
   `display()` method has been renamed to the `notation` property.
 - The string representation of `Marginal` now includes parameter names
-  alongside their values, closer to standard mathematical notation.
+  alongside their values and spells out full distribution names (e.g.,
+  `Exponential`, `Uniform`) rather than abbreviations, closer to standard
+  mathematical notation.
 - The string representation of `Parameters` now summarizes each value
   in a dedicated Value column, recognizing containers via their
   abstract base classes (so any sized object is summarized by length)
@@ -80,6 +82,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `KeyError` with a consistent, informative message instead of an
   unhandled exception, including a "did you mean ...?" suggestion when
   the name looks like a typo of a known one.
+- Corrected wrong ICDF formulas on several marginal distribution
+  documentation pages (Gumbel, normal, truncated normal, truncated
+  Gumbel).
 
 ### Removed
 

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -194,10 +194,10 @@ parts:
     chapters:
       - file: prob-input/overview
         title: Overview
-      - file: prob-input/preliminaries
-        title: Preliminaries
-      - file: prob-input/univariate-random-variable
-        title: Univariate Random Variable
+      - file: prob-input/concepts-and-notations
+        title: Concepts and Notations
+      - file: prob-input/marginal-distribution
+        title: Marginal Distribution
       - file: prob-input/probabilistic-input
         title: Probabilistic Input Model
       - file: prob-input/available

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -5,6 +5,8 @@
 CDF
     Cumulative distribution function, denoted by $F_X(x; \circ)$ where $\circ$
     is a placeholder for the distribution parameter(s).
+    
+    See {ref}`the relevant section in Concepts and Notations <prob-input:concepts-and-notations:cdf>` for more details.
 
 DS
     Directional sampling
@@ -27,6 +29,8 @@ ICDF
     ICDF is also known as the _quantile function_
     or _percent point function_.
 
+    See {ref}`the relevant section in Concepts and Notations <prob-input:concepts-and-notations:icdf>` for more details.
+
 IS
     Importance sampling
 
@@ -36,6 +40,8 @@ MCS
 PDF
     Probability density function, denoted by $f_X(x; \circ)$ where $\circ$
     is a placeholder for the distribution parameter(s).
+
+    See {ref}`the relevant section in Concepts and Notations <prob-input:concepts-and-notations:pdf>` for more details.
 
 SORM
     Second-order reliability method

--- a/docs/prob-input/available.md
+++ b/docs/prob-input/available.md
@@ -2,11 +2,14 @@
 # Available One-Dimensional Marginal Distributions
 
 The table below lists all the available one-dimensional marginal distribution
-types used to construct ``Marginal`` instances.
-``Marginal`` instances are used to represent the one-dimensional marginals
-of a (possibly, multivariate) probabilistic input model.
+types used to construct `Marginal` instances.
+`Marginal` instances are used to represent the one-dimensional marginals
+of a (possibly, multi-dimensional) probabilistic input model.
+The `parameters` argument follows the order shown in the Mathematical
+Notation column below; for instance, `parameters=[alpha, beta, a, b]` for
+the Beta distribution.
 
-|                                        Name                                         | Keyword value for `distribution` |                     Notation                      |             Support              | Number of parameters |
+|                                    Distribution                                     | Keyword value for `distribution` |                Mathematical Notation              |             Support              | Number of parameters |
 |:-----------------------------------------------------------------------------------:|:--------------------------------:|:-------------------------------------------------:|:--------------------------------:|:--------------------:|
 |                {ref}`Beta <prob-input:marginal-distributions:beta>`                 |             `"beta"`             |       $\mathrm{Beta}(\alpha, \beta, a, b)$        | $[a, b], \; a, b \in \mathbb{R}$ |          4           |
 |         {ref}`Exponential <prob-input:marginal-distributions:exponential>`          |         `"exponential"`          |              $\mathcal{E}(\lambda)$               |          $[0, \infty)$           |          1           |

--- a/docs/prob-input/concepts-and-notations.md
+++ b/docs/prob-input/concepts-and-notations.md
@@ -1,11 +1,12 @@
-(prob-input:preliminaries)=
-# Preliminaries
+(prob-input:concepts-and-notations)=
+# Probability Concepts and Notations
 
 This page is intended to provide the definitions of the basic concepts
 in probability and the notational conventions relevant to UQTestFuns.
 It is not intended to be an exhaustive treatment of the subject.
 
-In the current version of UQTestFuns, we concern only with continuous input variables.
+In the current version of UQTestFuns, we are concerned only
+with continuous input variables.
 Consequently, the discussion below is restricted to continuous random variables.
 
 ```{note}
@@ -19,6 +20,7 @@ Clearly, in this context, they are not random variables.
 We would appeal to your wisdom in making the distinction between these notations.
 ```
 
+(prob-input:concepts-and-notations:cdf)=
 ## Cumulative distribution function (CDF)
 
 A continuous random variable $X$ distributed according to a (univariate)
@@ -40,12 +42,13 @@ $$
 
 The distribution of $X$ is uniquely determined by its CDF.
 
+(prob-input:concepts-and-notations:pdf)=
 ## Probability density function (PDF)
 
-The derivative of the cumulative distribution function, if exists,
+The derivative of the cumulative distribution function, if it exists,
 is called the (univariate) probability density function (PDF) of $X$,
 denoted by $f_X(x)$.
-Specifically, if exists, the PDF value at $x$ is defined as follows:
+Specifically, if it exists, the PDF value at $x$ is defined as follows:
 
 $$
 f_X(x) \equiv \frac{d F_X(x)}{dx} = \lim_{\Delta x \to 0} \frac{F_X(x + \Delta x) - F_X(x)}{\Delta x} 
@@ -58,8 +61,8 @@ X \sim f_X(x).
 $$
 
 It is important to realize that for a continuous random variable,
-the density value for a given $x$ value is _not_ the probability; it's a density value.
-In fact, the probability of a $X$ taking a particular value $x$ is $0$.
+the density value at a given $x$ is not a probability.
+In fact, the probability of $X$ taking a particular value $x$ is $0$.
 You can, however, think of the quantity $f_X(x) \, dx$ as a probability;
 it's the probability of $X$ having a value in an infinitesimal interval around $x$. 
 
@@ -78,6 +81,7 @@ $$
 
 where $\mathcal{D}^-_X$ denotes the lower bound of the support.
 
+(prob-input:concepts-and-notations:icdf)=
 ## Inverse cumulative distribution function (ICDF)
 
 The inverse cumulative distribution function (ICDF) of a random variable $X$
@@ -103,18 +107,18 @@ where $\mu$ and $\sigma$ are the parameters of the normal distributions
 Given the values of the parameters, a particular (parametric) distribution
 is completely and uniquely specified.
 
-## Multivariate random variables
+## Random vectors
 
-A multi-dimensional probabilistic input model is, in principle,
-a multivariate random variable;
-such a variable consists of individual univariate random variables grouped
-together under some dependency structure.
+A multi-dimensional probabilistic input model is, in principle, a
+_random vector_, sometimes called a "multivariate random variable"[^imprecise].
+A random vector consists of individual random variables grouped together
+under some dependency structure.
 
-An $M$-variate random variable (or $M$-dimensional random vector)
-is denoted by $\boldsymbol{X} = (X_1, \ldots, X_M )^T$
+An $M$-dimensional random vector is denoted by
+$\boldsymbol{X} = (X_1, \ldots, X_M )^T$
 with a _joint_ cumulative distribution function (CDF)
 $F_{\boldsymbol{X}}: \mathcal{D}_{\boldsymbol{X}} \subseteq \mathbb{R}^M \mapsto [0, 1]$
-and, if exists, a _joint_ probability density function (PDF) 
+and, if it exists, a _joint_ probability density function (PDF) 
 $f_{\boldsymbol{X}}: \mathcal{D}_{\boldsymbol{X}} \subseteq \mathbb{R}^M \mapsto \mathbb{R}_{\geq 0}$.
 
 A common assumption (though in no way general) is the independence between
@@ -126,8 +130,9 @@ $$
 F_{\boldsymbol{X}} (x_1, \ldots, x_M) = \prod_{m = 1}^M F_{X_m} (x_m), 
 $$
 
-where $F_{X_m}$ is the univariate CDF of a component random variable.
-If exists, the PDF can be written accordingly:
+where $F_{X_m}$, the _marginal_ CDF of $X_m$, is the univariate CDF of a
+component random variable.
+If it exists, the PDF can be written accordingly:
 
 $$
 f_{\boldsymbol{X}} (x_1, \ldots, x_M) = \prod_{m = 1}^M f_{X_m} (x_m),
@@ -138,3 +143,5 @@ where $f_{X_m}$ is the univariate PDF of a component random variable.
 [^random-variable]: it's neither random
 (at least, not in _completely unpredictable_ sense)
 nor a variable (it's a function).
+[^imprecise]: "multivariate random variable" is, however, a less precise term,
+since a random variable is, strictly speaking, always univariate.

--- a/docs/prob-input/marginal-distribution.md
+++ b/docs/prob-input/marginal-distribution.md
@@ -13,14 +13,19 @@ kernelspec:
 ---
 
 (prob-input:marginal-distribution)=
-# Creating a One-Dimensional Marginal Distribution
+# Creating a (One-Dimensional) Marginal Distribution
 
-A probabilistic input to a UQ test function consists of input variables
-each of which is a (univariate) random variable.
-Therefore, the starting point of defining a (possibly multivariate)
+A probabilistic input to a UQ test function consists of input variables, 
+each of which is a random variable.
+Therefore, the starting point of defining a (possibly multi-dimensional)
 probabilistic input is defining the distribution
 for each of the constituent random variables.
 This page explains how such a marginal distribution can be created in UQTestFuns.
+
+```{note}
+See {ref}`Probabilistic Input Modeling <prob-input:overview>` for how this
+maps onto the general concepts of random variables and random vectors.
+```
 
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt
@@ -28,21 +33,21 @@ import numpy as np
 import uqtestfuns as uqtf
 ```
 
-Suppose we would like to define one-dimensional triangular marginal distribution
+Suppose we are to define a triangular probability distribution
 for random variable $X$:
 
 $$
-X \sim \mathcal{T}_r(a, b, c)
+X \sim \mathcal{T}_r(a=3.0, b=5.0, c=4.0)
 $$
 
 where $a$, $b$, and $c$ are the parameters of the triangular distribution.
 These parameters correspond to the lower bound, the upper bound,
-and the mid-point of the distribution. 
-For this particular example, we set these values to $3.0$, $5.0$, and $4.0$.
+and the mid-point of the distribution, respectively.
 
-## A ``Marginal`` instance
+## A `Marginal` instance
 
-A univariate random variable is represented in UQTestFuns by the ``Marginal`` class.
+A univariate random variable, or marginal distribution, is represented in
+UQTestFuns by the {ref}`Marginal <api_reference_marginal_distribution>` class.
 To create an instance of the class, you need to pass the following arguments:
 
 - `distribution`: the chosen univariate distribution (one from this {ref}`list <prob-input:available-marginal-distributions>`)
@@ -59,14 +64,18 @@ my_rand_var = uqtf.Marginal(
     name="X",
     description="My random variable",
 )
-my_rand_var
 ```
 
-The variable `my_rand_var` now stores an instance
-of a univariate random variable distributed as triangular
+The variable `my_rand_var` now stores an instance of a marginal
+distribution (a triangular-distributed univariate random variable)
 with the specified parameters.
+You can print the instance to the terminal to verify it:
 
-An instance of ``Marginal`` exposes the following properties:
+```{code-cell} ipython3
+print(my_rand_var)
+```
+
+An instance of `Marginal` exposes the following properties:
 
 |    Property    |                                              Description                                               |
 |:--------------:|:------------------------------------------------------------------------------------------------------:|
@@ -79,19 +88,20 @@ An instance of ``Marginal`` exposes the following properties:
 
 and methods:
 
-|            Method             |                                     Description                                      |
-|:-----------------------------:|:------------------------------------------------------------------------------------:|
-|           `cdf(xx)`           |         compute the cumulative distribution function on a set of values `xx`         |
-|           `pdf(xx)`           |           compute the probability density function on a set of values `xx`           |
-|          `icdf(xx)`           |     compute the inverse cumulative distribution function on a set of values `xx`     |
-|   `get_sample(sample_size)`   |               get a sample of size `sample_size` from the distribution               |
-| `transform_sample(xx, other)` | transform a set of sample values `xx` (of this distribution) to `other` distribution |
+|               Method                |                                      Description                                      |
+|:-----------------------------------:|:-------------------------------------------------------------------------------------:|
+|              `cdf(xx)`              |         compute the cumulative distribution function on a set of values `xx`          |
+|              `pdf(xx)`              |           compute the probability density function on a set of values `xx`            |
+|             `icdf(xx)`              |     compute the inverse cumulative distribution function on a set of values `xx`      |
+| `get_sample(sample_size, rng=None)` |   get a sample of size `sample_size` from the distribution with a NumPy PRNG[^prng]   |
+|     `transform_to(xx, target)`      | transform a set of sample values `xx` (of this distribution) to `target` distribution |
 
 Let's go through each one of these methods.
 
 ## Computing the CDF values
 
-The CDF values for a set of sample values in $\mathcal{D}_X$ can be computed using the `cdf()` method.
+The CDF values for a set of sample values in $\mathcal{D}_X$ can be computed
+using the `cdf()` method.
 Suppose we want to evaluate the CDF of the distribution on its support:
 
 ```{code-cell} ipython3
@@ -188,7 +198,7 @@ plt.gcf().set_dpi(150)
 
 ## Transforming a sample
 
-The `transform_sample()` method facilitates the transformation
+The `transform_to()` method facilitates the transformation
 between a sample generated from one distribution to another.
 
 Let's suppose, complementary to the random variable $X$ we define
@@ -202,7 +212,7 @@ In other words, the variable $Y$ is a standard normal random variable.
 The sample from $X$ can be transformed to $Y$ as follows:
 
 ```{code-cell} ipython3
-xx_sample_2 = my_rand_var.transform_sample(xx_sample, my_rand_var_2)
+xx_sample_2 = my_rand_var.transform_to(xx_sample, my_rand_var_2)
 ```
 
 The histogram of the transformed sample is shown below.
@@ -232,14 +242,14 @@ the lower and upper bounds.
 In the case of the above triangular distribution,
 its support is $\mathcal{D}_X = [3.0, 5.0]$ (the lower and upper bounds are $3.0$ and $5.0$, respectively).
 Such a distribution is _supported on a bounded interval_;
-specifically, the distribution is bounded from the right (below) and left (above).
+specifically, the distribution is bounded both below and above.
 
 Consider, on the other hand, the standard normal distribution.
 Its support is, strictly speaking, $\mathcal{D}_X = (-\infty, \infty)$.
 This is an example of distributions that are supported on the whole real line;
 it is neither bounded from below nor from above.
 
-The properties of a ``Marginal`` instance include among other things,
+The properties of a `Marginal` instance include, among other things,
 `lower` (lower bound) and `upper` (upper bound).
 For the triangular distribution defined above, the lower and upper bounds are indeed:
 
@@ -266,6 +276,7 @@ from both sides at these values,
 we are consciously ignoring the values whose probabilities are at most $10^{-16}$.
 This is an acceptable assumption in typical engineering applications.
 
-[^random-variable]: A random variable is neither random
-(it's uncertain, yes, but that does not necessarily mean the colloquial "random" or "completely unpredictable")
-nor a variable (it's a function).
+[^prng]: The `rng` argument accepts either a NumPy `numpy.random.Generator`
+instance directly or an integer used as a seed to construct one. If
+omitted, a fresh, unseeded generator is used, so consecutive calls without
+an explicit `rng` are not reproducible.

--- a/docs/prob-input/marginal-distributions/gumbel.md
+++ b/docs/prob-input/marginal-distributions/gumbel.md
@@ -34,7 +34,7 @@ The table below summarizes some important aspects of the distribution.
 |  **{term}`Support`** | $\mathcal{D}_X = (-\infty, \infty)$                                                                                               |
 |      **{term}`PDF`** | $f_X (x; \mu, \beta) = \frac{1}{\beta} \exp{- \left[ \frac{x - \mu}{\beta} + \exp{-\left(\frac{x - \mu}{\beta} \right)} \right]}$ |
 |      **{term}`CDF`** | $F_X (x; \mu, \beta) = \exp{-\left[ \exp{- \left(\frac{x - \mu}{\beta} \right)} \right]}$                                         |
-|     **{term}`ICDF`** | $F^{-1}_X (x; \mu, \beta) = \mu + \beta \ln{(\ln{x})}$                                                                            |
+|     **{term}`ICDF`** | $F^{-1}_X (x; \mu, \beta) = \mu - \beta \ln{(-\ln{x})}$                                                                           |
 
 The plots of probability density functions (PDFs),
 sample histogram (of $5'000$ points),

--- a/docs/prob-input/marginal-distributions/normal.md
+++ b/docs/prob-input/marginal-distributions/normal.md
@@ -146,7 +146,7 @@ $$
 and
 
 $$
-\Phi^{-1}(x) = \sqrt{2} \mathrm{erf}(2 x - 1).
+\Phi^{-1}(x) = \sqrt{2} \mathrm{erf}^{-1}(2 x - 1).
 $$
 
 

--- a/docs/prob-input/marginal-distributions/trunc-gumbel.md
+++ b/docs/prob-input/marginal-distributions/trunc-gumbel.md
@@ -37,7 +37,7 @@ The table below summarizes some important aspects of the distribution.
 |  **{term}`Support`** | $\mathcal{D}_X = [a, b]$                                                                                                                                                                                                                                          |
 |      **{term}`PDF`** | $f_X (x; \mu, \sigma, a, b) = \begin{cases} \frac{1}{F_{\mathrm{Gumbel}}(b; \mu, \sigma) - F_{\mathrm{Gumbel}}(a; \mu, \sigma)} f_{\mathrm{Gumbel}}(x; \mu, \sigma) & x \in [a, b]\\ 0.0 & x \notin [a, b] \end{cases}$                                           |
 |      **{term}`CDF`** | $F_X (x; \mu, \sigma, a, b) = \begin{cases} 0.0 & x < a \\ \frac{F_{\mathrm{Gumbel}}(x; \mu, \sigma) - F_{\mathrm{Gumbel}}(a; \mu, \sigma)}{F_{\mathrm{Gumbel}}(b; \mu, \sigma) - F_{\mathrm{Gumbel}}(a; \mu, \sigma)} & x \in [a, b] \\ 1.0 & x > b \end{cases}$ |
-|     **{term}`ICDF`** | $F^{-1}_X (x; \mu, \beta, a, b) = \left(F_{\mathrm{Gumbel}}(b; \mu, \sigma) - F_{\mathrm{Gumbel}}(a; \mu, \sigma)\right) x + F_{\mathrm{Gumbel}}(a; \mu, \sigma)$                                                                                                 |
+|     **{term}`ICDF`** | $F^{-1}_X (x; \mu, \beta, a, b) = F^{-1}_{\mathrm{Gumbel}}\left[\left(F_{\mathrm{Gumbel}}(b; \mu, \sigma) - F_{\mathrm{Gumbel}}(a; \mu, \sigma)\right) x + F_{\mathrm{Gumbel}}(a; \mu, \sigma)\right]$                                                           |
 
 In the table above, $f_{\mathrm{Gumbel}}$, $F_{\mathrm{Gumbel}}$,
 and $F^{-1}_{\mathrm{Gumbel}}$ are the probability density,

--- a/docs/prob-input/marginal-distributions/trunc-normal.md
+++ b/docs/prob-input/marginal-distributions/trunc-normal.md
@@ -37,7 +37,7 @@ The table below summarizes some important aspects of the distribution.
 |  **{term}`Support`** | $\mathcal{D}_X = [a, b]$                                                                                                                                                                                                           |
 |      **{term}`PDF`** | $f_X (x; \mu, \sigma, a, b) = \begin{cases} \frac{1}{\Phi(\frac{b - \mu}{\sigma}) - \Phi(\frac{a - \mu}{\sigma})} \frac{1}{\sigma} \phi\left(\frac{x - \mu}{\sigma}\right) & x \in [a, b] \\ 0.0 & x \notin [a, b] \end{cases}$    |
 |      **{term}`CDF`** | $F_X (x; \mu, \sigma, a, b) = \begin{cases} 0.0 & x < a \\ \frac{\Phi(\frac{x - \mu}{\sigma}) - \Phi(\frac{a - \mu}{\sigma})}{\Phi(\frac{b - \mu}{\sigma}) - \Phi(\frac{a - \mu}{\sigma})} & x \in [a, b] \\ 1.0 & x > b \end{cases}$ |
-|     **{term}`ICDF`** | $F^{-1}_X (x; \mu, \sigma, a, b) = \mu + \sigma \Phi^{-1} \left[ \left(\Phi\left(\frac{b - \mu}{\sigma}\right) - \Phi\left(\frac{a - \mu}{\sigma}\right)\right) x + \Phi\left(\frac{x - a}{\sigma}\right) \right]$                 |
+|     **{term}`ICDF`** | $F^{-1}_X (x; \mu, \sigma, a, b) = \mu + \sigma \Phi^{-1} \left[ \left(\Phi\left(\frac{b - \mu}{\sigma}\right) - \Phi\left(\frac{a - \mu}{\sigma}\right)\right) x + \Phi\left(\frac{a - \mu}{\sigma}\right) \right]$                 |
 
 In the table above, $\phi$, $\Phi$, and $\Phi^{-1}$ are the probability density,
 the cumulative and the inverse cumulative distribution functions 

--- a/docs/prob-input/overview.md
+++ b/docs/prob-input/overview.md
@@ -4,14 +4,16 @@
 Unique to uncertainty quantification (UQ) test functions is the representation
 of the input variables as random variables.
 This is because in a UQ problem, each of the relevant input variables is
-considered _uncertain_ and they are modeled probabilistically.
+considered _uncertain_ and modeled probabilistically. See
+{ref}`Uncertainty Quantification Framework <fundamentals:overview>` for how
+this fits into the broader UQ analysis workflow.
 
 In such a setting, each input variable is represented as a random variable
 whose distribution is described (in the case of a continuous random variable)
 by a probability density function (PDF).
-Multiple input variables are represented as a multivariate random variable
+Multiple input variables are represented as a random vector
 whose distribution is described by a _joint_ PDF.
-The random variables in such a multivariate random variable
+The random variables in such a random vector
 may or may not be statistically independent.
 
 ```{margin}
@@ -21,30 +23,49 @@ please refer to a complete UQ framework such as [UQLab](https://www.uqlab.com) o
 ```
 
 UQTestFuns includes some basic probabilistic input modeling capabilities
-that allows the built-in test functions to be specified
+that allow the built-in test functions to be specified
 without extensive dependencies[^dependencies].
-These capabilities, however, are not designed to be a flexible suite of tools 
-to handle the representation of a wide range of distributions
-for practical applications.
-Density functions and dependency structures are only made available
-when a specific UQ test function requires them.
-The list of supported univariate distributions can be found {ref}`here <prob-input:available-marginal-distributions>`.
+These capabilities are not meant to be a flexible,
+general-purpose toolkit for representing a wide range of distributions.
+Density functions and (in the future) dependency structures are only made
+available when a specific UQ test function requires them.
+See the {ref}`list of supported univariate distributions <prob-input:available-marginal-distributions>`.
 
 This section of the documentation explains in more detail how to specify
 a probabilistic input in UQTestFuns.
-In UQTestFuns, a probabilistic input consists of one or more input variables,
-each of which is represented as a univariate random variable with a prescribed
-distribution:
 
-- To learn more about how to create a univariate random variable,
+In terms of the general probability concepts introduced in
+{ref}`Probability Concepts and Notations <prob-input:concepts-and-notations>`,
+UQTestFuns gives the random variable and the random vector distinct names
+for their role as a UQ test function's input:
+
+| General probability term |                      UQTestFuns term                      |
+|:------------------------:|:---------------------------------------------------------:|
+|     Random variable      | (One-dimensional) marginal distribution[^one-dimensional] |
+|      Random vector       |                    Probabilistic input                    |
+
+Concretely, a probabilistic input is composed of one marginal distribution
+per input dimension, mirroring how a random vector
+$\boldsymbol{X} = (X_1, \ldots, X_M)^T$ is composed of its component random
+variables $X_1, \ldots, X_M$.
+
+The following pages go into more detail:
+
+- To learn more about how to create a (one-dimensional) marginal distribution,
   check out the {ref}`Creating a One-Dimensional Marginal Distribution <prob-input:marginal-distribution>`
   page.
 - To learn more about how to model one or more input variables probabilistically,
   check out the {ref}`Creating a Probabilistic Input Model <prob-input:probabilistic-input-model>`
   page.
 - To get an overview on the basic concepts in probability relevant to UQTestFuns,
-  check out the {ref}`prob-input:preliminaries` page.
+  check out the {ref}`Probability Concepts and Notations <prob-input:concepts-and-notations>` page.
 
 [^dependencies]: that is, outside the common numerical Python environment (NumPy and SciPy).
 In fact, the univariate distributions in UQTestFuns wrap around the ones from `scipy.stats`
 with parametrization that is more consistent with the applied UQ literature.
+
+[^one-dimensional]: A marginal distribution of a joint distribution is not
+necessarily one-dimensional in general (for example, the marginal over a
+subset of components of a random vector). UQTestFuns' convention is to use
+the term specifically for the one-dimensional case, corresponding to a
+single component.

--- a/docs/prob-input/probabilistic-input.md
+++ b/docs/prob-input/probabilistic-input.md
@@ -16,11 +16,11 @@ kernelspec:
 # Creating a Probabilistic Input Model
 
 The input of an uncertainty quantification (UQ) test function is modeled probabilistically.
-In the case of multi-dimensional input,
-the whole input model is, in essence, a multivariate random variable (or random vector).
-Each of the input variables is represented as a univariate random variable.
+In the case of a multi-dimensional input,
+the whole input model is, in essence, a random vector.
+Each of the input variables is represented as a (one-dimensional) marginal distribution.
 A fully-specified probabilistic input model
-then combines all the univariate random variables under some prescribed dependency structures.
+then combines all the marginals under some prescribed dependency structures.
 
 ```{note}
 Currently, UQTestFuns does not support specifying dependency between random variables.
@@ -28,7 +28,7 @@ Specifically, all input variables can only be modeled as independent random vari
 ```
 
 This page explains how a probabilistic input model can be specified in UQTestFuns.
-It assumes some familiarity with the univariate random variable explained on the previous page.
+It assumes some familiarity with {ref}`(one-dimensional) marginal distributions <prob-input:marginal-distribution>`
 
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt
@@ -37,13 +37,15 @@ import uqtestfuns as uqtf
 ```
 
 Suppose we want to define the probabilistic input model of a three-dimensional function.
-The probabilistic input model is then a multivariate random variable with a three-dimensional joint probability distribution.
-The one-dimensional marginal density of the distribution for each of the input variables is shown in the table below. 
+The probabilistic input model is then a three-dimensional random vector
+with a joint probability distribution.
+The one-dimensional marginal distribution for each of the input variables is shown
+in the table below. 
 
 | No. | Name  | Distribution  |                   Parameters                   |
 |:---:|:-----:|:-------------:|:----------------------------------------------:|
-| 1.  | $X_1$ | Gumbel (max.) |           $\mu = 3.0, \beta = 4.0$             |
-| 2.  | $X_2$ |   Normal      |              $\mu=1, \sigma=0.2$               |
+| 1.  | $X_1$ | Gumbel (max.) |            $\mu = 3.0, \beta = 4.0$            |
+| 2.  | $X_2$ |    Normal     |              $\mu=1, \sigma=0.2$               |
 | 3.  | $X_3$ |     Beta      | $\alpha = 5.0, \beta = 2.0, a = 0.25, b = 1.0$ |
 
 Moreover, it is assumed that all the input variables are statistically independent.
@@ -56,7 +58,7 @@ One-dimensional marginals are the distributions
 of the component univariate random variables.
 In UQTestFuns, the distribution of a univariate random variable is
 represented by ``Marginal`` class
-(please refer to {ref}`prob-input:marginal-distribution` for more detail).
+(please refer to {ref}`marginal distribution <prob-input:marginal-distribution>` for more detail).
 Because three marginals belong to a single probabilistic input model,
 we need to collect all the marginals inside a list (or a tuple) as follows:
 
@@ -77,14 +79,15 @@ my_marginals = [
 Note that in the snippet above,
 the parameters `name` and `description` of `Marginal()` are optional.
 
-## A ``ProbInput`` instance
+## A `ProbInput` instance
 
-A probabilistic input model in UQTestFuns is represented by the ``ProbInput`` class.
+A probabilistic input model in UQTestFuns is represented
+by the {ref}`ProbInput <api_reference_probabilistic_input>`.
 To create an instance of the class, you need to pass the following arguments:
 
-- `marginals`: a list or tuple of one-dimensional marginals each represented by an instance of ``Marginal``.
+- `marginals`: a list or tuple of one-dimensional marginals,
+  each represented by an instance of `Marginal`.
 - `name`: the name of the probabilistic input model (optional)
-- `description`: a short text describing the input model (optional)
 
 Once we define all the marginals,
 we create a probabilistic input model as follows:
@@ -93,11 +96,11 @@ we create a probabilistic input model as follows:
 my_probinput = uqtf.ProbInput(
   marginals=my_marginals,
   name="MyProbInput",
-  description="My probabilistic input",
 )
 ```
 
-The variable `my_probinput` now stores an instance of a probabilistic input model
+The variable `my_probinput` now stores
+an instance of a probabilistic input model
 consisting of three independent random variables.
 You can print the instance to the terminal to verify it:
 
@@ -105,28 +108,28 @@ You can print the instance to the terminal to verify it:
 print(my_probinput)
 ```
 
-An instance of ``Marginal`` exposes the following properties:
+An instance of ``Marginal`` exposes the following main properties:
 
-|      Property       |                                             Description                                              |
-|:-------------------:|:----------------------------------------------------------------------------------------------------:|
-|       `name`        |                  the assigned name of the probabilistic input model (may be `None`)                  |
-|    `description`    |          the assigned description of the probabilistic input model (may be `None`)                   |
-|    `marginals`      |                       One-dimensional marginal distribution of the input model                       | 
-| `input_dimension` |                             the number of dimensions of the input model                              |
-|      `copulas`      | specified copulas that model dependency structure between random variables (currently not supported) |
+|   Property   |                                                                Description                                                                |
+|:------------:|:-----------------------------------------------------------------------------------------------------------------------------------------:|
+|    `name`    |                                    the assigned name of the probabilistic input model (may be `None`)                                     |
+| `marginals`  |                                   A tuple of one-dimensional marginal distributions of the input model                                    | 
+| `dimension`  |                                                the number of dimensions of the input model                                                |
+|  `copulas`   | specified copulas that model dependency structure between random variables (currently always the independence copula; see the note above) |
 
 and methods:
 
-|            Method             |                                     Description                                      |
-|:-----------------------------:|:------------------------------------------------------------------------------------:|
-|   `get_sample(sample_size)`   |                get a sample of size `sample_size` from the                           |
-| `transform_sample(xx, other)` | transform a set of sample values `xx` (of this distribution) to `other` distribution |
+|             Method             |                                        Description                                        |
+|:------------------------------:|:-----------------------------------------------------------------------------------------:|
+| `get_sample(sample_size, rng)` |        get a sample of size `sample_size` from the input with a NumPy PRNG[^prng]         |
+|  `transform_from(xx, source)`  | transform a set of sample values `xx` (from a `source` distribution) to this distribution |
+|   `transform_to(xx, target)`   |   transform a set of sample values `xx` (of this distribution) to `target` distribution   |
 
 Below, we'll go quickly through each of the methods.
 
-```{note}
+```{important}
 In UQTestFuns, one-dimensional probabilistic input models are still represented
-as instances of `ProbInput` eventhough they only have one marginal.
+as instances of `ProbInput` even though they only have one marginal.
 This is because a one-dimensional probabilistic input
 and a univariate random variable are conceptually different.
 ```
@@ -144,7 +147,8 @@ xx_sample
 ```
 
 Notice that the sample values are given as a $5$-by-$3$ array.
-In general, a sample of size $N$ for an $M$-dimensional probabilistic input model will be given as an $N$-by-$M$ array.
+In general, a sample of size $N$ for an $M$-dimensional probabilistic input model
+will be given as an $N$-by-$M$ array.
 
 Shown below is the corner plot from $1'000$ sample points.
 The plot shows the histograms for each one-dimensional marginal
@@ -196,9 +200,9 @@ plt.gcf().set_dpi(150)
 
 ## Transforming a sample
 
-Using the `transform_sample()` method we can transform a sample generated
-from one probabilistic input model to another 
-with the same number of input dimensions.
+Using the `transform_from()` and `transform_to()` methods,
+we can transform a sample generated from one probabilistic input model
+to another.
 
 Let's suppose we define a three-dimensional probabilistic input model
 consisting of three independent standard uniform distributions.
@@ -212,7 +216,6 @@ my_marginals_2 = [
 my_probinput_2 = uqtf.ProbInput(
   marginals=my_marginals_2,
   name="MyProbInput-2",
-  description="My 2nd probabilistic input",
   )
 print(my_probinput_2)
 ```
@@ -221,7 +224,7 @@ A sample from this probabilistic input model can be transformed into a sample fr
 
 ```{code-cell} ipython3
 xx_sample_2 = my_probinput_2.get_sample(1000)
-xx_sample_1 = my_probinput_2.transform_sample(xx_sample_2, my_probinput)
+xx_sample_1 = my_probinput_2.transform_to(xx_sample_2, my_probinput)
 ```
 
 The histogram of the transformed sample is shown below.
@@ -271,3 +274,61 @@ axs[2, 2].set_xlabel("$X_3$")
 plt.gcf().set_dpi(150)
 ```
 
+### Transforming to and from a canonical domain
+
+Beyond transforming between two probabilistic input models, `transform_to()`
+and `transform_from()` also accept a plain domain tuple as `target`/`source`,
+defaulting to $(-1, 1)^M$ (i.e., the same bounds for all dimensions).
+This is arguably the more common case in practice.
+
+Many sampling schemes (Latin hypercube sampling, for instance) generate
+points on a canonical domain like $[-1, 1]^M$ or $[0, 1]^M$, which then need
+to be mapped into the model's actual input domain before the test function
+can be evaluated.
+
+Conversely, many metamodeling techniques are built on a
+canonical domain, so samples in the physical input space need to be mapped
+the other way before being used to fit or query the metamodel.
+
+Suppose a set of points has been generated on the canonical $[-1, 1]^3$
+domain by an external sampling scheme (a uniform random sample stands in
+for one here):
+
+```{code-cell} ipython3
+rng = np.random.default_rng(42)
+xx_canonical = rng.uniform(-1, 1, size=(5, 3))
+xx_canonical
+```
+
+These can be mapped into `my_probinput`'s own domain with `transform_from()`,
+ready to evaluate a test function on:
+
+```{code-cell} ipython3
+xx_original = my_probinput.transform_from(xx_canonical)  # source is (-1.0, 1.0)^M by default
+xx_original
+```
+
+Going the other way, for example, to prepare physical-domain samples for a
+metamodel built on $[-1, 1]$, use `transform_to()`:
+
+```{code-cell} ipython3
+xx_canonical_2 = my_probinput.transform_to(xx_original)  # target is (-1.0, 1.0)^M by default
+xx_canonical_2
+```
+
+Notice that the transformation returns the same sample points as the original.
+
+## Next steps
+
+You now know how to build a probabilistic input model, sample from it, and
+transform samples between two models. A `ProbInput` on its own, however,
+only represents the *input* side of a UQ test function; combined with an
+evaluation function (and, optionally, a set of parameters), it becomes a
+full {ref}`UQTestFun <api_reference_uqtestfun>` instance. See
+{ref}`Create a Custom Test Function <getting-started:tutorial-custom-functions>`
+for how to put these pieces together.
+
+[^prng]: The `rng` argument accepts either a NumPy `numpy.random.Generator`
+instance directly or an integer used as a seed to construct one. If
+omitted, a fresh, unseeded generator is used, so consecutive calls without
+an explicit `rng` are not reproducible.

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/exponential.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/exponential.py
@@ -16,7 +16,7 @@ from .utils import verify_param_nums, postprocess_icdf
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "exponential"
-DISPLAY_NAME = "Exp"
+DISPLAY_NAME = "Exponential"
 NUM_PARAMS = 1
 PARAM_NAMES = ("lambda",)
 

--- a/src/uqtestfuns/core/prob_input/univariate_distributions/uniform.py
+++ b/src/uqtestfuns/core/prob_input/univariate_distributions/uniform.py
@@ -11,7 +11,7 @@ from .utils import postprocess_icdf, verify_param_nums
 from ....global_settings import ARRAY_FLOAT
 
 DISTRIBUTION_NAME = "uniform"
-DISPLAY_NAME = "Unif"
+DISPLAY_NAME = "Uniform"
 NUM_PARAMS = 2
 PARAM_NAMES = ("a", "b")
 


### PR DESCRIPTION
This overhauls the `docs/prob-input/` section end to end: settles long-standing terminology ambiguity between "random variable"/"random vector" and "marginal distribution"/"probabilistic input", fixes several bugs (broken method calls, broken cross-references, wrong ICDF formulas), and adds missing narrative connection between pages.

Specific changes:

- Rename `preliminaries.md` to `concepts-and-notations.md` and `univariate-random-variable.md` to `marginal-distribution.md` for clearer, more descriptive titles.
- Settle terminology throughout: "random variable" maps to "marginal distribution", "random vector" maps to "probabilistic input"; add an explicit mapping table to `overview.md` and precise wording to `concepts-and-notations.md`.
- Fix a broken `.transform_sample()` call (method doesn't exist; the correct method is `.transform_to()`) in an executed code cell on `marginal-distribution.md`.
- Fix a broken `{ref}` target (stray leading underscore) on `marginal-distribution.md`.
- Fix incorrect ICDF formulas on four marginal-distribution pages: Gumbel (was undefined for x in (0,1)), the standard normal special case (missing inverse on erf), truncated normal (wrong shift term), and truncated Gumbel (missing the outer inverse-CDF wrapper). Verified all four numerically against the actual implementation.
- Add a "Transforming to and from a canonical domain" section to `probabilistic-input.md`, covering the practical sampling-design workflow, verified by execution.
- Add missing reciprocal cross-links between `overview.md`, `concepts-and-notations.md`, `marginal-distribution.md`, and `probabilistic-input.md`.
- Fix assorted grammar and phrasing issues across all pages.

---

Closes: #569
Ref: #546